### PR TITLE
Doc - Improve page about draining nodes

### DIFF
--- a/docs/Manual/Deployment/Kubernetes/Drain.md
+++ b/docs/Manual/Deployment/Kubernetes/Drain.md
@@ -158,8 +158,8 @@ Check that each instance has a `Status` field with the value `"GOOD"`.
 Here is a shell command which makes this check easy, using the
 [`jq` JSON pretty printer](https://stedolan.github.io/jq/):
 
-```bash
-curl -k https://arangodb.9hoeffer.de:8529/_admin/cluster/health --user root: | jq . | grep '"Status"' | grep -v '"GOOD"'
+```
+curl -k https://localhost:8529/_admin/cluster/health --user root: | jq "[.Health | to_entries[] | select(.value.Status!=\"GOOD\") | {(.key): .value.Status }] | add"
 ```
 
 For the shards being in sync there is the


### PR DESCRIPTION
I basically use this as note pad for possible changes to Drain.md

- jq might be able to do what would otherwise require *nix commands (grep, sort, uniq), which would be cross-platform (although there are some issues with quote marks it seems)
- > (please compare the above output of the `/_admin/cluster/health` API).

  I don't understand this sentence, compare the cleanOutServer output to the cluster health output?
- > The value of the `"server"` attribute should be the name of the DBserver
  > which is one the pod which shall be drained next.

  Is there a word missing and should it be plural?
  -> which is one **of** the pod**s** which shall be drained next. This uses the UI short
- Sounds like cleaning out the server manually is what we should recommend, yet we say it's optional. What are the other options? The problem I see with any grace period is that you never know if it's too long or too short, and that the draining process never finish before the end of the grace period...
- is `uncordoned` a real word? I know _to cordon off_, and k8s seems to have a `cordon` command, but `uncordoned` seems to be missing in dictionaries
