### PR TITLE
Avoid useless warnings in log

### DIFF
--- a/pkg/deployment/cleanup.go
+++ b/pkg/deployment/cleanup.go
@@ -35,7 +35,8 @@ func (d *Deployment) removePodFinalizers() error {
 		return maskAny(err)
 	}
 	for _, p := range pods {
-		if err := k8sutil.RemovePodFinalizers(log, kubecli, &p, p.GetFinalizers()); err != nil {
+		ignoreNotFound := true
+		if err := k8sutil.RemovePodFinalizers(log, kubecli, &p, p.GetFinalizers(), ignoreNotFound); err != nil {
 			log.Warn().Err(err).Msg("Failed to remove pod finalizers")
 		}
 	}
@@ -51,7 +52,8 @@ func (d *Deployment) removePVCFinalizers() error {
 		return maskAny(err)
 	}
 	for _, p := range pvcs {
-		if err := k8sutil.RemovePVCFinalizers(log, kubecli, &p, p.GetFinalizers()); err != nil {
+		ignoreNotFound := true
+		if err := k8sutil.RemovePVCFinalizers(log, kubecli, &p, p.GetFinalizers(), ignoreNotFound); err != nil {
 			log.Warn().Err(err).Msg("Failed to remove PVC finalizers")
 		}
 	}

--- a/pkg/deployment/cluster_scaling_integration.go
+++ b/pkg/deployment/cluster_scaling_integration.go
@@ -50,6 +50,10 @@ type clusterScalingIntegration struct {
 	}
 }
 
+const (
+	maxClusterBootstrapTime = time.Minute * 2 // Time we allow a cluster bootstrap to take, before we can do cluster inspections.
+)
+
 // newClusterScalingIntegration creates a new clusterScalingIntegration.
 func newClusterScalingIntegration(depl *Deployment) *clusterScalingIntegration {
 	return &clusterScalingIntegration{
@@ -67,6 +71,8 @@ func (ci *clusterScalingIntegration) SendUpdateToCluster(spec api.DeploymentSpec
 
 // listenForClusterEvents keep listening for changes entered in the UI of the cluster.
 func (ci *clusterScalingIntegration) ListenForClusterEvents(stopCh <-chan struct{}) {
+	start := time.Now()
+	goodInspections := 0
 	for {
 		delay := time.Second * 2
 
@@ -74,13 +80,20 @@ func (ci *clusterScalingIntegration) ListenForClusterEvents(stopCh <-chan struct
 		if ci.depl.GetPhase() == api.DeploymentPhaseRunning {
 			// Update cluster with our state
 			ctx := context.Background()
-			safeToAskCluster, err := ci.updateClusterServerCount(ctx)
+			expectSuccess := goodInspections > 0 || time.Since(start) > maxClusterBootstrapTime
+			safeToAskCluster, err := ci.updateClusterServerCount(ctx, expectSuccess)
 			if err != nil {
-				ci.log.Debug().Err(err).Msg("Cluster update failed")
+				if expectSuccess {
+					ci.log.Debug().Err(err).Msg("Cluster update failed")
+				}
 			} else if safeToAskCluster {
 				// Inspect once
-				if err := ci.inspectCluster(ctx); err != nil {
-					ci.log.Debug().Err(err).Msg("Cluster inspection failed")
+				if err := ci.inspectCluster(ctx, expectSuccess); err != nil {
+					if expectSuccess {
+						ci.log.Debug().Err(err).Msg("Cluster inspection failed")
+					}
+				} else {
+					goodInspections++
 				}
 			}
 		}
@@ -96,7 +109,7 @@ func (ci *clusterScalingIntegration) ListenForClusterEvents(stopCh <-chan struct
 }
 
 // Perform a single inspection of the cluster
-func (ci *clusterScalingIntegration) inspectCluster(ctx context.Context) error {
+func (ci *clusterScalingIntegration) inspectCluster(ctx context.Context, expectSuccess bool) error {
 	log := ci.log
 	c, err := ci.depl.clientCache.GetDatabase(ctx)
 	if err != nil {
@@ -104,7 +117,9 @@ func (ci *clusterScalingIntegration) inspectCluster(ctx context.Context) error {
 	}
 	req, err := arangod.GetNumberOfServers(ctx, c.Connection())
 	if err != nil {
-		log.Debug().Err(err).Msg("Failed to get number of servers")
+		if expectSuccess {
+			log.Debug().Err(err).Msg("Failed to get number of servers")
+		}
 		return maskAny(err)
 	}
 	if req.Coordinators == nil && req.DBServers == nil {
@@ -150,7 +165,7 @@ func (ci *clusterScalingIntegration) inspectCluster(ctx context.Context) error {
 
 // updateClusterServerCount updates the intended number of servers of the cluster.
 // Returns true when it is safe to ask the cluster for updates.
-func (ci *clusterScalingIntegration) updateClusterServerCount(ctx context.Context) (bool, error) {
+func (ci *clusterScalingIntegration) updateClusterServerCount(ctx context.Context, expectSuccess bool) (bool, error) {
 	// Any update needed?
 	ci.pendingUpdate.mutex.Lock()
 	spec := ci.pendingUpdate.spec
@@ -168,7 +183,9 @@ func (ci *clusterScalingIntegration) updateClusterServerCount(ctx context.Contex
 	coordinatorCount := spec.Coordinators.GetCount()
 	dbserverCount := spec.DBServers.GetCount()
 	if err := arangod.SetNumberOfServers(ctx, c.Connection(), coordinatorCount, dbserverCount); err != nil {
-		log.Debug().Err(err).Msg("Failed to set number of servers")
+		if expectSuccess {
+			log.Debug().Err(err).Msg("Failed to set number of servers")
+		}
 		return false, maskAny(err)
 	}
 

--- a/pkg/deployment/deployment_finalizers.go
+++ b/pkg/deployment/deployment_finalizers.go
@@ -109,7 +109,8 @@ func removeDeploymentFinalizers(log zerolog.Logger, cli versioned.Interface, dep
 		*depl = *result
 		return nil
 	}
-	if err := k8sutil.RemoveFinalizers(log, finalizers, getFunc, updateFunc); err != nil {
+	ignoreNotFound := false
+	if err := k8sutil.RemoveFinalizers(log, finalizers, getFunc, updateFunc, ignoreNotFound); err != nil {
 		return maskAny(err)
 	}
 	return nil

--- a/pkg/deployment/resources/pod_finalizers.go
+++ b/pkg/deployment/resources/pod_finalizers.go
@@ -62,7 +62,8 @@ func (r *Resources) runPodFinalizers(ctx context.Context, p *v1.Pod, memberStatu
 	// Remove finalizers (if needed)
 	if len(removalList) > 0 {
 		kubecli := r.context.GetKubeCli()
-		if err := k8sutil.RemovePodFinalizers(log, kubecli, p, removalList); err != nil {
+		ignoreNotFound := false
+		if err := k8sutil.RemovePodFinalizers(log, kubecli, p, removalList, ignoreNotFound); err != nil {
 			log.Debug().Err(err).Msg("Failed to update pod (to remove finalizers)")
 			return maskAny(err)
 		}

--- a/pkg/deployment/resources/pod_inspector.go
+++ b/pkg/deployment/resources/pod_inspector.go
@@ -78,7 +78,8 @@ func (r *Resources) InspectPods(ctx context.Context) error {
 				// Remove all finalizers, so it can be removed.
 				log.Warn().Msg("Pod belongs to this deployment, but we don't know the member. Removing all finalizers")
 				kubecli := r.context.GetKubeCli()
-				if err := k8sutil.RemovePodFinalizers(log, kubecli, &p, p.GetFinalizers()); err != nil {
+				ignoreNotFound := false
+				if err := k8sutil.RemovePodFinalizers(log, kubecli, &p, p.GetFinalizers(), ignoreNotFound); err != nil {
 					log.Debug().Err(err).Msg("Failed to update pod (to remove all finalizers)")
 					return maskAny(err)
 				}

--- a/pkg/deployment/resources/pvc_finalizers.go
+++ b/pkg/deployment/resources/pvc_finalizers.go
@@ -53,7 +53,8 @@ func (r *Resources) runPVCFinalizers(ctx context.Context, p *v1.PersistentVolume
 	// Remove finalizers (if needed)
 	if len(removalList) > 0 {
 		kubecli := r.context.GetKubeCli()
-		if err := k8sutil.RemovePVCFinalizers(log, kubecli, p, removalList); err != nil {
+		ignoreNotFound := false
+		if err := k8sutil.RemovePVCFinalizers(log, kubecli, p, removalList, ignoreNotFound); err != nil {
 			log.Debug().Err(err).Msg("Failed to update PVC (to remove finalizers)")
 			return maskAny(err)
 		}

--- a/pkg/deployment/resources/pvc_inspector.go
+++ b/pkg/deployment/resources/pvc_inspector.go
@@ -59,7 +59,8 @@ func (r *Resources) InspectPVCs(ctx context.Context) error {
 				// Remove all finalizers, so it can be removed.
 				log.Warn().Msg("PVC belongs to this deployment, but we don't know the member. Removing all finalizers")
 				kubecli := r.context.GetKubeCli()
-				if err := k8sutil.RemovePVCFinalizers(log, kubecli, &p, p.GetFinalizers()); err != nil {
+				ignoreNotFound := false
+				if err := k8sutil.RemovePVCFinalizers(log, kubecli, &p, p.GetFinalizers(), ignoreNotFound); err != nil {
 					log.Debug().Err(err).Msg("Failed to update PVC (to remove all finalizers)")
 					return maskAny(err)
 				}


### PR DESCRIPTION
This PR holds a collection of changes that all prevent warnings in logs that are not really something to worry about:

- The scaling cluster integration that cannot reach the cluster while it is still bootstrapping
- Removing finalizers of resources that are already gone (which is perfectly valid in that case)
- Reporting that an image ID is not yet know for all 9 pods (where 1 is sufficient)

<!---
@huboard:{"order":166.0166,"milestone_order":174,"custom_state":""}
-->
