### PR TITLE
Run tests on multiple clusters in parallel

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -72,9 +72,12 @@ pipeline {
                 timestamps {
                     withEnv([
                     "IMAGETAG=${env.GIT_COMMIT}",
+                    "LONG=${params.LONG ? 1 : 0}",
+                    "PUSHIMAGES=1",
                     ]) {
                         sh "make"
                         sh "make run-unit-tests"
+                        sh "make docker-test"
                     }
                 }
             }


### PR DESCRIPTION
Running tests on multiple clusters in parallel.
The tests themselves still fail, but that is for other reasons