### PR TITLE
Fix scale-up

### DIFF
--- a/pkg/deployment/reconcile/plan_executor.go
+++ b/pkg/deployment/reconcile/plan_executor.go
@@ -64,6 +64,9 @@ func (d *Reconciler) ExecutePlan(ctx context.Context) (bool, error) {
 					Msg("Failed to start action")
 				return false, maskAny(err)
 			}
+			// action.Start may have changed status, so reload it.
+			status = d.context.GetStatus()
+			// Update status according to result on action.Start.
 			if ready {
 				// Remove action from list
 				status.Plan = status.Plan[1:]
@@ -91,6 +94,8 @@ func (d *Reconciler) ExecutePlan(ctx context.Context) (bool, error) {
 				return false, maskAny(err)
 			}
 			if ready {
+				// action.CheckProgress may have changed status, so reload it.
+				status = d.context.GetStatus()
 				// Remove action from list
 				status.Plan = status.Plan[1:]
 				// Save plan update


### PR DESCRIPTION
Avoid overwriting Status updating the plan which is being executed.
This did happen and as a result, members being added by the scale-up (addmember)
action where never added because this change was overwritten immediately.