### PR TITLE
Use new CurrentImage field to prevent unintended upgrades.

### DIFF
--- a/pkg/apis/deployment/v1alpha/deployment_status.go
+++ b/pkg/apis/deployment/v1alpha/deployment_status.go
@@ -38,6 +38,8 @@ type DeploymentStatus struct {
 
 	// Images holds a list of ArangoDB images with their ID and ArangoDB version.
 	Images ImageInfoList `json:"arangodb-images,omitempty"`
+	// Image that is currently being used when new pods are created
+	CurrentImage *ImageInfo `json:"current-image,omitempty"`
 
 	// Members holds the status for all members in all server groups
 	Members DeploymentStatusMembers `json:"members"`

--- a/pkg/apis/deployment/v1alpha/plan.go
+++ b/pkg/apis/deployment/v1alpha/plan.go
@@ -49,6 +49,8 @@ const (
 	ActionTypeRenewTLSCertificate ActionType = "RenewTLSCertificate"
 	// ActionTypeRenewTLSCACertificate causes the TLS CA certificate of the entire deployment to be renewed.
 	ActionTypeRenewTLSCACertificate ActionType = "RenewTLSCACertificate"
+	// ActionTypeSetCurrentImage causes status.CurrentImage to be updated to the image given in the action.
+	ActionTypeSetCurrentImage ActionType = "SetCurrentImage"
 )
 
 const (
@@ -73,6 +75,8 @@ type Action struct {
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// Reason for this action
 	Reason string `json:"reason,omitempty"`
+	// Image used in can of a SetCurrentImage action.
+	Image string `json:"image,omitempty"`
 }
 
 // NewAction instantiates a new Action.
@@ -87,6 +91,13 @@ func NewAction(actionType ActionType, group ServerGroup, memberID string, reason
 	if len(reason) != 0 {
 		a.Reason = reason[0]
 	}
+	return a
+}
+
+// SetImage sets the Image field to the given value and returns the modified
+// action.
+func (a Action) SetImage(image string) Action {
+	a.Image = image
 	return a
 }
 

--- a/pkg/apis/deployment/v1alpha/zz_generated.deepcopy.go
+++ b/pkg/apis/deployment/v1alpha/zz_generated.deepcopy.go
@@ -295,6 +295,15 @@ func (in *DeploymentStatus) DeepCopyInto(out *DeploymentStatus) {
 		*out = make(ImageInfoList, len(*in))
 		copy(*out, *in)
 	}
+	if in.CurrentImage != nil {
+		in, out := &in.CurrentImage, &out.CurrentImage
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(ImageInfo)
+			**out = **in
+		}
+	}
 	in.Members.DeepCopyInto(&out.Members)
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions

--- a/pkg/deployment/reconcile/action_upgrade_current_image.go
+++ b/pkg/deployment/reconcile/action_upgrade_current_image.go
@@ -1,0 +1,85 @@
+//
+// DISCLAIMER
+//
+// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package reconcile
+
+import (
+	"context"
+	"time"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1alpha"
+	"github.com/rs/zerolog"
+)
+
+// NewSetCurrentImageAction creates a new Action that implements the given
+// planned SetCurrentImage action.
+func NewSetCurrentImageAction(log zerolog.Logger, action api.Action, actionCtx ActionContext) Action {
+	return &setCurrentImageAction{
+		log:       log,
+		action:    action,
+		actionCtx: actionCtx,
+	}
+}
+
+// setCurrentImageAction implements an SetCurrentImage.
+type setCurrentImageAction struct {
+	log       zerolog.Logger
+	action    api.Action
+	actionCtx ActionContext
+}
+
+// Start performs the start of the action.
+// Returns true if the action is completely finished, false in case
+// the start time needs to be recorded and a ready condition needs to be checked.
+func (a *setCurrentImageAction) Start(ctx context.Context) (bool, error) {
+	ready, _, err := a.CheckProgress(ctx)
+	if err != nil {
+		return false, maskAny(err)
+	}
+	return ready, nil
+}
+
+// CheckProgress checks the progress of the action.
+// Returns true if the action is completely finished, false otherwise.
+func (a *setCurrentImageAction) CheckProgress(ctx context.Context) (bool, bool, error) {
+	log := a.log
+
+	imageInfo, found := a.actionCtx.GetImageInfo(a.action.Image)
+	if !found {
+		return false, false, nil
+	}
+	if err := a.actionCtx.SetCurrentImage(imageInfo); err != nil {
+		return false, false, maskAny(err)
+	}
+	log.Info().Str("image", a.action.Image).Msg("Changed current image")
+	return true, false, nil
+}
+
+// Timeout returns the amount of time after which this action will timeout.
+func (a *setCurrentImageAction) Timeout() time.Duration {
+	return upgradeMemberTimeout
+}
+
+// Return the MemberID used / created in this action
+func (a *setCurrentImageAction) MemberID() string {
+	return ""
+}

--- a/pkg/deployment/reconcile/plan_executor.go
+++ b/pkg/deployment/reconcile/plan_executor.go
@@ -181,6 +181,8 @@ func (d *Reconciler) createAction(ctx context.Context, log zerolog.Logger, actio
 		return NewRenewTLSCertificateAction(log, action, actionCtx)
 	case api.ActionTypeRenewTLSCACertificate:
 		return NewRenewTLSCACertificateAction(log, action, actionCtx)
+	case api.ActionTypeSetCurrentImage:
+		return NewSetCurrentImageAction(log, action, actionCtx)
 	default:
 		panic(fmt.Sprintf("Unknown action type '%s'", action.Type))
 	}

--- a/pkg/deployment/server_api.go
+++ b/pkg/deployment/server_api.go
@@ -218,17 +218,15 @@ func (d *Deployment) DatabaseURL() string {
 // DatabaseVersion returns the version used by the deployment
 // Returns versionNumber, licenseType
 func (d *Deployment) DatabaseVersion() (string, string) {
-	image := d.GetSpec().GetImage()
 	status, _ := d.GetStatus()
-	info, found := status.Images.GetByImage(image)
-	if !found {
-		return "", ""
+	if current := status.CurrentImage; current != nil {
+		license := "community"
+		if current.Enterprise {
+			license = "enterprise"
+		}
+		return string(current.ArangoDBVersion), license
 	}
-	license := "community"
-	if info.Enterprise {
-		license = "enterprise"
-	}
-	return string(info.ArangoDBVersion), license
+	return "", ""
 }
 
 // Members returns all members of the deployment by role.

--- a/pkg/util/k8sutil/events.go
+++ b/pkg/util/k8sutil/events.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"strings"
 
+	driver "github.com/arangodb/go-driver"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -188,6 +189,20 @@ func NewDowntimeNotAllowedEvent(apiObject APIObject, operation string) *Event {
 	event.Type = v1.EventTypeNormal
 	event.Reason = "Downtime Operation Postponed"
 	event.Message = fmt.Sprintf("The '%s' operation is postponed because downtime it not allowed. Set `spec.downtimeAllowed` to true to execute this operation", operation)
+	return event
+}
+
+// NewUpgradeNotAllowedEvent creates an event indicating that an upgrade (or downgrade) is not allowed.
+func NewUpgradeNotAllowedEvent(apiObject APIObject, fromVersion, toVersion driver.Version) *Event {
+	event := newDeploymentEvent(apiObject)
+	event.Type = v1.EventTypeNormal
+	if fromVersion.CompareTo(toVersion) < 0 {
+		event.Reason = "Upgrade not allowed"
+		event.Message = fmt.Sprintf("Upgrading ArangoDB from version %s to %s is not allowed", fromVersion, toVersion)
+	} else {
+		event.Reason = "Downgrade not allowed"
+		event.Message = fmt.Sprintf("Downgrading ArangoDB from version %s to %s is not allowed", fromVersion, toVersion)
+	}
 	return event
 }
 


### PR DESCRIPTION
Before a new Pod would always use the image given in the spec of an `ArangoDeployment`.
That could lead to scaling up to new (and unintended) versions.

With this PR a new `current-image` field is added to the status of an `ArangoDeployment`.
When a pod is created, the `current-image` is used. When upgrading, the `current-image` field is updated first, if confirmed that an upgrade is indeed allowed.

If an upgrade is not allowed, an event is added to the `ArangoDeployment`.