### PR TITLE
Run chaos-monkey in go-routine to avoid blocking the operator

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -137,7 +137,7 @@ func New(config Config, deps Dependencies, apiObject *api.ArangoDeployment) (*De
 	}
 	if config.AllowChaos {
 		d.chaosMonkey = chaos.NewMonkey(deps.Log, d)
-		d.chaosMonkey.Run(d.stopCh)
+		go d.chaosMonkey.Run(d.stopCh)
 	}
 
 	return d, nil


### PR DESCRIPTION
The chaos-monkey was running in the main go-routine of the operator, so no other events for `ArangoDeployment` changes would ever arrive.