### PR TITLE
No stickyness for EA service of type LoadBalancer

### DIFF
--- a/examples/single-server.yaml
+++ b/examples/single-server.yaml
@@ -4,5 +4,4 @@ metadata:
   name: "example-simple-single"
 spec:
   mode: Single
-  single:
-    storageClassName: my-local-ssd
+  image: arangodb/arangodb-preview:3.3

--- a/pkg/deployment/resources/services.go
+++ b/pkg/deployment/resources/services.go
@@ -170,6 +170,9 @@ func (r *Resources) ensureExternalAccessServices(eaServiceName, ns, svcRole, tit
 		// Let's create or update the database external access service
 		nodePort := spec.GetNodePort()
 		loadBalancerIP := spec.GetLoadBalancerIP()
+		if eaServiceType == v1.ServiceTypeLoadBalancer {
+			sessionAffinity = v1.ServiceAffinityNone
+		}
 		_, newlyCreated, err := k8sutil.CreateExternalAccessService(kubecli, eaServiceName, svcRole, apiObject, eaServiceType, port, nodePort, loadBalancerIP, sessionAffinity, apiObject.AsOwner())
 		if err != nil {
 			log.Debug().Err(err).Msgf("Failed to create %s external access service", title)


### PR DESCRIPTION
Reason: AWS ELB do not support clientIP stickyness.