### PR TITLE
fix make for docker 1.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 .gobuild
 bin
-
+tools/codegen/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch 
+FROM scratch
 
 ADD bin/arangodb_operator /usr/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,9 @@ update-vendor:
 	@$(PULSAR) go flatten -V $(VENDORDIR) $(VENDORDIR)
 	@${MAKE} -B -s clean
 
-update-generated: $(GOBUILDDIR) 
-	@docker build $(SRCDIR)/tools/codegen --build-arg GOVERSION=$(GOVERSION) -t k8s-codegen
+update-generated: $(GOBUILDDIR)
+	@sed 's/GOVERSION/$(GOVERSION)/' $(SRCDIR)/tools/codegen/Dockerfile.in > $(SRCDIR)/tools/codegen/Dockerfile
+	@docker build $(SRCDIR)/tools/codegen -t k8s-codegen
 	docker run \
 		--rm \
 		-v $(SRCDIR):/usr/code \

--- a/tools/codegen/Dockerfile
+++ b/tools/codegen/Dockerfile
@@ -1,4 +1,0 @@
-ARG GOVERSION
-FROM golang:${GOVERSION}
-
-RUN apk add --update --no-cache bash

--- a/tools/codegen/Dockerfile.in
+++ b/tools/codegen/Dockerfile.in
@@ -1,0 +1,2 @@
+FROM golang:GOVERSION
+RUN apk add --update --no-cache bash


### PR DESCRIPTION
docker 1.13 requires FROM as first directive in a Dockerfile. Furthermore older versions do not support environment variable expansion in FROM directives.