### PR TITLE
Abort reconcilientation plan on failed cleanout server

### DIFF
--- a/deps/github.com/arangodb/go-driver/cluster_impl.go
+++ b/deps/github.com/arangodb/go-driver/cluster_impl.go
@@ -123,6 +123,10 @@ type cleanOutServerRequest struct {
 	Server string `json:"server"`
 }
 
+type cleanOutServerResponse struct {
+	JobID string `json:"id"`
+}
+
 // CleanOutServer triggers activities to clean out a DBServers.
 func (c *cluster) CleanOutServer(ctx context.Context, serverID string) error {
 	req, err := c.conn.NewRequest("POST", "_admin/cluster/cleanOutServer")
@@ -135,13 +139,20 @@ func (c *cluster) CleanOutServer(ctx context.Context, serverID string) error {
 	if _, err := req.SetBody(input); err != nil {
 		return WithStack(err)
 	}
-	applyContextSettings(ctx, req)
+	cs := applyContextSettings(ctx, req)
 	resp, err := c.conn.Do(ctx, req)
 	if err != nil {
 		return WithStack(err)
 	}
 	if err := resp.CheckStatus(200, 202); err != nil {
 		return WithStack(err)
+	}
+	var result cleanOutServerResponse
+	if err := resp.ParseBody("", &result); err != nil {
+		return WithStack(err)
+	}
+	if cs.JobIDResponse != nil {
+		*cs.JobIDResponse = result.JobID
 	}
 	return nil
 }

--- a/deps/github.com/arangodb/go-driver/context.go
+++ b/deps/github.com/arangodb/go-driver/context.go
@@ -56,6 +56,7 @@ const (
 	keyFollowLeaderRedirect     ContextKey = "arangodb-followLeaderRedirect"
 	keyDBServerID               ContextKey = "arangodb-dbserverID"
 	keyBatchID                  ContextKey = "arangodb-batchID"
+	keyJobIDResponse            ContextKey = "arangodb-jobIDResponse"
 )
 
 // WithRevision is used to configure a context to make document
@@ -213,6 +214,13 @@ func WithBatchID(parent context.Context, id string) context.Context {
 	return context.WithValue(contextOrBackground(parent), keyBatchID, id)
 }
 
+// WithJobIDResponse is used to configure a context that includes a reference to a JobID
+// that is filled on a error-free response.
+// This is used in cluster functions.
+func WithJobIDResponse(parent context.Context, jobID *string) context.Context {
+	return context.WithValue(contextOrBackground(parent), keyJobIDResponse, jobID)
+}
+
 type contextSettings struct {
 	Silent                   bool
 	WaitForSync              bool
@@ -229,6 +237,7 @@ type contextSettings struct {
 	FollowLeaderRedirect     *bool
 	DBServerID               string
 	BatchID                  string
+	JobIDResponse            *string
 }
 
 // applyContextSettings returns the settings configured in the context in the given request.
@@ -354,6 +363,12 @@ func applyContextSettings(ctx context.Context, req Request) contextSettings {
 		if id, ok := v.(string); ok {
 			req.SetQuery("batchId", id)
 			result.BatchID = id
+		}
+	}
+	// JobIDResponse
+	if v := ctx.Value(keyJobIDResponse); v != nil {
+		if idRef, ok := v.(*string); ok {
+			result.JobIDResponse = idRef
 		}
 	}
 	return result

--- a/deps/github.com/arangodb/go-driver/test/cursor_test.go
+++ b/deps/github.com/arangodb/go-driver/test/cursor_test.go
@@ -229,6 +229,27 @@ func TestCreateCursor(t *testing.T) {
 	}
 }
 
+// TestCreateCursorReturnNull creates a cursor with a `RETURN NULL` query.
+func TestCreateCursorReturnNull(t *testing.T) {
+	ctx := context.Background()
+	c := createClientFromEnv(t, true)
+	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
+
+	var result interface{}
+	query := "return null"
+	cursor, err := db.Query(ctx, query, nil)
+	if err != nil {
+		t.Fatalf("Query(return null) failed: %s", describe(err))
+	}
+	defer cursor.Close()
+	if _, err := cursor.ReadDocument(ctx, &result); err != nil {
+		t.Fatalf("ReadDocument failed: %s", describe(err))
+	}
+	if result != nil {
+		t.Errorf("Expected result to be nil, got %#v", result)
+	}
+}
+
 // Test stream query cursors. The goroutines are technically only
 // relevant for the MMFiles engine, but don't hurt on rocksdb either
 func TestCreateStreamCursor(t *testing.T) {

--- a/deps/github.com/arangodb/go-driver/vst/protocol/chunk.go
+++ b/deps/github.com/arangodb/go-driver/vst/protocol/chunk.go
@@ -87,6 +87,10 @@ func buildChunks(messageID uint64, maxChunkSize uint32, messageParts ...[]byte) 
 func readBytes(dst []byte, r io.Reader) error {
 	offset := 0
 	remaining := len(dst)
+	if remaining == 0 {
+		// Nothing left to read
+		return nil
+	}
 	for {
 		n, err := r.Read(dst[offset:])
 		offset += n

--- a/deps/github.com/arangodb/go-driver/vst/protocol/connection.go
+++ b/deps/github.com/arangodb/go-driver/vst/protocol/connection.go
@@ -43,13 +43,14 @@ type Connection struct {
 	msgStore      messageStore
 	conn          net.Conn
 	writeMutex    sync.Mutex
-	closing       bool
+	closing       int32
 	lastActivity  time.Time
 	configured    int32 // Set to 1 after the configuration callback has finished without errors.
 }
 
 const (
 	defaultMaxChunkSize = 30000
+	maxRecentErrors     = 64
 )
 
 var (
@@ -59,13 +60,8 @@ var (
 
 // dial opens a new connection to the server on the given address.
 func dial(version Version, addr string, tlsConfig *tls.Config) (*Connection, error) {
-	var conn net.Conn
-	var err error
-	if tlsConfig != nil {
-		conn, err = tls.Dial("tcp", addr, tlsConfig)
-	} else {
-		conn, err = net.Dial("tcp", addr)
-	}
+	// Create TCP connection
+	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		return nil, driver.WithStack(err)
 	}
@@ -74,6 +70,12 @@ func dial(version Version, addr string, tlsConfig *tls.Config) (*Connection, err
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		tcpConn.SetKeepAlive(true)
 		tcpConn.SetNoDelay(true)
+	}
+
+	// Add TLS if needed
+	if tlsConfig != nil {
+		tlsConn := tls.Client(conn, tlsConfig)
+		conn = tlsConn
 	}
 
 	// Send protocol header
@@ -112,8 +114,7 @@ func (c *Connection) load() int {
 
 // Close the connection to the server
 func (c *Connection) Close() error {
-	if !c.closing {
-		c.closing = true
+	if atomic.CompareAndSwapInt32(&c.closing, 0, 1) {
 		if err := c.conn.Close(); err != nil {
 			return driver.WithStack(err)
 		}
@@ -126,7 +127,7 @@ func (c *Connection) Close() error {
 
 // IsClosed returns true when the connection is closed, false otherwise.
 func (c *Connection) IsClosed() bool {
-	return c.closing
+	return atomic.LoadInt32(&c.closing) == 1
 }
 
 // IsConfigured returns true when the configuration callback has finished on this connection, without errors.
@@ -208,8 +209,10 @@ func (c *Connection) sendChunk(deadline time.Time, chunk chunk) error {
 
 // readChunkLoop reads chunks from the connection until it is closed.
 func (c *Connection) readChunkLoop() {
+	recentErrors := 0
+	goodChunks := 0
 	for {
-		if c.closing {
+		if c.IsClosed() {
 			// Closing, we're done
 			return
 		}
@@ -225,17 +228,27 @@ func (c *Connection) readChunkLoop() {
 		}
 		c.updateLastActivity()
 		if err != nil {
-			if !c.closing {
+			if !c.IsClosed() {
 				// Handle error
 				if err == io.EOF {
 					// Connection closed
 					c.Close()
 				} else {
-					fmt.Printf("readChunkLoop error: %#v\n", err)
+					recentErrors++
+					fmt.Printf("readChunkLoop error: %#v (goodChunks=%d)\n", err, goodChunks)
+					if recentErrors > maxRecentErrors {
+						// When we get to many errors in a row, close this connection
+						c.Close()
+					} else {
+						// Backoff a bit, so we allow things to settle.
+						time.Sleep(time.Millisecond * time.Duration(recentErrors*5))
+					}
 				}
 			}
 		} else {
 			// Process chunk
+			recentErrors = 0
+			goodChunks++
 			go c.processChunk(chunk)
 		}
 	}

--- a/pkg/apis/deployment/v1alpha/member_status.go
+++ b/pkg/apis/deployment/v1alpha/member_status.go
@@ -50,6 +50,8 @@ type MemberStatus struct {
 	// IsInitialized is set after the very first time a pod was created for this member.
 	// After that, DBServers must have a UUID field or fail.
 	IsInitialized bool `json:"initialized"`
+	// CleanoutJobID holds the ID of the agency job for cleaning out this server
+	CleanoutJobID string `json:"cleanout-job-id,omitempty"`
 }
 
 // Age returns the duration since the creation timestamp of this member.

--- a/pkg/deployment/context_impl.go
+++ b/pkg/deployment/context_impl.go
@@ -28,12 +28,14 @@ import (
 	"github.com/arangodb/arangosync/client"
 	"github.com/arangodb/arangosync/tasks"
 	driver "github.com/arangodb/go-driver"
+	"github.com/arangodb/go-driver/agency"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1alpha"
 	"github.com/arangodb/kube-arangodb/pkg/deployment/resources"
+	"github.com/arangodb/kube-arangodb/pkg/util/arangod"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil"
 )
 
@@ -117,6 +119,15 @@ func (d *Deployment) GetAgencyClients(ctx context.Context, predicate func(id str
 		}
 		conn := client.Connection()
 		result = append(result, conn)
+	}
+	return result, nil
+}
+
+// GetAgency returns a connection to the entire agency.
+func (d *Deployment) GetAgency(ctx context.Context) (agency.Agency, error) {
+	result, err := arangod.CreateArangodAgencyClient(ctx, d.deps.KubeCli.CoreV1(), d.apiObject)
+	if err != nil {
+		return nil, maskAny(err)
 	}
 	return result, nil
 }

--- a/pkg/deployment/reconcile/action.go
+++ b/pkg/deployment/reconcile/action.go
@@ -34,8 +34,8 @@ type Action interface {
 	// the start time needs to be recorded and a ready condition needs to be checked.
 	Start(ctx context.Context) (bool, error)
 	// CheckProgress checks the progress of the action.
-	// Returns true if the action is completely finished, false otherwise.
-	CheckProgress(ctx context.Context) (bool, error)
+	// Returns: ready, abort, error.
+	CheckProgress(ctx context.Context) (bool, bool, error)
 	// Timeout returns the amount of time after which this action will timeout.
 	Timeout() time.Duration
 }

--- a/pkg/deployment/reconcile/action_add_member.go
+++ b/pkg/deployment/reconcile/action_add_member.go
@@ -61,9 +61,9 @@ func (a *actionAddMember) Start(ctx context.Context) (bool, error) {
 
 // CheckProgress checks the progress of the action.
 // Returns true if the action is completely finished, false otherwise.
-func (a *actionAddMember) CheckProgress(ctx context.Context) (bool, error) {
+func (a *actionAddMember) CheckProgress(ctx context.Context) (bool, bool, error) {
 	// Nothing todo
-	return true, nil
+	return true, false, nil
 }
 
 // Timeout returns the amount of time after which this action will timeout.

--- a/pkg/deployment/reconcile/action_context.go
+++ b/pkg/deployment/reconcile/action_context.go
@@ -26,6 +26,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/arangodb/go-driver/agency"
+
 	"github.com/arangodb/arangosync/client"
 	driver "github.com/arangodb/go-driver"
 	"github.com/rs/zerolog"
@@ -46,6 +48,8 @@ type ActionContext interface {
 	GetServerClient(ctx context.Context, group api.ServerGroup, id string) (driver.Client, error)
 	// GetAgencyClients returns a client connection for every agency member.
 	GetAgencyClients(ctx context.Context) ([]driver.Connection, error)
+	// GetAgency returns a connection to the entire agency.
+	GetAgency(ctx context.Context) (agency.Agency, error)
 	// GetSyncServerClient returns a cached client for a specific arangosync server.
 	GetSyncServerClient(ctx context.Context, group api.ServerGroup, id string) (client.API, error)
 	// GetMemberStatusByID returns the current member status
@@ -116,6 +120,15 @@ func (ac *actionContext) GetAgencyClients(ctx context.Context) ([]driver.Connect
 		return nil, maskAny(err)
 	}
 	return c, nil
+}
+
+// GetAgency returns a connection to the entire agency.
+func (ac *actionContext) GetAgency(ctx context.Context) (agency.Agency, error) {
+	a, err := ac.context.GetAgency(ctx)
+	if err != nil {
+		return nil, maskAny(err)
+	}
+	return a, nil
 }
 
 // GetSyncServerClient returns a cached client for a specific arangosync server.

--- a/pkg/deployment/reconcile/action_remove_member.go
+++ b/pkg/deployment/reconcile/action_remove_member.go
@@ -24,6 +24,7 @@ package reconcile
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -86,14 +87,18 @@ func (a *actionRemoveMember) Start(ctx context.Context) (bool, error) {
 	if err := a.actionCtx.RemoveMemberByID(a.action.MemberID); err != nil {
 		return false, maskAny(err)
 	}
+	// Check that member has been removed
+	if _, found := a.actionCtx.GetMemberStatusByID(a.action.MemberID); found {
+		return false, maskAny(fmt.Errorf("Member %s still exists", a.action.MemberID))
+	}
 	return true, nil
 }
 
 // CheckProgress checks the progress of the action.
 // Returns true if the action is completely finished, false otherwise.
-func (a *actionRemoveMember) CheckProgress(ctx context.Context) (bool, error) {
+func (a *actionRemoveMember) CheckProgress(ctx context.Context) (bool, bool, error) {
 	// Nothing todo
-	return true, nil
+	return true, false, nil
 }
 
 // Timeout returns the amount of time after which this action will timeout.

--- a/pkg/deployment/reconcile/action_renew_tls_certificate.go
+++ b/pkg/deployment/reconcile/action_renew_tls_certificate.go
@@ -67,8 +67,8 @@ func (a *renewTLSCertificateAction) Start(ctx context.Context) (bool, error) {
 
 // CheckProgress checks the progress of the action.
 // Returns true if the action is completely finished, false otherwise.
-func (a *renewTLSCertificateAction) CheckProgress(ctx context.Context) (bool, error) {
-	return true, nil
+func (a *renewTLSCertificateAction) CheckProgress(ctx context.Context) (bool, bool, error) {
+	return true, false, nil
 }
 
 // Timeout returns the amount of time after which this action will timeout.

--- a/pkg/deployment/reconcile/action_upgrade_member.go
+++ b/pkg/deployment/reconcile/action_upgrade_member.go
@@ -75,7 +75,7 @@ func (a *actionUpgradeMember) Start(ctx context.Context) (bool, error) {
 		defer cancel()
 		if err := c.Shutdown(ctx, removeFromCluster); err != nil {
 			// Shutdown failed. Let's check if we're already done
-			if ready, err := a.CheckProgress(ctx); err == nil && ready {
+			if ready, _, err := a.CheckProgress(ctx); err == nil && ready {
 				// We're done
 				return true, nil
 			}
@@ -98,13 +98,13 @@ func (a *actionUpgradeMember) Start(ctx context.Context) (bool, error) {
 
 // CheckProgress checks the progress of the action.
 // Returns true if the action is completely finished, false otherwise.
-func (a *actionUpgradeMember) CheckProgress(ctx context.Context) (bool, error) {
+func (a *actionUpgradeMember) CheckProgress(ctx context.Context) (bool, bool, error) {
 	// Check that pod is removed
 	log := a.log
 	m, found := a.actionCtx.GetMemberStatusByID(a.action.MemberID)
 	if !found {
 		log.Error().Msg("No such member")
-		return true, nil
+		return true, false, nil
 	}
 	isUpgrading := m.Phase == api.MemberPhaseUpgrading
 	log = log.With().
@@ -112,20 +112,21 @@ func (a *actionUpgradeMember) CheckProgress(ctx context.Context) (bool, error) {
 		Bool("is-upgrading", isUpgrading).Logger()
 	if !m.Conditions.IsTrue(api.ConditionTypeTerminated) {
 		// Pod is not yet terminated
-		return false, nil
+		return false, false, nil
 	}
 	// Pod is terminated, we can now remove it
 	log.Debug().Msg("Deleting pod")
 	if err := a.actionCtx.DeletePod(m.PodName); err != nil {
-		return false, maskAny(err)
+		return false, false, maskAny(err)
 	}
 	// Pod is now gone, update the member status
 	m.Phase = api.MemberPhaseNone
 	m.RecentTerminations = nil // Since we're upgrading, we do not care about old terminations.
+	m.CleanoutJobID = ""
 	if err := a.actionCtx.UpdateMember(m); err != nil {
-		return false, maskAny(err)
+		return false, false, maskAny(err)
 	}
-	return isUpgrading, nil
+	return isUpgrading, false, nil
 }
 
 // Timeout returns the amount of time after which this action will timeout.

--- a/pkg/deployment/reconcile/context.go
+++ b/pkg/deployment/reconcile/context.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/arangodb/arangosync/client"
 	driver "github.com/arangodb/go-driver"
+	"github.com/arangodb/go-driver/agency"
 	"k8s.io/api/core/v1"
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1alpha"
@@ -52,6 +53,8 @@ type Context interface {
 	// GetAgencyClients returns a client connection for every agency member.
 	// If the given predicate is not nil, only agents are included where the given predicate returns true.
 	GetAgencyClients(ctx context.Context, predicate func(id string) bool) ([]driver.Connection, error)
+	// GetAgency returns a connection to the entire agency.
+	GetAgency(ctx context.Context) (agency.Agency, error)
 	// GetSyncServerClient returns a cached client for a specific arangosync server.
 	GetSyncServerClient(ctx context.Context, group api.ServerGroup, id string) (client.API, error)
 	// CreateEvent creates a given event.

--- a/pkg/deployment/reconcile/plan_builder.go
+++ b/pkg/deployment/reconcile/plan_builder.go
@@ -358,7 +358,7 @@ func createScalePlan(log zerolog.Logger, members api.MemberStatusList, group api
 			Str("role", group.AsRole()).
 			Msg("Creating scale-up plan")
 	} else if len(members) > count {
-		// Note, we scale down 1 member as a time
+		// Note, we scale down 1 member at a time
 		if m, err := members.SelectMemberToRemove(); err == nil {
 			if group == api.ServerGroupDBServers {
 				plan = append(plan,
@@ -373,6 +373,7 @@ func createScalePlan(log zerolog.Logger, members api.MemberStatusList, group api
 				Int("count", count).
 				Int("actual-count", len(members)).
 				Str("role", group.AsRole()).
+				Str("member-id", m.ID).
 				Msg("Creating scale-down plan")
 		}
 	}

--- a/pkg/deployment/reconcile/plan_executor.go
+++ b/pkg/deployment/reconcile/plan_executor.go
@@ -44,7 +44,10 @@ func (d *Reconciler) ExecutePlan(ctx context.Context) (bool, error) {
 	for {
 		loopStatus, _ := d.context.GetStatus()
 		if len(loopStatus.Plan) == 0 {
-			// No plan exists, nothing to be done
+			// No plan exists or all action have finished, nothing to be done
+			if !firstLoop {
+				log.Debug().Msg("Reconciliation plan has finished")
+			}
 			return !firstLoop, nil
 		}
 		firstLoop = false

--- a/pkg/util/arangod/cleanout_server.go
+++ b/pkg/util/arangod/cleanout_server.go
@@ -1,0 +1,99 @@
+//
+// DISCLAIMER
+//
+// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package arangod
+
+import (
+	"context"
+	"fmt"
+
+	driver "github.com/arangodb/go-driver"
+	"github.com/arangodb/go-driver/agency"
+)
+
+// CleanoutJobStatus is a strongly typed status of an agency cleanout-server-job.
+type CleanoutJobStatus struct {
+	state  string
+	reason string
+}
+
+// IsFailed returns true when the job is failed
+func (s CleanoutJobStatus) IsFailed() bool {
+	return s.state == "Failed"
+}
+
+// IsDone returns true when the job is finished
+func (s CleanoutJobStatus) IsDone() bool {
+	return s.state == "Done"
+}
+
+// Reason returns the reason for the current state.
+func (s CleanoutJobStatus) Reason() string {
+	return s.reason
+}
+
+// String returns a string representation of the given state.
+func (s CleanoutJobStatus) String() string {
+	return fmt.Sprintf("state: '%s', reason: '%s'", s.state, s.reason)
+}
+
+var (
+	agencyJobStateKeyPrefixes = [][]string{
+		{"arango", "Target", "ToDo"},
+		{"arango", "Target", "Pending"},
+		{"arango", "Target", "Done"},
+		{"arango", "Target", "Failed"},
+	}
+)
+
+type agencyJob struct {
+	Reason string `json:"reason,omitempty"`
+	Server string `json:"server,omitempty"`
+	JobID  string `json:"jobId,omitempty"`
+	Type   string `json:"type,omitempty"`
+}
+
+const (
+	agencyJobTypeCleanOutServer = "cleanOutServer"
+)
+
+// CleanoutServerJobStatus checks the status of a cleanout-server job with given ID.
+func CleanoutServerJobStatus(ctx context.Context, jobID string, client driver.Client, agencyClient agency.Agency) (CleanoutJobStatus, error) {
+	for _, keyPrefix := range agencyJobStateKeyPrefixes {
+		key := append(keyPrefix, jobID)
+		var job agencyJob
+		if err := agencyClient.ReadKey(ctx, key, &job); err == nil {
+			return CleanoutJobStatus{
+				state:  keyPrefix[len(keyPrefix)-1],
+				reason: job.Reason,
+			}, nil
+		} else if agency.IsKeyNotFound(err) {
+			continue
+		} else {
+			return CleanoutJobStatus{}, maskAny(err)
+		}
+	}
+	// Job not found in any states
+	return CleanoutJobStatus{
+		reason: "job not found",
+	}, nil
+}

--- a/pkg/util/arangod/cleanout_server.go
+++ b/pkg/util/arangod/cleanout_server.go
@@ -41,9 +41,9 @@ func (s CleanoutJobStatus) IsFailed() bool {
 	return s.state == "Failed"
 }
 
-// IsDone returns true when the job is finished
-func (s CleanoutJobStatus) IsDone() bool {
-	return s.state == "Done"
+// IsFinished returns true when the job is finished
+func (s CleanoutJobStatus) IsFinished() bool {
+	return s.state == "Finished"
 }
 
 // Reason returns the reason for the current state.
@@ -60,7 +60,7 @@ var (
 	agencyJobStateKeyPrefixes = [][]string{
 		{"arango", "Target", "ToDo"},
 		{"arango", "Target", "Pending"},
-		{"arango", "Target", "Done"},
+		{"arango", "Target", "Finished"},
 		{"arango", "Target", "Failed"},
 	}
 )

--- a/pkg/util/k8sutil/events.go
+++ b/pkg/util/k8sutil/events.go
@@ -155,6 +155,16 @@ func NewPlanTimeoutEvent(apiObject APIObject, itemType, memberID, role string) *
 	return event
 }
 
+// NewPlanAbortedEvent creates an event indicating that an item on a reconciliation plan wants to abort
+// the entire plan.
+func NewPlanAbortedEvent(apiObject APIObject, itemType, memberID, role string) *v1.Event {
+	event := newDeploymentEvent(apiObject)
+	event.Type = v1.EventTypeNormal
+	event.Reason = "Reconciliation Plan Aborted"
+	event.Message = fmt.Sprintf("An plan item of type %s or member %s with role %s wants to abort the plan", itemType, memberID, role)
+	return event
+}
+
 // NewErrorEvent creates an even of type error.
 func NewErrorEvent(reason string, err error, apiObject APIObject) *v1.Event {
 	event := newDeploymentEvent(apiObject)


### PR DESCRIPTION
This PR checks the status of ongoing cleanout server action by inspecting the right keys in the agency.
If a cleanout server job has failed, the reconciliation plan is aborted.

This PR uses https://github.com/arangodb/go-driver/pull/131

<!---
@huboard:{"order":166.03320166,"milestone_order":171,"custom_state":""}
-->
