### PR TITLE
Operator high-availability

### DIFF
--- a/manifests/templates/deployment-replication/deployment-replication.yaml
+++ b/manifests/templates/deployment-replication/deployment-replication.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .DeploymentReplication.OperatorDeploymentName }}
   namespace: {{ .DeploymentReplication.Operator.Namespace }}
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: Recreate
   template:
@@ -50,3 +50,12 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
+      tolerations:
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 5
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 5

--- a/manifests/templates/deployment/deployment.yaml
+++ b/manifests/templates/deployment/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Deployment.OperatorDeploymentName }}
   namespace: {{ .Deployment.Operator.Namespace }}
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: Recreate
   template:

--- a/manifests/templates/storage/deployment.yaml
+++ b/manifests/templates/storage/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ .Storage.OperatorDeploymentName }}
   namespace: {{ .Storage.Operator.Namespace }}
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
This PR sets the number of replicas for the all operator to 2 (from 1). This ensures that 1 replica is always standing by (waiting in leader election) and able to take over quickly when the leader is not responding.
This is faster than waiting for kubernetes to terminate a pod that becomes unresponsive.

This PR also adds tolerations that were still missing on the deployment-replication operator.