### PR TITLE
Change docs to "authentication default on"

### DIFF
--- a/docs/user/custom_resource.md
+++ b/docs/user/custom_resource.md
@@ -122,9 +122,8 @@ The encryption key cannot be changed after the cluster has been created.
 
 This setting specifies the name of a kubernetes `Secret` that contains
 the JWT token used for accessing all ArangoDB servers.
-When a JWT token is used, authentication of the cluster is enabled, without it
-authentication is disabled.
-The default value is empty.
+When no name is specified, it defaults to `<deployment-name>-jwt`.
+To disable authentication, set this value to `-`.
 
 If you specify a name of a `Secret` that does not exist, a random token is created
 and stored in a `Secret` with given name.


### PR DESCRIPTION
As discussed in TeamClifton standup, authentication will be on by default.