### PR TITLE
Set PublishNotReadyAddresses on coordinator&syncmasters service

### DIFF
--- a/pkg/util/k8sutil/services.go
+++ b/pkg/util/k8sutil/services.go
@@ -60,7 +60,8 @@ func CreateHeadlessService(kubecli kubernetes.Interface, deployment metav1.Objec
 			Port:     ArangoPort,
 		},
 	}
-	if err := createService(kubecli, svcName, deploymentName, deployment.GetNamespace(), ClusterIPNone, "", ports, owner); err != nil {
+	publishNotReadyAddresses := false
+	if err := createService(kubecli, svcName, deploymentName, deployment.GetNamespace(), ClusterIPNone, "", ports, publishNotReadyAddresses, owner); err != nil {
 		return "", maskAny(err)
 	}
 	return svcName, nil
@@ -85,7 +86,8 @@ func CreateDatabaseClientService(kubecli kubernetes.Interface, deployment metav1
 	} else {
 		role = "coordinator"
 	}
-	if err := createService(kubecli, svcName, deploymentName, deployment.GetNamespace(), "", role, ports, owner); err != nil {
+	publishNotReadyAddresses := true
+	if err := createService(kubecli, svcName, deploymentName, deployment.GetNamespace(), "", role, ports, publishNotReadyAddresses, owner); err != nil {
 		return "", maskAny(err)
 	}
 	return svcName, nil
@@ -104,7 +106,8 @@ func CreateSyncMasterClientService(kubecli kubernetes.Interface, deployment meta
 			Port:     ArangoPort,
 		},
 	}
-	if err := createService(kubecli, svcName, deploymentName, deployment.GetNamespace(), "", "syncmaster", ports, owner); err != nil {
+	publishNotReadyAddresses := true
+	if err := createService(kubecli, svcName, deploymentName, deployment.GetNamespace(), "", "syncmaster", ports, publishNotReadyAddresses, owner); err != nil {
 		return "", maskAny(err)
 	}
 	return svcName, nil
@@ -113,20 +116,24 @@ func CreateSyncMasterClientService(kubecli kubernetes.Interface, deployment meta
 // createService prepares and creates a service in k8s.
 // If the service already exists, nil is returned.
 // If another error occurs, that error is returned.
-func createService(kubecli kubernetes.Interface, svcName, deploymentName, ns, clusterIP, role string, ports []v1.ServicePort, owner metav1.OwnerReference) error {
+func createService(kubecli kubernetes.Interface, svcName, deploymentName, ns, clusterIP, role string, ports []v1.ServicePort, publishNotReadyAddresses bool, owner metav1.OwnerReference) error {
 	labels := LabelsForDeployment(deploymentName, role)
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   svcName,
 			Labels: labels,
 			Annotations: map[string]string{
+				// This annotation is deprecated, PublishNotReadyAddresses is
+				// used instead. We leave the annotation in for a while.
+				// See https://github.com/kubernetes/kubernetes/pull/49061
 				TolerateUnreadyEndpointsAnnotation: "true",
 			},
 		},
 		Spec: v1.ServiceSpec{
-			Ports:     ports,
-			Selector:  labels,
-			ClusterIP: clusterIP,
+			Ports:                    ports,
+			Selector:                 labels,
+			ClusterIP:                clusterIP,
+			PublishNotReadyAddresses: publishNotReadyAddresses,
 		},
 	}
 	addOwnerRefToObject(svc.GetObjectMeta(), &owner)


### PR DESCRIPTION
This PR changes a flag on the services that expose the coordinators & syncmasters.
It ensures that all coordinators (&syncmasters) are exposed as soon as they run and not wait until their readiness probe says it is ok. 
Since the readiness probe only starts after a minute, it could (before this PR) take that long for the cluster to become available to the user.