### PR TITLE
Tracking recent pod terminations

### DIFF
--- a/pkg/apis/deployment/v1alpha/member_status_test.go
+++ b/pkg/apis/deployment/v1alpha/member_status_test.go
@@ -1,0 +1,53 @@
+//
+// DISCLAIMER
+//
+// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package v1alpha
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestMemberStatusRecentTerminations tests the functions related to MemberStatus.RecentTerminations.
+func TestMemberStatusRecentTerminations(t *testing.T) {
+	relTime := func(delta time.Duration) metav1.Time {
+		return metav1.Time{Time: time.Now().Add(delta)}
+	}
+
+	s := MemberStatus{}
+	assert.Equal(t, 0, s.RecentTerminationsSince(time.Now().Add(-time.Hour)))
+	assert.Equal(t, 0, s.RemoveTerminationsBefore(time.Now()))
+
+	s.RecentTerminations = []metav1.Time{metav1.Now()}
+	assert.Equal(t, 1, s.RecentTerminationsSince(time.Now().Add(-time.Minute)))
+	assert.Equal(t, 0, s.RecentTerminationsSince(time.Now().Add(time.Minute)))
+	assert.Equal(t, 0, s.RemoveTerminationsBefore(time.Now().Add(-time.Hour)))
+
+	s.RecentTerminations = []metav1.Time{relTime(-time.Hour), relTime(-time.Minute), relTime(time.Minute)}
+	assert.Equal(t, 3, s.RecentTerminationsSince(time.Now().Add(-time.Hour*2)))
+	assert.Equal(t, 2, s.RecentTerminationsSince(time.Now().Add(-time.Minute*2)))
+	assert.Equal(t, 2, s.RemoveTerminationsBefore(time.Now()))
+	assert.Len(t, s.RecentTerminations, 1)
+}

--- a/pkg/apis/deployment/v1alpha/zz_generated.deepcopy.go
+++ b/pkg/apis/deployment/v1alpha/zz_generated.deepcopy.go
@@ -371,6 +371,13 @@ func (in *MemberStatus) DeepCopyInto(out *MemberStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.RecentTerminations != nil {
+		in, out := &in.RecentTerminations, &out.RecentTerminations
+		*out = make([]v1.Time, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/deployment/reconcile/action_rotate_member.go
+++ b/pkg/deployment/reconcile/action_rotate_member.go
@@ -110,6 +110,7 @@ func (a *actionRotateMember) CheckProgress(ctx context.Context) (bool, error) {
 	}
 	// Pod is now gone, update the member status
 	m.State = api.MemberStateNone
+	m.RecentTerminations = nil // Since we're rotating, we do not care about old terminations.
 	if err := a.actionCtx.UpdateMember(m); err != nil {
 		return false, maskAny(err)
 	}

--- a/pkg/deployment/reconcile/action_upgrade_member.go
+++ b/pkg/deployment/reconcile/action_upgrade_member.go
@@ -120,6 +120,7 @@ func (a *actionUpgradeMember) CheckProgress(ctx context.Context) (bool, error) {
 	}
 	// Pod is now gone, update the member status
 	m.State = api.MemberStateNone
+	m.RecentTerminations = nil // Since we're rotating, we do not care about old terminations.
 	if err := a.actionCtx.UpdateMember(m); err != nil {
 		return false, maskAny(err)
 	}

--- a/pkg/deployment/reconcile/action_upgrade_member.go
+++ b/pkg/deployment/reconcile/action_upgrade_member.go
@@ -120,7 +120,7 @@ func (a *actionUpgradeMember) CheckProgress(ctx context.Context) (bool, error) {
 	}
 	// Pod is now gone, update the member status
 	m.State = api.MemberStateNone
-	m.RecentTerminations = nil // Since we're rotating, we do not care about old terminations.
+	m.RecentTerminations = nil // Since we're upgrading, we do not care about old terminations.
 	if err := a.actionCtx.UpdateMember(m); err != nil {
 		return false, maskAny(err)
 	}


### PR DESCRIPTION
This PR records termination timestamps of the pod for each member.
Right now this information is not yet used. A future PR will perform high level operations on it, like killing a member when there are frequent terminations.