### PR TITLE
Applying defaults after immutable fields have been reset

### DIFF
--- a/pkg/apis/deployment/v1alpha/server_group_spec.go
+++ b/pkg/apis/deployment/v1alpha/server_group_spec.go
@@ -135,7 +135,7 @@ func (s *ServerGroupSpec) SetDefaults(group ServerGroup, used bool, mode Deploym
 			s.Count = util.NewInt(3)
 		}
 	} else if s.GetCount() > 0 && !used {
-		s.Count = nil // util.NewInt(0)
+		s.Count = nil
 	}
 	if _, found := s.Resources.Requests[v1.ResourceStorage]; !found {
 		switch group {

--- a/pkg/apis/deployment/v1alpha/server_group_spec.go
+++ b/pkg/apis/deployment/v1alpha/server_group_spec.go
@@ -135,7 +135,7 @@ func (s *ServerGroupSpec) SetDefaults(group ServerGroup, used bool, mode Deploym
 			s.Count = util.NewInt(3)
 		}
 	} else if s.GetCount() > 0 && !used {
-		s.Count = util.NewInt(0)
+		s.Count = nil // util.NewInt(0)
 	}
 	if _, found := s.Resources.Requests[v1.ResourceStorage]; !found {
 		switch group {

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -292,6 +292,7 @@ func (d *Deployment) handleArangoDeploymentUpdatedEvent() error {
 	resetFields := specBefore.ResetImmutableFields(&newAPIObject.Spec)
 	if len(resetFields) > 0 {
 		log.Debug().Strs("fields", resetFields).Msg("Found modified immutable fields")
+		newAPIObject.Spec.SetDefaults(d.apiObject.GetName())
 	}
 	if err := newAPIObject.Spec.Validate(); err != nil {
 		d.CreateEvent(k8sutil.NewErrorEvent("Validation failed", err, d.apiObject))


### PR DESCRIPTION
This PR fixes a problem where a `mode` field was not reset, because the validation of the spec after applying ResetImmutableFields failed.