### PR TITLE
Fixes needed to run on latest openshift.

### DIFF
--- a/manifests/templates/deployment/rbac.yaml
+++ b/manifests/templates/deployment/rbac.yaml
@@ -38,7 +38,7 @@ rules:
 
 ---
 
-## Bind the cluster role granting access to ArangoLocalStorage resources
+## Bind the cluster role granting access to ArangoDeployment resources
 ## to the default service account of the configured namespace.
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/pkg/apis/deployment/v1alpha/deployment.go
+++ b/pkg/apis/deployment/v1alpha/deployment.go
@@ -52,12 +52,13 @@ type ArangoDeployment struct {
 func (d *ArangoDeployment) AsOwner() metav1.OwnerReference {
 	trueVar := true
 	return metav1.OwnerReference{
-		APIVersion:         SchemeGroupVersion.String(),
-		Kind:               ArangoDeploymentResourceKind,
-		Name:               d.Name,
-		UID:                d.UID,
-		Controller:         &trueVar,
-		BlockOwnerDeletion: &trueVar,
+		APIVersion: SchemeGroupVersion.String(),
+		Kind:       ArangoDeploymentResourceKind,
+		Name:       d.Name,
+		UID:        d.UID,
+		Controller: &trueVar,
+		// For now BlockOwnerDeletion does not work on OpenShift, so we leave it out.
+		//BlockOwnerDeletion: &trueVar,
 	}
 }
 

--- a/pkg/deployment/images.go
+++ b/pkg/deployment/images.go
@@ -167,6 +167,8 @@ func (ib *imagesBuilder) fetchArangoDBImageIDAndVersion(ctx context.Context, ima
 	args := []string{
 		"--server.authentication=false",
 		fmt.Sprintf("--server.endpoint=tcp://[::]:%d", k8sutil.ArangoPort),
+		"--database.directory=" + k8sutil.ArangodVolumeMountDir,
+		"--log.output=+",
 	}
 	terminationGracePeriod := time.Second * 30
 	tolerations := make([]v1.Toleration, 0, 2)


### PR DESCRIPTION
This PR contains fixes needed to deploy ArangoDB on OpenShift.
Tested on `minishift v1.17.0+f974f0c`.

Note that in order to make it work, also a patched version of the ArangoDB image is needed.
A `Dockerfile` as below is known to work.

```
FROM arangodb/arangodb-preview:3.3
RUN chgrp 0 /var/lib/arangodb3 && chmod 775 /var/lib/arangodb3
RUN chgrp 0 /var/lib/arangodb3-apps && chmod 775 /var/lib/arangodb3-apps
```

These changes are patched into newly released arangodb images.