### PR TITLE
Control jenkins from git commit log.

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -95,7 +95,7 @@ pipeline {
       string(name: 'TESTNAMESPACE', defaultValue: 'jenkins', description: 'TESTNAMESPACE sets the kubernetes namespace to ru tests in (this must be short!!)', )
       string(name: 'ENTERPRISEIMAGE', defaultValue: '', description: 'ENTERPRISEIMAGE sets the docker image used for enterprise tests)', )
     }
-    def myParams;
+    def myParams = [:];
     stages {
         stage("Prepare") {
             steps {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -82,12 +82,12 @@ def buildCleanupSteps(Map myParams, String kubeConfigRoot, String kubeconfig) {
     }
 }
 
-pipeline {
+node {
     options {
         buildDiscarder(logRotator(daysToKeepStr: '7', numToKeepStr: '10'))
         lock resource: 'kube-arangodb'
     }
-    agent any
+//    agent any
     parameters {
       booleanParam(name: 'LONG', defaultValue: false, description: 'Execute long running tests')
       string(name: 'DOCKERNAMESPACE', defaultValue: 'arangodb', description: 'DOCKERNAMESPACE sets the docker registry namespace in which the operator docker image will be pushed', )

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -22,7 +22,9 @@ def notifySlack(String buildStatus = 'STARTED') {
 def fetchParamsFromGitLog() {
     def options = sh(returnStdout: true, script: "git log --reverse remotes/origin/master..HEAD | grep -o \'\\[ci[^\\[]*\\]\' | sed -E \'s/\\[ci (.*)\\]/\\1/\'").trim().split("\n")
     for (opt in options) {
+        println("Processing option ${opt}");
         def idx = opt.indexOf('=');
+        println("Processing option ${opt} with idx=${idx}");
         if (idx > 0) {
             def key = opt.subString(0, idx);
             def value = opt.subString(idx+1);

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -108,6 +108,7 @@ pipeline {
       string(name: 'KUBECONFIGS', defaultValue: 'kube-ams1,scw-183a3b', description: 'KUBECONFIGS is a comma separated list of Kubernetes configuration files (relative to /home/jenkins/.kube) on which the tests are run', )
       string(name: 'TESTNAMESPACE', defaultValue: 'jenkins', description: 'TESTNAMESPACE sets the kubernetes namespace to ru tests in (this must be short!!)', )
       string(name: 'ENTERPRISEIMAGE', defaultValue: '', description: 'ENTERPRISEIMAGE sets the docker image used for enterprise tests)', )
+      string(name: 'TESTOPTIONS', defaultValue: '', description: 'TESTOPTIONS is used to pass additional test options to the integration test', )
     }
     stages {
         stage('Build') {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -83,10 +83,10 @@ def buildCleanupSteps(Map myParams, String kubeConfigRoot, String kubeconfig) {
 }
 
 node {
-    options {
+    /*options {
         buildDiscarder(logRotator(daysToKeepStr: '7', numToKeepStr: '10'))
         lock resource: 'kube-arangodb'
-    }
+    }*/
 //    agent any
     parameters {
       booleanParam(name: 'LONG', defaultValue: false, description: 'Execute long running tests')

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -20,7 +20,7 @@ def notifySlack(String buildStatus = 'STARTED') {
 }
 
 def fetchParamsFromGitLog() {
-    def options = sh(returnStdout: true, script: "git log --reverse master..HEAD | grep -o \'\\[ci[^\\[]*\\]\' | sed -E \'s/\\[ci (.*)\\]/\\1/\'").trim().split("\n")
+    def options = sh(returnStdout: true, script: "git log --reverse remotes/origin/master..HEAD | grep -o \'\\[ci[^\\[]*\\]\' | sed -E \'s/\\[ci (.*)\\]/\\1/\'").trim().split("\n")
     for (opt in options) {
         def idx = opt.indexOf('=');
         if (idx > 0) {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -82,12 +82,12 @@ def buildCleanupSteps(Map myParams, String kubeConfigRoot, String kubeconfig) {
     }
 }
 
-node {
-    /*options {
+pipeline {
+    options {
         buildDiscarder(logRotator(daysToKeepStr: '7', numToKeepStr: '10'))
         lock resource: 'kube-arangodb'
-    }*/
-//    agent any
+    }
+    agent any
     parameters {
       booleanParam(name: 'LONG', defaultValue: false, description: 'Execute long running tests')
       string(name: 'DOCKERNAMESPACE', defaultValue: 'arangodb', description: 'DOCKERNAMESPACE sets the docker registry namespace in which the operator docker image will be pushed', )
@@ -95,8 +95,8 @@ node {
       string(name: 'TESTNAMESPACE', defaultValue: 'jenkins', description: 'TESTNAMESPACE sets the kubernetes namespace to ru tests in (this must be short!!)', )
       string(name: 'ENTERPRISEIMAGE', defaultValue: '', description: 'ENTERPRISEIMAGE sets the docker image used for enterprise tests)', )
     }
-    def myParams = [:];
-    //stages {
+    stages {
+        def myParams = [:];
         stage("Prepare") {
             steps {
                 script {
@@ -133,7 +133,7 @@ node {
                 }
             }
         }
-    //}
+    }
 
     post {
         always {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -36,9 +36,15 @@ def fetchParamsFromGitLog() {
             def key = opt.substring(0, idx);
             def value = opt.substring(idx+1).replaceAll('^\"|\"$', '');
             myParams[key] = value;
-            println("Overwriting myParams.${key} with ${value}");
+            //println("Overwriting myParams.${key} with ${value}");
         }
     }
+
+    // Show params in log
+    for (entry in myParams) {
+        println("Using myParams.${entry.key} with ${entry.value}");
+    }
+
     return myParams;
 }
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -26,8 +26,8 @@ def fetchParamsFromGitLog() {
         def idx = opt.indexOf('=');
         println("Processing option ${opt} with idx=${idx}");
         if (idx > 0) {
-            def key = opt.subString(0, idx);
-            def value = opt.subString(idx+1);
+            def key = opt.substring(0, idx);
+            def value = opt.substring(idx+1);
             params[key] = value;
             println("Overwriting params.${key} with ${value}");
         }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -20,7 +20,7 @@ def notifySlack(String buildStatus = 'STARTED') {
 }
 
 def fetchParamsFromGitLog() {
-    def options = sh(returnStdout: true, script: "git log --reverse master..HEAD | grep -o '\[ci[^\[]*\]' | sed -E 's/\[ci (.*)\]/\1/'").trim().split("\n")
+    def options = sh(returnStdout: true, script: "git log --reverse master..HEAD | grep -o \'\\[ci[^\\[]*\\]\' | sed -E \'s/\\[ci (.*)\\]/\\1/\'").trim().split("\n")
     for (opt in options) {
         def idx = opt.indexOf('=');
         if (idx > 0) {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -24,6 +24,8 @@ def myParams = [:];
 def fetchParamsFromGitLog() {
     // Copy configured params 
     for (entry in params) {
+        println("Fetching entry from params: ${entry}");
+        println("Fetching entry from params: key=${entry.key}, value=${entry.value}");
         myParams[entry.key] = entry.value;
     }
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -34,7 +34,7 @@ def fetchParamsFromGitLog() {
         def idx = opt.indexOf('=');
         if (idx > 0) {
             def key = opt.substring(0, idx);
-            def value = opt.substring(idx+1);
+            def value = opt.substring(idx+1).replaceAll("^\"|\"$", "");
             myParams[key] = value;
             println("Overwriting myParams.${key} with ${value}");
         }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -96,7 +96,7 @@ node {
       string(name: 'ENTERPRISEIMAGE', defaultValue: '', description: 'ENTERPRISEIMAGE sets the docker image used for enterprise tests)', )
     }
     def myParams = [:];
-    stages {
+    //stages {
         stage("Prepare") {
             steps {
                 script {
@@ -133,7 +133,7 @@ node {
                 }
             }
         }
-    }
+    //}
 
     post {
         always {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -34,7 +34,7 @@ def fetchParamsFromGitLog() {
         def idx = opt.indexOf('=');
         if (idx > 0) {
             def key = opt.substring(0, idx);
-            def value = opt.substring(idx+1).replaceAll("^\"|\"$", "");
+            def value = opt.substring(idx+1).replaceAll('^\"|\"$', '');
             myParams[key] = value;
             println("Overwriting myParams.${key} with ${value}");
         }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -53,13 +53,13 @@ def buildTestSteps(String kubeConfigRoot, String kubeconfig) {
         timestamps {
             withCredentials([string(credentialsId: 'ENTERPRISEIMAGE', variable: 'DEFAULTENTERPRISEIMAGE')]) { 
                 withEnv([
-                "DEPLOYMENTNAMESPACE=${myParams.TESTNAMESPACE}-${env.GIT_COMMIT}",
-                "DOCKERNAMESPACE=${myParams.DOCKERNAMESPACE}",
-                "ENTERPRISEIMAGE=${myParams.ENTERPRISEIMAGE}",
+                "DEPLOYMENTNAMESPACE=${myParams['TESTNAMESPACE']}-${env.GIT_COMMIT}",
+                "DOCKERNAMESPACE=${myParams['DOCKERNAMESPACE']}",
+                "ENTERPRISEIMAGE=${myParams['ENTERPRISEIMAGE']}",
                 "IMAGETAG=jenkins-test",
                 "KUBECONFIG=${kubeConfigRoot}/${kubeconfig}",
-                "LONG=${myParams.LONG ? 1 : 0}",
-                "TESTOPTIONS=${myParams.TESTOPTIONS}",
+                "LONG=${myParams['LONG'] ? 1 : 0}",
+                "TESTOPTIONS=${myParams['TESTOPTIONS']}",
                 ]) {
                     sh "make run-tests"
                 }
@@ -72,8 +72,8 @@ def buildCleanupSteps(String kubeConfigRoot, String kubeconfig) {
     return {
         timestamps {
             withEnv([
-                "DEPLOYMENTNAMESPACE=${myParams.TESTNAMESPACE}-${env.GIT_COMMIT}",
-                "DOCKERNAMESPACE=${myParams.DOCKERNAMESPACE}",
+                "DEPLOYMENTNAMESPACE=${myParams['TESTNAMESPACE']}-${env.GIT_COMMIT}",
+                "DOCKERNAMESPACE=${myParams['DOCKERNAMESPACE']}",
                 "KUBECONFIG=${kubeConfigRoot}/${kubeconfig}",
             ]) {
                 sh "make cleanup-tests"
@@ -107,11 +107,11 @@ pipeline {
             steps {
                 timestamps {
                     withEnv([
-                    "DEPLOYMENTNAMESPACE=${myParams.TESTNAMESPACE}-${env.GIT_COMMIT}",
-                    "DOCKERNAMESPACE=${myParams.DOCKERNAMESPACE}",
+                    "DEPLOYMENTNAMESPACE=${myParams['TESTNAMESPACE']}-${env.GIT_COMMIT}",
+                    "DOCKERNAMESPACE=${myParams['DOCKERNAMESPACE']}",
                     "IMAGETAG=jenkins-test",
-                    "LONG=${myParams.LONG ? 1 : 0}",
-                    "TESTOPTIONS=${myParams.TESTOPTIONS}",
+                    "LONG=${myParams['LONG'] ? 1 : 0}",
+                    "TESTOPTIONS=${myParams['TESTOPTIONS']}",
                     ]) {
                         sh "make"
                         sh "make run-unit-tests"
@@ -123,7 +123,7 @@ pipeline {
         stage('Test') {
             steps {
                 script {
-                    def configs = "${myParams.KUBECONFIGS}".split(",")
+                    def configs = "${myParams['KUBECONFIGS']}".split(",")
                     def testTasks = [:]
                     for (kubeconfig in configs) {
                         testTasks["${kubeconfig}"] = buildTestSteps(kubeConfigRoot, kubeconfig)
@@ -137,7 +137,7 @@ pipeline {
     post {
         always {
             script {
-                def configs = "${myParams.KUBECONFIGS}".split(",")
+                def configs = "${myParams['KUBECONFIGS']}".split(",")
                 def cleanupTasks = [:]
                 for (kubeconfig in configs) {
                     cleanupTasks["${kubeconfig}"] = buildCleanupSteps(kubeConfigRoot, kubeconfig)


### PR DESCRIPTION
With this PR you can control jenkins parameters using git commit messages.
Examples:
- Put `[ci LONG=1]` in your commit log and it will run long tests.
- Put `[ci TESTOPTIONS="-test.run ^TestImmutableStorageEngine$"]` in your commit logs and in will run the selected test only.

You can put many `[ci ...]` blocks in your commit log. Recent blocks overwrite older ones.