### PR TITLE
Check contents of persisted volume when dbserver is restarting

### DIFF
--- a/pkg/apis/deployment/v1alpha/member_status.go
+++ b/pkg/apis/deployment/v1alpha/member_status.go
@@ -44,6 +44,9 @@ type MemberStatus struct {
 	// RecentTerminatons holds the times when this member was recently terminated.
 	// First entry is the oldest. (do not add omitempty, since we want to be able to switch from a list to an empty list)
 	RecentTerminations []metav1.Time `json:"recent-terminations"`
+	// IsInitialized is set after the very first time a pod was created for this member.
+	// After that, DBServers must have a UUID field or fail.
+	IsInitialized bool `json:"initialized"`
 }
 
 // RemoveTerminationsBefore removes all recent terminations before the given timestamp.

--- a/pkg/deployment/images.go
+++ b/pkg/deployment/images.go
@@ -166,7 +166,7 @@ func (ib *imagesBuilder) fetchArangoDBImageIDAndVersion(ctx context.Context, ima
 		"--server.authentication=false",
 		fmt.Sprintf("--server.endpoint=tcp://[::]:%d", k8sutil.ArangoPort),
 	}
-	if err := k8sutil.CreateArangodPod(ib.KubeCli, true, ib.APIObject, role, id, podName, "", image, ib.Spec.GetImagePullPolicy(), args, nil, nil, nil, "", ""); err != nil {
+	if err := k8sutil.CreateArangodPod(ib.KubeCli, true, ib.APIObject, role, id, podName, "", image, ib.Spec.GetImagePullPolicy(), "", false, args, nil, nil, nil, "", ""); err != nil {
 		log.Debug().Err(err).Msg("Failed to create image ID pod")
 		return true, maskAny(err)
 	}

--- a/pkg/deployment/resources/pod_creator.go
+++ b/pkg/deployment/resources/pod_creator.go
@@ -366,7 +366,10 @@ func (r *Resources) createPodForMember(spec api.DeploymentSpec, group api.Server
 				SecretKey:  constants.SecretKeyJWT,
 			}
 		}
-		if err := k8sutil.CreateArangodPod(kubecli, spec.IsDevelopment(), apiObject, role, m.ID, m.PodName, m.PersistentVolumeClaimName, info.ImageID, spec.GetImagePullPolicy(), args, env, livenessProbe, readinessProbe, tlsKeyfileSecretName, rocksdbEncryptionSecretName); err != nil {
+		engine := string(spec.GetStorageEngine())
+		requireUUID := group == api.ServerGroupDBServers && m.IsInitialized
+		if err := k8sutil.CreateArangodPod(kubecli, spec.IsDevelopment(), apiObject, role, m.ID, m.PodName, m.PersistentVolumeClaimName, info.ImageID, spec.GetImagePullPolicy(),
+			engine, requireUUID, args, env, livenessProbe, readinessProbe, tlsKeyfileSecretName, rocksdbEncryptionSecretName); err != nil {
 			return maskAny(err)
 		}
 		log.Debug().Str("pod-name", m.PodName).Msg("Created pod")

--- a/pkg/deployment/resources/pod_inspector.go
+++ b/pkg/deployment/resources/pod_inspector.go
@@ -100,6 +100,7 @@ func (r *Resources) InspectPods() error {
 			// Pod is now ready
 			if memberStatus.Conditions.Update(api.ConditionTypeReady, true, "Pod Ready", "") {
 				log.Debug().Str("pod-name", p.GetName()).Msg("Updating member condition Ready to true")
+				memberStatus.IsInitialized = true // Require future pods for this member to have an existing UUID (in case of dbserver).
 				updateMemberStatusNeeded = true
 			}
 		} else {


### PR DESCRIPTION
This PR adds additional safety when restarting a dbserver.
It ensures that the persistent volume contains a UUID file with expected content
and an ENGINE file with expected content.