### PR TITLE
Avoid overwriting status changes

### DIFF
--- a/pkg/apis/deployment/v1alpha/deployment_status_members.go
+++ b/pkg/apis/deployment/v1alpha/deployment_status_members.go
@@ -75,23 +75,23 @@ func (ds DeploymentStatusMembers) ElementByID(id string) (MemberStatus, ServerGr
 // ForeachServerGroup calls the given callback for all server groups.
 // If the callback returns an error, this error is returned and the callback is
 // not called for the remaining groups.
-func (ds DeploymentStatusMembers) ForeachServerGroup(cb func(group ServerGroup, list *MemberStatusList) error) error {
-	if err := cb(ServerGroupSingle, &ds.Single); err != nil {
+func (ds DeploymentStatusMembers) ForeachServerGroup(cb func(group ServerGroup, list MemberStatusList) error) error {
+	if err := cb(ServerGroupSingle, ds.Single); err != nil {
 		return maskAny(err)
 	}
-	if err := cb(ServerGroupAgents, &ds.Agents); err != nil {
+	if err := cb(ServerGroupAgents, ds.Agents); err != nil {
 		return maskAny(err)
 	}
-	if err := cb(ServerGroupDBServers, &ds.DBServers); err != nil {
+	if err := cb(ServerGroupDBServers, ds.DBServers); err != nil {
 		return maskAny(err)
 	}
-	if err := cb(ServerGroupCoordinators, &ds.Coordinators); err != nil {
+	if err := cb(ServerGroupCoordinators, ds.Coordinators); err != nil {
 		return maskAny(err)
 	}
-	if err := cb(ServerGroupSyncMasters, &ds.SyncMasters); err != nil {
+	if err := cb(ServerGroupSyncMasters, ds.SyncMasters); err != nil {
 		return maskAny(err)
 	}
-	if err := cb(ServerGroupSyncWorkers, &ds.SyncWorkers); err != nil {
+	if err := cb(ServerGroupSyncWorkers, ds.SyncWorkers); err != nil {
 		return maskAny(err)
 	}
 	return nil
@@ -190,8 +190,8 @@ func (ds *DeploymentStatusMembers) RemoveByID(id string, group ServerGroup) erro
 
 // AllMembersReady returns true when all members are in the Ready state.
 func (ds DeploymentStatusMembers) AllMembersReady() bool {
-	if err := ds.ForeachServerGroup(func(group ServerGroup, list *MemberStatusList) error {
-		for _, x := range *list {
+	if err := ds.ForeachServerGroup(func(group ServerGroup, list MemberStatusList) error {
+		for _, x := range list {
 			if !x.Conditions.IsTrue(ConditionTypeReady) {
 				return fmt.Errorf("not ready")
 			}

--- a/pkg/apis/deployment/v1alpha/member_status_list_test.go
+++ b/pkg/apis/deployment/v1alpha/member_status_list_test.go
@@ -49,6 +49,8 @@ func TestMemberStatusList(t *testing.T) {
 	assert.NoError(t, list.RemoveByID(m3.ID))
 	assert.Equal(t, 2, len(*list))
 	assert.False(t, list.ContainsID(m3.ID))
+	assert.Equal(t, m1.ID, (*list)[0].ID)
+	assert.Equal(t, m2.ID, (*list)[1].ID)
 
 	m2.PodName = "foo"
 	assert.NoError(t, list.Update(m2))
@@ -58,4 +60,10 @@ func TestMemberStatusList(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, "foo", x.PodName)
 	assert.Equal(t, m2.ID, x.ID)
+
+	assert.NoError(t, list.Add(m3))
+	assert.Equal(t, 3, len(*list))
+	assert.Equal(t, m1.ID, (*list)[0].ID)
+	assert.Equal(t, m2.ID, (*list)[1].ID)
+	assert.Equal(t, m3.ID, (*list)[2].ID)
 }

--- a/pkg/apis/deployment/v1alpha/member_status_list_test.go
+++ b/pkg/apis/deployment/v1alpha/member_status_list_test.go
@@ -1,0 +1,61 @@
+//
+// DISCLAIMER
+//
+// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package v1alpha
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMemberStatusList tests modifying a MemberStatusList.
+func TestMemberStatusList(t *testing.T) {
+	list := &MemberStatusList{}
+	m1 := MemberStatus{ID: "m1"}
+	m2 := MemberStatus{ID: "m2"}
+	m3 := MemberStatus{ID: "m3"}
+	assert.Equal(t, 0, len(*list))
+
+	assert.NoError(t, list.Add(m1))
+	assert.Equal(t, 1, len(*list))
+
+	assert.NoError(t, list.Add(m2))
+	assert.NoError(t, list.Add(m3))
+	assert.Equal(t, 3, len(*list))
+
+	assert.Error(t, list.Add(m2))
+	assert.Equal(t, 3, len(*list))
+
+	assert.NoError(t, list.RemoveByID(m3.ID))
+	assert.Equal(t, 2, len(*list))
+	assert.False(t, list.ContainsID(m3.ID))
+
+	m2.PodName = "foo"
+	assert.NoError(t, list.Update(m2))
+	assert.Equal(t, 2, len(*list))
+	assert.True(t, list.ContainsID(m2.ID))
+	x, found := list.ElementByPodName("foo")
+	assert.True(t, found)
+	assert.Equal(t, "foo", x.PodName)
+	assert.Equal(t, m2.ID, x.ID)
+}

--- a/pkg/deployment/cluster_scaling_integration.go
+++ b/pkg/deployment/cluster_scaling_integration.go
@@ -71,7 +71,7 @@ func (ci *clusterScalingIntegration) ListenForClusterEvents(stopCh <-chan struct
 		delay := time.Second * 2
 
 		// Is deployment in running state
-		if ci.depl.status.Phase == api.DeploymentPhaseRunning {
+		if ci.depl.GetPhase() == api.DeploymentPhaseRunning {
 			// Update cluster with our state
 			ctx := context.Background()
 			safeToAskCluster, err := ci.updateClusterServerCount(ctx)

--- a/pkg/deployment/context_impl.go
+++ b/pkg/deployment/context_impl.go
@@ -24,6 +24,8 @@ package deployment
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 
 	"github.com/arangodb/arangosync/client"
 	"github.com/arangodb/arangosync/tasks"
@@ -63,20 +65,31 @@ func (d *Deployment) GetNamespace() string {
 	return d.apiObject.GetNamespace()
 }
 
+// GetPhase returns the current phase of the deployment
+func (d *Deployment) GetPhase() api.DeploymentPhase {
+	return d.status.last.Phase
+}
+
 // GetSpec returns the current specification
 func (d *Deployment) GetSpec() api.DeploymentSpec {
 	return d.apiObject.Spec
 }
 
 // GetStatus returns the current status of the deployment
-func (d *Deployment) GetStatus() api.DeploymentStatus {
-	return d.status
+// together with the current version of that status.
+func (d *Deployment) GetStatus() (api.DeploymentStatus, int32) {
+	version := atomic.LoadInt32(&d.status.version)
+	return *d.status.last.DeepCopy(), version
 }
 
 // UpdateStatus replaces the status of the deployment with the given status and
 // updates the resources in k8s.
-func (d *Deployment) UpdateStatus(status api.DeploymentStatus, force ...bool) error {
-	d.status = status
+func (d *Deployment) UpdateStatus(status api.DeploymentStatus, lastVersion int32, force ...bool) error {
+	if !atomic.CompareAndSwapInt32(&d.status.version, lastVersion, lastVersion+1) {
+		// Status is obsolete
+		return maskAny(fmt.Errorf("Status conflict error. Expected version %d, got %d", lastVersion, d.status.version))
+	}
+	d.status.last = *status.DeepCopy()
 	if err := d.updateCRStatus(force...); err != nil {
 		return maskAny(err)
 	}
@@ -105,7 +118,7 @@ func (d *Deployment) GetServerClient(ctx context.Context, group api.ServerGroup,
 // GetAgencyClients returns a client connection for every agency member.
 // If the given predicate is not nil, only agents are included where the given predicate returns true.
 func (d *Deployment) GetAgencyClients(ctx context.Context, predicate func(id string) bool) ([]driver.Connection, error) {
-	agencyMembers := d.status.Members.Agents
+	agencyMembers := d.status.last.Members.Agents
 	result := make([]driver.Connection, 0, len(agencyMembers))
 	for _, m := range agencyMembers {
 		if predicate != nil && !predicate(m.ID) {
@@ -157,13 +170,14 @@ func (d *Deployment) GetSyncServerClient(ctx context.Context, group api.ServerGr
 // If ID is non-empty, it will be used, otherwise a new ID is created.
 func (d *Deployment) CreateMember(group api.ServerGroup, id string) error {
 	log := d.deps.Log
-	id, err := d.createMember(group, id, d.apiObject)
+	status, lastVersion := d.GetStatus()
+	id, err := createMember(log, &status, group, id, d.apiObject)
 	if err != nil {
 		log.Debug().Err(err).Str("group", group.AsRole()).Msg("Failed to create member")
 		return maskAny(err)
 	}
 	// Save added member
-	if err := d.updateCRStatus(); err != nil {
+	if err := d.UpdateStatus(status, lastVersion); err != nil {
 		log.Debug().Err(err).Msg("Updating CR status failed")
 		return maskAny(err)
 	}

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -25,6 +25,7 @@ package deployment
 import (
 	"fmt"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -84,6 +85,7 @@ const (
 type Deployment struct {
 	apiObject *api.ArangoDeployment // API object
 	status    struct {
+		mutex   sync.Mutex
 		version int32
 		last    api.DeploymentStatus // Internal status copy of the CR
 	}

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -83,9 +83,12 @@ const (
 // Deployment is the in process state of an ArangoDeployment.
 type Deployment struct {
 	apiObject *api.ArangoDeployment // API object
-	status    api.DeploymentStatus  // Internal status of the CR
-	config    Config
-	deps      Dependencies
+	status    struct {
+		version int32
+		last    api.DeploymentStatus // Internal status copy of the CR
+	}
+	config Config
+	deps   Dependencies
 
 	eventCh chan *deploymentEvent
 	stopCh  chan struct{}
@@ -112,7 +115,6 @@ func New(config Config, deps Dependencies, apiObject *api.ArangoDeployment) (*De
 	}
 	d := &Deployment{
 		apiObject:   apiObject,
-		status:      *(apiObject.Status.DeepCopy()),
 		config:      config,
 		deps:        deps,
 		eventCh:     make(chan *deploymentEvent, deploymentEventQueueSize),
@@ -120,12 +122,13 @@ func New(config Config, deps Dependencies, apiObject *api.ArangoDeployment) (*De
 		eventsCli:   deps.KubeCli.Core().Events(apiObject.GetNamespace()),
 		clientCache: newClientCache(deps.KubeCli, apiObject),
 	}
+	d.status.last = *(apiObject.Status.DeepCopy())
 	d.reconciler = reconcile.NewReconciler(deps.Log, d)
 	d.resilience = resilience.NewResilience(deps.Log, d)
 	d.resources = resources.NewResources(deps.Log, d)
-	if d.status.AcceptedSpec == nil {
+	if d.status.last.AcceptedSpec == nil {
 		// We've validated the spec, so let's use it from now.
-		d.status.AcceptedSpec = apiObject.Spec.DeepCopy()
+		d.status.last.AcceptedSpec = apiObject.Spec.DeepCopy()
 	}
 
 	go d.run()
@@ -185,7 +188,7 @@ func (d *Deployment) send(ev *deploymentEvent) {
 func (d *Deployment) run() {
 	log := d.deps.Log
 
-	if d.status.Phase == api.DeploymentPhaseNone {
+	if d.GetPhase() == api.DeploymentPhaseNone {
 		// Create secrets
 		if err := d.resources.EnsureSecrets(); err != nil {
 			d.CreateEvent(k8sutil.NewErrorEvent("Failed to create secrets", err, d.GetAPIObject()))
@@ -211,8 +214,9 @@ func (d *Deployment) run() {
 			d.CreateEvent(k8sutil.NewErrorEvent("Failed to create pods", err, d.GetAPIObject()))
 		}
 
-		d.status.Phase = api.DeploymentPhaseRunning
-		if err := d.updateCRStatus(); err != nil {
+		status, lastVersion := d.GetStatus()
+		status.Phase = api.DeploymentPhaseRunning
+		if err := d.UpdateStatus(status, lastVersion); err != nil {
 			log.Warn().Err(err).Msg("update initial CR status failed")
 		}
 		log.Info().Msg("start running...")
@@ -277,13 +281,14 @@ func (d *Deployment) handleArangoDeploymentUpdatedEvent() error {
 	}
 
 	specBefore := d.apiObject.Spec
-	if d.status.AcceptedSpec != nil {
-		specBefore = *d.status.AcceptedSpec
+	status := d.status.last
+	if d.status.last.AcceptedSpec != nil {
+		specBefore = *status.AcceptedSpec.DeepCopy()
 	}
 	newAPIObject := current.DeepCopy()
 	newAPIObject.Spec.SetDefaultsFrom(specBefore)
 	newAPIObject.Spec.SetDefaults(d.apiObject.GetName())
-	newAPIObject.Status = d.status
+	newAPIObject.Status = status
 	resetFields := specBefore.ResetImmutableFields(&newAPIObject.Spec)
 	if len(resetFields) > 0 {
 		log.Debug().Strs("fields", resetFields).Msg("Found modified immutable fields")
@@ -309,9 +314,12 @@ func (d *Deployment) handleArangoDeploymentUpdatedEvent() error {
 		return maskAny(fmt.Errorf("failed to update ArangoDeployment spec: %v", err))
 	}
 	// Save updated accepted spec
-	d.status.AcceptedSpec = newAPIObject.Spec.DeepCopy()
-	if err := d.updateCRStatus(); err != nil {
-		return maskAny(fmt.Errorf("failed to update ArangoDeployment status: %v", err))
+	{
+		status, lastVersion := d.GetStatus()
+		status.AcceptedSpec = newAPIObject.Spec.DeepCopy()
+		if err := d.UpdateStatus(status, lastVersion); err != nil {
+			return maskAny(fmt.Errorf("failed to update ArangoDeployment status: %v", err))
+		}
 	}
 
 	// Notify cluster of desired server count
@@ -351,7 +359,7 @@ func (d *Deployment) updateCRStatus(force ...bool) error {
 	attempt := 0
 	for {
 		attempt++
-		update.Status = d.status
+		update.Status = d.status.last
 		if update.GetDeletionTimestamp() == nil {
 			ensureFinalizers(update)
 		}
@@ -388,7 +396,7 @@ func (d *Deployment) updateCRSpec(newSpec api.DeploymentSpec) error {
 	for {
 		attempt++
 		update.Spec = newSpec
-		update.Status = d.status
+		update.Status = d.status.last
 		ns := d.apiObject.GetNamespace()
 		newAPIObject, err := d.deps.DatabaseCRCli.DatabaseV1alpha().ArangoDeployments(ns).Update(update)
 		if err == nil {
@@ -417,7 +425,7 @@ func (d *Deployment) updateCRSpec(newSpec api.DeploymentSpec) error {
 // Since there is no recovery from a failed deployment, use with care!
 func (d *Deployment) failOnError(err error, msg string) {
 	log.Error().Err(err).Msg(msg)
-	d.status.Reason = err.Error()
+	d.status.last.Reason = err.Error()
 	d.reportFailedStatus()
 }
 
@@ -428,7 +436,7 @@ func (d *Deployment) reportFailedStatus() {
 	log.Info().Msg("deployment failed. Reporting failed reason...")
 
 	op := func() error {
-		d.status.Phase = api.DeploymentPhaseFailed
+		d.status.last.Phase = api.DeploymentPhaseFailed
 		err := d.updateCRStatus()
 		if err == nil || k8sutil.IsNotFound(err) {
 			// Status has been updated

--- a/pkg/deployment/deployment_inspector.go
+++ b/pkg/deployment/deployment_inspector.go
@@ -60,7 +60,7 @@ func (d *Deployment) inspectDeployment(lastInterval time.Duration) time.Duration
 		}
 	} else {
 		// Is the deployment in failed state, if so, give up.
-		if d.status.Phase == api.DeploymentPhaseFailed {
+		if d.GetPhase() == api.DeploymentPhaseFailed {
 			log.Debug().Msg("Deployment is in Failed state.")
 			return nextInterval
 		}
@@ -72,7 +72,8 @@ func (d *Deployment) inspectDeployment(lastInterval time.Duration) time.Duration
 		}
 
 		// Is the deployment in a good state?
-		if d.status.Conditions.IsTrue(api.ConditionTypeSecretsChanged) {
+		status, _ := d.GetStatus()
+		if status.Conditions.IsTrue(api.ConditionTypeSecretsChanged) {
 			log.Debug().Msg("Condition SecretsChanged is true. Revert secrets before we can continue")
 			return nextInterval
 		}

--- a/pkg/deployment/images.go
+++ b/pkg/deployment/images.go
@@ -55,15 +55,15 @@ type imagesBuilder struct {
 // ensureImages creates pods needed to detect ImageID for specified images.
 // Returns: retrySoon, error
 func (d *Deployment) ensureImages(apiObject *api.ArangoDeployment) (bool, error) {
+	status, lastVersion := d.GetStatus()
 	ib := imagesBuilder{
 		APIObject: apiObject,
 		Spec:      apiObject.Spec,
-		Status:    d.status,
+		Status:    status,
 		Log:       d.deps.Log,
 		KubeCli:   d.deps.KubeCli,
 		UpdateCRStatus: func(status api.DeploymentStatus) error {
-			d.status = status
-			if err := d.updateCRStatus(); err != nil {
+			if err := d.UpdateStatus(status, lastVersion); err != nil {
 				return maskAny(err)
 			}
 			return nil

--- a/pkg/deployment/reconcile/action_context.go
+++ b/pkg/deployment/reconcile/action_context.go
@@ -153,7 +153,9 @@ func (ac *actionContext) UpdateMember(member api.MemberStatus) error {
 	if !found {
 		return maskAny(fmt.Errorf("Member %s not found", member.ID))
 	}
-	status.Members.UpdateMemberStatus(member, group)
+	if err := status.Members.UpdateMemberStatus(member, group); err != nil {
+		return maskAny(err)
+	}
 	if err := ac.context.UpdateStatus(status, lastVersion); err != nil {
 		log.Debug().Err(err).Msg("Updating CR status failed")
 		return maskAny(err)

--- a/pkg/deployment/reconcile/context.go
+++ b/pkg/deployment/reconcile/context.go
@@ -40,10 +40,10 @@ type Context interface {
 	// GetSpec returns the current specification of the deployment
 	GetSpec() api.DeploymentSpec
 	// GetStatus returns the current status of the deployment
-	GetStatus() api.DeploymentStatus
+	GetStatus() (api.DeploymentStatus, int32)
 	// UpdateStatus replaces the status of the deployment with the given status and
 	// updates the resources in k8s.
-	UpdateStatus(status api.DeploymentStatus, force ...bool) error
+	UpdateStatus(status api.DeploymentStatus, lastVersion int32, force ...bool) error
 	// GetDatabaseClient returns a cached client for the entire database (cluster coordinators or single server),
 	// creating one if needed.
 	GetDatabaseClient(ctx context.Context) (driver.Client, error)

--- a/pkg/deployment/reconcile/plan_builder.go
+++ b/pkg/deployment/reconcile/plan_builder.go
@@ -57,7 +57,7 @@ func (d *Reconciler) CreatePlan() error {
 	// Create plan
 	apiObject := d.context.GetAPIObject()
 	spec := d.context.GetSpec()
-	status := d.context.GetStatus()
+	status, lastVersion := d.context.GetStatus()
 	newPlan, changed := createPlan(d.log, apiObject, status.Plan, spec, status, pods, d.context.GetTLSKeyfile)
 
 	// If not change, we're done
@@ -71,7 +71,7 @@ func (d *Reconciler) CreatePlan() error {
 		return nil
 	}
 	status.Plan = newPlan
-	if err := d.context.UpdateStatus(status); err != nil {
+	if err := d.context.UpdateStatus(status, lastVersion); err != nil {
 		return maskAny(err)
 	}
 	return nil

--- a/pkg/deployment/reconcile/plan_builder.go
+++ b/pkg/deployment/reconcile/plan_builder.go
@@ -93,8 +93,8 @@ func createPlan(log zerolog.Logger, apiObject metav1.Object,
 	var plan api.Plan
 
 	// Check for members in failed state
-	status.Members.ForeachServerGroup(func(group api.ServerGroup, members *api.MemberStatusList) error {
-		for _, m := range *members {
+	status.Members.ForeachServerGroup(func(group api.ServerGroup, members api.MemberStatusList) error {
+		for _, m := range members {
 			if m.Phase == api.MemberPhaseFailed && len(plan) == 0 {
 				newID := ""
 				if group == api.ServerGroupAgents {
@@ -149,8 +149,8 @@ func createPlan(log zerolog.Logger, apiObject metav1.Object,
 			}
 			return nil
 		}
-		status.Members.ForeachServerGroup(func(group api.ServerGroup, members *api.MemberStatusList) error {
-			for _, m := range *members {
+		status.Members.ForeachServerGroup(func(group api.ServerGroup, members api.MemberStatusList) error {
+			for _, m := range members {
 				if len(plan) > 0 {
 					// Only 1 change at a time
 					continue
@@ -180,8 +180,8 @@ func createPlan(log zerolog.Logger, apiObject metav1.Object,
 
 	// Check for the need to rotate TLS certificate of a members
 	if len(plan) == 0 && spec.TLS.IsSecure() {
-		status.Members.ForeachServerGroup(func(group api.ServerGroup, members *api.MemberStatusList) error {
-			for _, m := range *members {
+		status.Members.ForeachServerGroup(func(group api.ServerGroup, members api.MemberStatusList) error {
+			for _, m := range members {
 				if len(plan) > 0 {
 					// Only 1 change at a time
 					continue

--- a/pkg/deployment/reconcile/plan_executor.go
+++ b/pkg/deployment/reconcile/plan_executor.go
@@ -39,19 +39,20 @@ import (
 // False otherwise.
 func (d *Reconciler) ExecutePlan(ctx context.Context) (bool, error) {
 	log := d.log
-	initialPlanLen := len(d.context.GetStatus().Plan)
+	firstLoop := true
 
 	for {
-		status := d.context.GetStatus()
-		if len(status.Plan) == 0 {
+		loopStatus, _ := d.context.GetStatus()
+		if len(loopStatus.Plan) == 0 {
 			// No plan exists, nothing to be done
-			return initialPlanLen > 0, nil
+			return !firstLoop, nil
 		}
+		firstLoop = false
 
 		// Take first action
-		planAction := status.Plan[0]
+		planAction := loopStatus.Plan[0]
 		log := log.With().
-			Int("plan-len", len(status.Plan)).
+			Int("plan-len", len(loopStatus.Plan)).
 			Str("action-id", planAction.ID).
 			Str("action-type", string(planAction.Type)).
 			Str("group", planAction.Group.AsRole()).
@@ -66,21 +67,22 @@ func (d *Reconciler) ExecutePlan(ctx context.Context) (bool, error) {
 					Msg("Failed to start action")
 				return false, maskAny(err)
 			}
-			// action.Start may have changed status, so reload it.
-			status = d.context.GetStatus()
-			// Update status according to result on action.Start.
-			if ready {
-				// Remove action from list
-				status.Plan = status.Plan[1:]
-			} else {
-				// Mark start time
-				now := metav1.Now()
-				status.Plan[0].StartTime = &now
-			}
-			// Save plan update
-			if err := d.context.UpdateStatus(status, true); err != nil {
-				log.Debug().Err(err).Msg("Failed to update CR status")
-				return false, maskAny(err)
+			{ // action.Start may have changed status, so reload it.
+				status, lastVersion := d.context.GetStatus()
+				// Update status according to result on action.Start.
+				if ready {
+					// Remove action from list
+					status.Plan = status.Plan[1:]
+				} else {
+					// Mark start time
+					now := metav1.Now()
+					status.Plan[0].StartTime = &now
+				}
+				// Save plan update
+				if err := d.context.UpdateStatus(status, lastVersion, true); err != nil {
+					log.Debug().Err(err).Msg("Failed to update CR status")
+					return false, maskAny(err)
+				}
 			}
 			log.Debug().Bool("ready", ready).Msg("Action Start completed")
 			if !ready {
@@ -96,14 +98,15 @@ func (d *Reconciler) ExecutePlan(ctx context.Context) (bool, error) {
 				return false, maskAny(err)
 			}
 			if ready {
-				// action.CheckProgress may have changed status, so reload it.
-				status = d.context.GetStatus()
-				// Remove action from list
-				status.Plan = status.Plan[1:]
-				// Save plan update
-				if err := d.context.UpdateStatus(status); err != nil {
-					log.Debug().Err(err).Msg("Failed to update CR status")
-					return false, maskAny(err)
+				{ // action.CheckProgress may have changed status, so reload it.
+					status, lastVersion := d.context.GetStatus()
+					// Remove action from list
+					status.Plan = status.Plan[1:]
+					// Save plan update
+					if err := d.context.UpdateStatus(status, lastVersion); err != nil {
+						log.Debug().Err(err).Msg("Failed to update CR status")
+						return false, maskAny(err)
+					}
 				}
 			}
 			log.Debug().Bool("ready", ready).Msg("Action CheckProgress completed")
@@ -115,8 +118,9 @@ func (d *Reconciler) ExecutePlan(ctx context.Context) (bool, error) {
 					log.Warn().Msg("Action not finished in time. Removing the entire plan")
 					d.context.CreateEvent(k8sutil.NewPlanTimeoutEvent(d.context.GetAPIObject(), string(planAction.Type), planAction.MemberID, planAction.Group.AsRole()))
 					// Replace plan with empty one and save it.
+					status, lastVersion := d.context.GetStatus()
 					status.Plan = api.Plan{}
-					if err := d.context.UpdateStatus(status); err != nil {
+					if err := d.context.UpdateStatus(status, lastVersion); err != nil {
 						log.Debug().Err(err).Msg("Failed to update CR status")
 						return false, maskAny(err)
 					}

--- a/pkg/deployment/resilience/context.go
+++ b/pkg/deployment/resilience/context.go
@@ -34,10 +34,10 @@ type Context interface {
 	// GetSpec returns the current specification of the deployment
 	GetSpec() api.DeploymentSpec
 	// GetStatus returns the current status of the deployment
-	GetStatus() api.DeploymentStatus
+	GetStatus() (api.DeploymentStatus, int32)
 	// UpdateStatus replaces the status of the deployment with the given status and
 	// updates the resources in k8s.
-	UpdateStatus(status api.DeploymentStatus, force ...bool) error
+	UpdateStatus(status api.DeploymentStatus, lastVersion int32, force ...bool) error
 	// GetAgencyClients returns a client connection for every agency member.
 	// If the given predicate is not nil, only agents are included where the given predicate returns true.
 	GetAgencyClients(ctx context.Context, predicate func(id string) bool) ([]driver.Connection, error)

--- a/pkg/deployment/resilience/member_failure.go
+++ b/pkg/deployment/resilience/member_failure.go
@@ -41,7 +41,7 @@ const (
 // - They are frequently restarted
 // - They cannot be scheduled for a long time (TODO)
 func (r *Resilience) CheckMemberFailure() error {
-	status := r.context.GetStatus()
+	status, lastVersion := r.context.GetStatus()
 	updateStatusNeeded := false
 	if err := status.Members.ForeachServerGroup(func(group api.ServerGroup, list *api.MemberStatusList) error {
 		for _, m := range *list {
@@ -103,7 +103,7 @@ func (r *Resilience) CheckMemberFailure() error {
 		return maskAny(err)
 	}
 	if updateStatusNeeded {
-		if err := r.context.UpdateStatus(status); err != nil {
+		if err := r.context.UpdateStatus(status, lastVersion); err != nil {
 			return maskAny(err)
 		}
 	}

--- a/pkg/deployment/resilience/member_failure.go
+++ b/pkg/deployment/resilience/member_failure.go
@@ -43,8 +43,8 @@ const (
 func (r *Resilience) CheckMemberFailure() error {
 	status, lastVersion := r.context.GetStatus()
 	updateStatusNeeded := false
-	if err := status.Members.ForeachServerGroup(func(group api.ServerGroup, list *api.MemberStatusList) error {
-		for _, m := range *list {
+	if err := status.Members.ForeachServerGroup(func(group api.ServerGroup, list api.MemberStatusList) error {
+		for _, m := range list {
 			log := r.log.With().
 				Str("id", m.ID).
 				Str("role", group.AsRole()).
@@ -70,7 +70,7 @@ func (r *Resilience) CheckMemberFailure() error {
 					} else if failureAcceptable {
 						log.Info().Msg("Member is not ready for long time, marking is failed")
 						m.Phase = api.MemberPhaseFailed
-						list.Update(m)
+						status.Members.UpdateMemberStatus(m, group)
 						updateStatusNeeded = true
 					} else {
 						log.Warn().Msgf("Member is not ready for long time, but it is not safe to mark it a failed because: %s", reason)
@@ -89,7 +89,7 @@ func (r *Resilience) CheckMemberFailure() error {
 					} else if failureAcceptable {
 						log.Info().Msg("Member has terminated too often in recent history, marking is failed")
 						m.Phase = api.MemberPhaseFailed
-						list.Update(m)
+						status.Members.UpdateMemberStatus(m, group)
 						updateStatusNeeded = true
 					} else {
 						log.Warn().Msgf("Member has terminated too often in recent history, but it is not safe to mark it a failed because: %s", reason)

--- a/pkg/deployment/resources/context.go
+++ b/pkg/deployment/resources/context.go
@@ -52,10 +52,10 @@ type Context interface {
 	// GetSpec returns the current specification of the deployment
 	GetSpec() api.DeploymentSpec
 	// GetStatus returns the current status of the deployment
-	GetStatus() api.DeploymentStatus
+	GetStatus() (api.DeploymentStatus, int32)
 	// UpdateStatus replaces the status of the deployment with the given status and
 	// updates the resources in k8s.
-	UpdateStatus(status api.DeploymentStatus, force ...bool) error
+	UpdateStatus(status api.DeploymentStatus, lastVersion int32, force ...bool) error
 	// GetKubeCli returns the kubernetes client
 	GetKubeCli() kubernetes.Interface
 	// GetLifecycleImage returns the image name containing the lifecycle helper (== name of operator image)

--- a/pkg/deployment/resources/member_cleanup.go
+++ b/pkg/deployment/resources/member_cleanup.go
@@ -77,7 +77,9 @@ func (r *Resources) cleanupRemovedClusterMembers() error {
 	}
 
 	// For over all members that can be removed
-	status := r.context.GetStatus()
+	status, lastVersion := r.context.GetStatus()
+	updateStatusNeeded := false
+	var podNamesToRemove, pvcNamesToRemove []string
 	status.Members.ForeachServerGroup(func(group api.ServerGroup, list *api.MemberStatusList) error {
 		if group != api.ServerGroupCoordinators && group != api.ServerGroupDBServers {
 			// We're not interested in these other groups
@@ -88,9 +90,7 @@ func (r *Resources) cleanupRemovedClusterMembers() error {
 				// Member is (still) found, skip it
 				if m.Conditions.Update(api.ConditionTypeMemberOfCluster, true, "", "") {
 					list.Update(m)
-					if err := r.context.UpdateStatus(status); err != nil {
-						return maskAny(err)
-					}
+					updateStatusNeeded = true
 				}
 				continue
 			} else if !m.Conditions.IsTrue(api.ConditionTypeMemberOfCluster) {
@@ -104,23 +104,34 @@ func (r *Resources) cleanupRemovedClusterMembers() error {
 				log.Info().Str("member", m.ID).Str("role", group.AsRole()).Msg("Member is no longer part of the ArangoDB cluster. Removing it.")
 			}
 			list.RemoveByID(m.ID)
-			if err := r.context.UpdateStatus(status); err != nil {
-				return maskAny(err)
-			}
+			updateStatusNeeded = true
 			// Remove Pod & PVC (if any)
 			if m.PodName != "" {
-				if err := r.context.DeletePod(m.PodName); err != nil && !k8sutil.IsNotFound(err) {
-					log.Warn().Err(err).Str("pod", m.PodName).Msg("Failed to remove obsolete pod")
-				}
+				podNamesToRemove = append(podNamesToRemove, m.PodName)
 			}
 			if m.PersistentVolumeClaimName != "" {
-				if err := r.context.DeletePvc(m.PersistentVolumeClaimName); err != nil && !k8sutil.IsNotFound(err) {
-					log.Warn().Err(err).Str("pvc", m.PersistentVolumeClaimName).Msg("Failed to remove obsolete PVC")
-				}
+				pvcNamesToRemove = append(pvcNamesToRemove, m.PersistentVolumeClaimName)
 			}
 		}
 		return nil
 	})
+
+	if updateStatusNeeded {
+		if err := r.context.UpdateStatus(status, lastVersion); err != nil {
+			return maskAny(err)
+		}
+	}
+
+	for _, podName := range podNamesToRemove {
+		if err := r.context.DeletePod(podName); err != nil && !k8sutil.IsNotFound(err) {
+			log.Warn().Err(err).Str("pod", podName).Msg("Failed to remove obsolete pod")
+		}
+	}
+	for _, pvcName := range pvcNamesToRemove {
+		if err := r.context.DeletePvc(pvcName); err != nil && !k8sutil.IsNotFound(err) {
+			log.Warn().Err(err).Str("pvc", pvcName).Msg("Failed to remove obsolete PVC")
+		}
+	}
 
 	return nil
 }

--- a/pkg/deployment/resources/member_cleanup.go
+++ b/pkg/deployment/resources/member_cleanup.go
@@ -80,12 +80,12 @@ func (r *Resources) cleanupRemovedClusterMembers() error {
 	status, lastVersion := r.context.GetStatus()
 	updateStatusNeeded := false
 	var podNamesToRemove, pvcNamesToRemove []string
-	status.Members.ForeachServerGroup(func(group api.ServerGroup, list *api.MemberStatusList) error {
+	status.Members.ForeachServerGroup(func(group api.ServerGroup, list api.MemberStatusList) error {
 		if group != api.ServerGroupCoordinators && group != api.ServerGroupDBServers {
 			// We're not interested in these other groups
 			return nil
 		}
-		for _, m := range *list {
+		for _, m := range list {
 			if serverFound(m.ID) {
 				// Member is (still) found, skip it
 				if m.Conditions.Update(api.ConditionTypeMemberOfCluster, true, "", "") {
@@ -103,7 +103,7 @@ func (r *Resources) cleanupRemovedClusterMembers() error {
 				// Member no longer part of cluster, remove it
 				log.Info().Str("member", m.ID).Str("role", group.AsRole()).Msg("Member is no longer part of the ArangoDB cluster. Removing it.")
 			}
-			list.RemoveByID(m.ID)
+			status.Members.RemoveByID(m.ID, group)
 			updateStatusNeeded = true
 			// Remove Pod & PVC (if any)
 			if m.PodName != "" {

--- a/pkg/deployment/resources/pod_cleanup.go
+++ b/pkg/deployment/resources/pod_cleanup.go
@@ -45,7 +45,7 @@ func (r *Resources) CleanupTerminatedPods() error {
 	}
 
 	// Update member status from all pods found
-	status := r.context.GetStatus()
+	status, _ := r.context.GetStatus()
 	for _, p := range pods {
 		if k8sutil.IsArangoDBImageIDAndVersionPod(p) {
 			// Image ID pods are not relevant to inspect here

--- a/pkg/deployment/resources/pod_creator.go
+++ b/pkg/deployment/resources/pod_creator.go
@@ -428,13 +428,17 @@ func (r *Resources) createPodTolerations(group api.ServerGroup, groupSpec api.Se
 }
 
 // createPodForMember creates all Pods listed in member status
-func (r *Resources) createPodForMember(spec api.DeploymentSpec, group api.ServerGroup,
-	groupSpec api.ServerGroupSpec, m api.MemberStatus, memberStatusList *api.MemberStatusList) error {
+func (r *Resources) createPodForMember(spec api.DeploymentSpec, memberID string) error {
 	kubecli := r.context.GetKubeCli()
 	log := r.log
 	apiObject := r.context.GetAPIObject()
 	ns := r.context.GetNamespace()
-	status := r.context.GetStatus()
+	status, lastVersion := r.context.GetStatus()
+	m, group, found := status.Members.ElementByID(memberID)
+	if !found {
+		return maskAny(fmt.Errorf("Member '%s' not found", memberID))
+	}
+	groupSpec := spec.GetServerGroupSpec(group)
 	lifecycleImage := r.context.GetLifecycleImage()
 	terminationGracePeriod := group.DefaultTerminationGracePeriod()
 	tolerations := r.createPodTolerations(group, groupSpec)
@@ -582,10 +586,10 @@ func (r *Resources) createPodForMember(spec api.DeploymentSpec, group api.Server
 	m.Conditions.Remove(api.ConditionTypeReady)
 	m.Conditions.Remove(api.ConditionTypeTerminated)
 	m.Conditions.Remove(api.ConditionTypeAutoUpgrade)
-	if err := memberStatusList.Update(m); err != nil {
+	if err := status.Members.UpdateMemberStatus(m, group); err != nil {
 		return maskAny(err)
 	}
-	if err := r.context.UpdateStatus(status); err != nil {
+	if err := r.context.UpdateStatus(status, lastVersion); err != nil {
 		return maskAny(err)
 	}
 	// Create event
@@ -597,7 +601,7 @@ func (r *Resources) createPodForMember(spec api.DeploymentSpec, group api.Server
 // EnsurePods creates all Pods listed in member status
 func (r *Resources) EnsurePods() error {
 	iterator := r.context.GetServerGroupIterator()
-	status := r.context.GetStatus()
+	status, _ := r.context.GetStatus()
 	if err := iterator.ForeachServerGroup(func(group api.ServerGroup, groupSpec api.ServerGroupSpec, status *api.MemberStatusList) error {
 		for _, m := range *status {
 			if m.Phase != api.MemberPhaseNone {
@@ -607,7 +611,7 @@ func (r *Resources) EnsurePods() error {
 				continue
 			}
 			spec := r.context.GetSpec()
-			if err := r.createPodForMember(spec, group, groupSpec, m, status); err != nil {
+			if err := r.createPodForMember(spec, m.ID); err != nil {
 				return maskAny(err)
 			}
 		}

--- a/pkg/deployment/resources/pod_inspector.go
+++ b/pkg/deployment/resources/pod_inspector.go
@@ -56,7 +56,7 @@ func (r *Resources) InspectPods(ctx context.Context) error {
 	}
 
 	// Update member status from all pods found
-	status := r.context.GetStatus()
+	status, lastVersion := r.context.GetStatus()
 	apiObject := r.context.GetAPIObject()
 	var podNamesWithScheduleTimeout []string
 	var unscheduledPodNames []string
@@ -236,7 +236,7 @@ func (r *Resources) InspectPods(ctx context.Context) error {
 	}
 
 	// Save status
-	if err := r.context.UpdateStatus(status); err != nil {
+	if err := r.context.UpdateStatus(status, lastVersion); err != nil {
 		return maskAny(err)
 	}
 

--- a/pkg/deployment/resources/pod_inspector.go
+++ b/pkg/deployment/resources/pod_inspector.go
@@ -162,8 +162,8 @@ func (r *Resources) InspectPods(ctx context.Context) error {
 	}
 
 	// Go over all members, check for missing pods
-	status.Members.ForeachServerGroup(func(group api.ServerGroup, members *api.MemberStatusList) error {
-		for _, m := range *members {
+	status.Members.ForeachServerGroup(func(group api.ServerGroup, members api.MemberStatusList) error {
+		for _, m := range members {
 			if podName := m.PodName; podName != "" {
 				if !podExists(podName) {
 					switch m.Phase {

--- a/pkg/deployment/resources/pvc_inspector.go
+++ b/pkg/deployment/resources/pvc_inspector.go
@@ -45,7 +45,7 @@ func (r *Resources) InspectPVCs(ctx context.Context) error {
 	}
 
 	// Update member status from all pods found
-	status := r.context.GetStatus()
+	status, _ := r.context.GetStatus()
 	for _, p := range pvcs {
 		// PVC belongs to this deployment, update metric
 		inspectedPVCCounter.Inc()

--- a/pkg/deployment/resources/pvcs.go
+++ b/pkg/deployment/resources/pvcs.go
@@ -42,7 +42,7 @@ func (r *Resources) EnsurePVCs() error {
 	ns := apiObject.GetNamespace()
 	owner := apiObject.AsOwner()
 	iterator := r.context.GetServerGroupIterator()
-	status := r.context.GetStatus()
+	status, _ := r.context.GetStatus()
 	enforceAntiAffinity := r.context.GetSpec().GetEnvironment().IsProduction()
 
 	if err := iterator.ForeachServerGroup(func(group api.ServerGroup, spec api.ServerGroupSpec, status *api.MemberStatusList) error {

--- a/pkg/deployment/resources/services.go
+++ b/pkg/deployment/resources/services.go
@@ -64,11 +64,13 @@ func (r *Resources) EnsureServices() error {
 	if newlyCreated {
 		log.Debug().Str("service", svcName).Msg("Created database client service")
 	}
-	status := r.context.GetStatus()
-	if status.ServiceName != svcName {
-		status.ServiceName = svcName
-		if err := r.context.UpdateStatus(status); err != nil {
-			return maskAny(err)
+	{
+		status, lastVersion := r.context.GetStatus()
+		if status.ServiceName != svcName {
+			status.ServiceName = svcName
+			if err := r.context.UpdateStatus(status, lastVersion); err != nil {
+				return maskAny(err)
+			}
 		}
 	}
 
@@ -89,10 +91,10 @@ func (r *Resources) EnsureServices() error {
 		if err := r.ensureExternalAccessServices(eaServiceName, ns, role, "sync", k8sutil.ArangoSyncMasterPort, true, spec.Sync.ExternalAccess.ExternalAccessSpec, apiObject, log, kubecli); err != nil {
 			return maskAny(err)
 		}
-		status := r.context.GetStatus()
+		status, lastVersion := r.context.GetStatus()
 		if status.SyncServiceName != eaServiceName {
 			status.SyncServiceName = eaServiceName
-			if err := r.context.UpdateStatus(status); err != nil {
+			if err := r.context.UpdateStatus(status, lastVersion); err != nil {
 				return maskAny(err)
 			}
 		}


### PR DESCRIPTION
There were some cases where status could be overwritten, resulting in member objects being listed twice.
This PR makes modifying the status a very controlled procedure. When you fetch the status you get a last version number. When updating the status, that last version has to match the current version number.

<!---
@huboard:{"order":166.0166,"milestone_order":172,"custom_state":""}
-->
