### PR TITLE
Added no-execute tolerations on operators to failover quicker

### DIFF
--- a/manifests/templates/deployment/deployment.yaml
+++ b/manifests/templates/deployment/deployment.yaml
@@ -51,3 +51,12 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
+      tolerations:
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 5
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 5

--- a/manifests/templates/storage/deployment.yaml
+++ b/manifests/templates/storage/deployment.yaml
@@ -59,4 +59,12 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
-      
+      tolerations:
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 5
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 5


### PR DESCRIPTION
This PR adds tolerations to the deployments of the operators to make them failover quicker in case of node-failure.

The tolerations assume kubernetes 1.10. `node.alpha.kubernetes.io/unreachable` is now `node.kubernetes.io/unreachable`

See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for details.