### PR TITLE
Min dbserver count is 2. Revert phase when cleanout has failed

### DIFF
--- a/pkg/apis/deployment/v1alpha/server_group_spec.go
+++ b/pkg/apis/deployment/v1alpha/server_group_spec.go
@@ -77,6 +77,7 @@ func (s ServerGroupSpec) Validate(group ServerGroup, used bool, mode DeploymentM
 	if used {
 		minCount := 1
 		if env == EnvironmentProduction {
+			// Set validation boundaries for production mode
 			switch group {
 			case ServerGroupSingle:
 				if mode == DeploymentModeActiveFailover {
@@ -85,6 +86,16 @@ func (s ServerGroupSpec) Validate(group ServerGroup, used bool, mode DeploymentM
 			case ServerGroupAgents:
 				minCount = 3
 			case ServerGroupDBServers, ServerGroupCoordinators, ServerGroupSyncMasters, ServerGroupSyncWorkers:
+				minCount = 2
+			}
+		} else {
+			// Set validation boundaries for development mode
+			switch group {
+			case ServerGroupSingle:
+				if mode == DeploymentModeActiveFailover {
+					minCount = 2
+				}
+			case ServerGroupDBServers:
 				minCount = 2
 			}
 		}

--- a/pkg/deployment/reconcile/action_cleanout_member.go
+++ b/pkg/deployment/reconcile/action_cleanout_member.go
@@ -131,6 +131,12 @@ func (a *actionCleanoutMember) CheckProgress(ctx context.Context) (bool, bool, e
 		}
 		if jobStatus.IsFailed() {
 			log.Warn().Str("reason", jobStatus.Reason()).Msg("Cleanout Job failed. Aborting plan")
+			// Revert cleanout state
+			m.Phase = api.MemberPhaseCreated
+			m.CleanoutJobID = ""
+			if a.actionCtx.UpdateMember(m); err != nil {
+				return false, false, maskAny(err)
+			}
 			return false, true, nil
 		}
 		return false, false, nil

--- a/pkg/deployment/reconcile/plan_builder.go
+++ b/pkg/deployment/reconcile/plan_builder.go
@@ -359,7 +359,9 @@ func createScalePlan(log zerolog.Logger, members api.MemberStatusList, group api
 			Msg("Creating scale-up plan")
 	} else if len(members) > count {
 		// Note, we scale down 1 member at a time
-		if m, err := members.SelectMemberToRemove(); err == nil {
+		if m, err := members.SelectMemberToRemove(); err != nil {
+			log.Warn().Err(err).Str("role", group.AsRole()).Msg("Failed to select member to remove")
+		} else {
 			if group == api.ServerGroupDBServers {
 				plan = append(plan,
 					api.NewAction(api.ActionTypeCleanOutMember, group, m.ID),


### PR DESCRIPTION
This PR changes the following:

- Minimum server count for dbserver is always 2
- Minimum server count for single+activefailover is always 2
- Members in phase CleanoutServer are reverted to Created when cleanout action fails and causes the reconciliation plan to abort.

fixes #178