### PR TITLE
Set a `role=leader` label on the Pod who won the leader election

### DIFF
--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -51,4 +51,7 @@ const (
 	FinalizerPVCMemberExists           = "pvc.database.arangodb.com/member-exists"       // Finalizer added to PVCs, indicating the need to keep is as long as its member exists
 
 	AnnotationEnforceAntiAffinity = "database.arangodb.com/enforce-anti-affinity" // Key of annotation added to PVC. Value is a boolean "true" or "false"
+
+	LabelRole       = "role"
+	LabelRoleLeader = "leader"
 )


### PR DESCRIPTION
This PR sets a label (`role=leader`) on the operator Pod who won the leader election.

After this, fetching the logs of the leader deployment operator looks like this

```
kubectl logs --selector=name=arango-deployment-operator,role=leader
```