### PR TITLE
Fixing imageID retrieval issue when sidecars are injected.

### DIFF
--- a/pkg/deployment/images.go
+++ b/pkg/deployment/images.go
@@ -119,7 +119,7 @@ func (ib *imagesBuilder) fetchArangoDBImageIDAndVersion(ctx context.Context, ima
 			log.Warn().Msg("Empty list of ContainerStatuses")
 			return true, nil
 		}
-		imageID := k8sutil.ConvertImageID2Image(pod.Status.ContainerStatuses[0].ImageID)
+		imageID := k8sutil.GetArangoDBImageIDFromPod(pod)
 		if imageID == "" {
 			// Fall back to specified image
 			imageID = image

--- a/pkg/util/k8sutil/images.go
+++ b/pkg/util/k8sutil/images.go
@@ -22,7 +22,11 @@
 
 package k8sutil
 
-import "strings"
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 const (
 	dockerPullableImageIDPrefix = "docker-pullable://"
@@ -35,4 +39,17 @@ func ConvertImageID2Image(imageID string) string {
 		return imageID[len(dockerPullableImageIDPrefix):]
 	}
 	return imageID
+}
+
+// GetArangoDBImageIDFromPod returns the ArangoDB specific image from a pod
+func GetArangoDBImageIDFromPod(pod *corev1.Pod) string {
+	rawImageID := pod.Status.ContainerStatuses[0].ImageID
+	if len(pod.Status.ContainerStatuses) > 1 {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if strings.Contains(containerStatus.ImageID, "arango") {
+				rawImageID = containerStatus.ImageID
+			}
+		}
+	}
+	return ConvertImageID2Image(rawImageID)
 }


### PR DESCRIPTION
Fixed image ID retrieval issue occurring when sidecars were injected where the sidecar's ID was being retrieved instead of ArangoDB in platforms such as Istio.  See issue: #260 