### PR TITLE
README updates, removing `kubectl apply -f crd.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ helm install https://github.com/arangodb/kube-arangodb/releases/download/0.3.0/k
 ## Installation of latest release using Kubectl
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/arangodb/kube-arangodb/0.3.0/manifests/crd.yaml
 kubectl apply -f https://raw.githubusercontent.com/arangodb/kube-arangodb/0.3.0/manifests/arango-deployment.yaml
 # To use `ArangoLocalStorage`, also run
 kubectl apply -f https://raw.githubusercontent.com/arangodb/kube-arangodb/0.3.0/manifests/arango-storage.yaml
@@ -61,7 +60,6 @@ kubectl apply -f https://raw.githubusercontent.com/arangodb/kube-arangodb/0.3.0/
 
 ```bash
 DOCKERNAMESPACE=<your dockerhub account> make
-kubectl apply -f manifests/crd.yaml
 kubectl apply -f manifests/arango-deployment-dev.yaml
 # To use `ArangoLocalStorage`, also run
 kubectl apply -f manifests/arango-storage-dev.yaml


### PR DESCRIPTION
This PR must be merged just before the first release that contains #255.

DO NOT MERGE BEFORE A NEW RELEASE.