### PR TITLE
Enable LONG on kube-arangodb-long test

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -26,6 +26,11 @@ def fetchParamsFromGitLog() {
         myParams[entry.key] = entry.value;
     }
 
+    // Is this a LONG test?
+    if ("${env.JOB_NAME}" == "kube-arangodb-long") {
+        myParams["LONG"] = true;
+    }
+
     // Fetch params configured in git commit messages 
     // Syntax: [ci OPT=value]
     // Example: [ci TESTOPTIONS="-test.run ^TestSimpleSingle$"]


### PR DESCRIPTION
This PR is a dirty hack to always set `LONG=true` on the jenkins `kube-arangodb-long` test.