### PR TITLE
Improved readiness probe, database services only use ready pods

### DIFF
--- a/pkg/apis/deployment/v1alpha/deployment_status_members.go
+++ b/pkg/apis/deployment/v1alpha/deployment_status_members.go
@@ -211,7 +211,7 @@ func (ds *DeploymentStatusMembers) RemoveByID(id string, group ServerGroup) erro
 	return nil
 }
 
-// AllMembersReady returns true when all members are in the Ready state.
+// AllMembersReady returns true when all members, that must be ready for the given mode, are in the Ready state.
 func (ds DeploymentStatusMembers) AllMembersReady(mode DeploymentMode, syncEnabled bool) bool {
 	syncReady := func() bool {
 		if syncEnabled {

--- a/pkg/apis/deployment/v1alpha/member_status_list.go
+++ b/pkg/apis/deployment/v1alpha/member_status_list.go
@@ -134,3 +134,19 @@ func (l MemberStatusList) SelectMemberToRemove() (MemberStatus, error) {
 	}
 	return MemberStatus{}, maskAny(errors.Wrap(NotFoundError, "No member available for removal"))
 }
+
+// MembersReady returns the number of members that are in the Ready state.
+func (l MemberStatusList) MembersReady() int {
+	readyCount := 0
+	for _, x := range l {
+		if x.Conditions.IsTrue(ConditionTypeReady) {
+			readyCount++
+		}
+	}
+	return readyCount
+}
+
+// AllMembersReady returns the true if all members are in the Ready state.
+func (l MemberStatusList) AllMembersReady() bool {
+	return len(l) == l.MembersReady()
+}

--- a/pkg/deployment/resources/pod_inspector.go
+++ b/pkg/deployment/resources/pod_inspector.go
@@ -217,7 +217,8 @@ func (r *Resources) InspectPods(ctx context.Context) error {
 	})
 
 	// Update overall conditions
-	allMembersReady := status.Members.AllMembersReady()
+	spec := r.context.GetSpec()
+	allMembersReady := status.Members.AllMembersReady(spec.GetMode(), spec.Sync.IsEnabled())
 	status.Conditions.Update(api.ConditionTypeReady, allMembersReady, "", "")
 
 	// Update conditions

--- a/pkg/util/k8sutil/probes_test.go
+++ b/pkg/util/k8sutil/probes_test.go
@@ -34,7 +34,7 @@ func TestCreate(t *testing.T) {
 	secret := "the secret"
 
 	// http
-	config := HTTPProbeConfig{path, false, secret, 0}
+	config := HTTPProbeConfig{path, false, secret, 0, 0, 0, 0, 0, 0}
 	probe := config.Create()
 
 	assert.Equal(t, probe.InitialDelaySeconds, int32(30))
@@ -50,8 +50,18 @@ func TestCreate(t *testing.T) {
 	assert.Equal(t, probe.Handler.HTTPGet.Scheme, v1.URISchemeHTTP)
 
 	// https
-	config = HTTPProbeConfig{path, true, secret, 0}
+	config = HTTPProbeConfig{path, true, secret, 0, 0, 0, 0, 0, 0}
 	probe = config.Create()
 
 	assert.Equal(t, probe.Handler.HTTPGet.Scheme, v1.URISchemeHTTPS)
+
+	// http, custom timing
+	config = HTTPProbeConfig{path, false, secret, 0, 1, 2, 3, 4, 5}
+	probe = config.Create()
+
+	assert.Equal(t, probe.InitialDelaySeconds, int32(1))
+	assert.Equal(t, probe.TimeoutSeconds, int32(2))
+	assert.Equal(t, probe.PeriodSeconds, int32(3))
+	assert.Equal(t, probe.SuccessThreshold, int32(4))
+	assert.Equal(t, probe.FailureThreshold, int32(5))
 }


### PR DESCRIPTION
This PR changes the readiness tests of some pods & tweaks the services used to access the database.

- The readiness probe is now added to all single & coordinator pods (before only coordinator)
- The readiness probe is done a lot quicker and more often
- The readiness probe is done on `_admin/echo` for activefailover deployments
- The database & external access services no only accept ready endpoints

As a result, activefailover deployments only expose the master single server.
Also a cluster deployment exposes only ready coordinators.
