### PR TITLE
Added examples for exposing metrics to Prometheus

### DIFF
--- a/docs/Manual/Deployment/Kubernetes/Metrics.md
+++ b/docs/Manual/Deployment/Kubernetes/Metrics.md
@@ -1,3 +1,10 @@
 # Metrics
 
-TBD
+The ArangoDB Kubernetes Operator (`kube-arangodb`) exposes metrics of
+its operations in a format that is compatible with [Prometheus](https://prometheus.io).
+
+The metrics are exposed through HTTPS on port `8528` under path `/metrics`.
+
+Look at [examples/metrics](https://github.com/arangodb/kube-arangodb/tree/master/examples/metrics)
+for examples of `Services` and `ServiceMonitors` you can use to integrate
+with Prometheus through the [Prometheus-Operator by CoreOS](https://github.com/coreos/prometheus-operator).

--- a/examples/metrics/deployment-operator-servicemonitor.yaml
+++ b/examples/metrics/deployment-operator-servicemonitor.yaml
@@ -1,0 +1,34 @@
+# This example shows how to integrate with the Prometheus Operator
+# to bring metrics from kube-arangodb to Prometheus.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: arango-deployment-operator
+  labels:
+    app: arango-deployment-operator
+spec:
+  selector:
+    app: arango-deployment-operator
+  ports:
+  - name: metrics
+    port: 8528
+
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arango-deployment-operator
+  labels:
+    team: frontend
+spec:
+  selector:
+    matchLabels:
+      app: arango-deployment-operator
+  endpoints:
+  - port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+

--- a/manifests/templates/deployment/deployment.yaml
+++ b/manifests/templates/deployment/deployment.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         name: {{ .Deployment.OperatorDeploymentName }}
+        app: arango-deployment-operator
     spec:
       containers:
       - name: operator

--- a/manifests/templates/storage/deployment.yaml
+++ b/manifests/templates/storage/deployment.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       labels:
         name: {{ .Storage.OperatorDeploymentName }}
+        app: arango-storage-operator
     spec:
       serviceAccountName: {{ .Storage.Operator.ServiceAccountName }}
       containers:


### PR DESCRIPTION
This PR adds an example how to expose operator metrics
to Prometheus, when that is deployed using the Prometheus-Operator
by CoreOS.