### PR TITLE
Fixed down/upgrading resilient single deployments.

### DIFF
--- a/pkg/deployment/reconcile/action_wait_for_member_up.go
+++ b/pkg/deployment/reconcile/action_wait_for_member_up.go
@@ -69,6 +69,11 @@ func (a *actionWaitForMemberUp) CheckProgress(ctx context.Context) (bool, error)
 	switch a.actionCtx.GetMode() {
 	case api.DeploymentModeSingle:
 		return a.checkProgressSingle(ctx)
+	case api.DeploymentModeResilientSingle:
+		if a.action.Group == api.ServerGroupAgents {
+			return a.checkProgressAgent(ctx)
+		}
+		return a.checkProgressSingle(ctx)
 	default:
 		if a.action.Group == api.ServerGroupAgents {
 			return a.checkProgressAgent(ctx)


### PR DESCRIPTION
Upgrading/downgrading resilient single deployments failed because it tried to use a cluster "wait until ready" test.