### PR TITLE
AsOwner no longer things the owner refers to a controller. It refers to the ArangoDeployment

### DIFF
--- a/pkg/apis/deployment/v1alpha/deployment.go
+++ b/pkg/apis/deployment/v1alpha/deployment.go
@@ -50,13 +50,11 @@ type ArangoDeployment struct {
 
 // AsOwner creates an OwnerReference for the given deployment
 func (d *ArangoDeployment) AsOwner() metav1.OwnerReference {
-	controller := true
 	return metav1.OwnerReference{
 		APIVersion: SchemeGroupVersion.String(),
 		Kind:       ArangoDeploymentResourceKind,
 		Name:       d.Name,
 		UID:        d.UID,
-		Controller: &controller,
 	}
 }
 

--- a/pkg/apis/storage/v1alpha/local_storage.go
+++ b/pkg/apis/storage/v1alpha/local_storage.go
@@ -52,12 +52,10 @@ type ArangoLocalStorage struct {
 
 // AsOwner creates an OwnerReference for the given storage
 func (d *ArangoLocalStorage) AsOwner() metav1.OwnerReference {
-	controller := true
 	return metav1.OwnerReference{
 		APIVersion: SchemeGroupVersion.String(),
 		Kind:       ArangoLocalStorageResourceKind,
 		Name:       d.Name,
 		UID:        d.UID,
-		Controller: &controller,
 	}
 }


### PR DESCRIPTION
This was incorrect anyway.
Fixing it makes the pods show up properly in the k8s dashboard.