### PR TITLE
Supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,25 @@ it is intended to be.
 
 ### Production readiness state
 
-| Platform             | Kubernetes version | ArangoDB version | State | Production ready | Remarks               |
-|----------------------|--------------------|------------------|-------|------------------|-----------------------|
-| Google GKE           | 1.10               | >= 3.3.13        | Runs  | Yes              | Don't use micro nodes |
-| Google GKE           | 1.11               | >= 3.3.13        | Runs  | Yes              | Don't use micro nodes |
-| Amazon EKS           | 1.11               | >= 3.3.13        | Runs  | Yes              |                       |
-| Pivotal PKS          | 1.11               | >= 3.3.13        | Runs  | Yes              |                       |
-| Amazon & Kops        | 1.10               | >= 3.3.13        | Runs  | No               |                       |
-| Azure AKS            | 1.10               | >= 3.3.13        | Runs  | No               |                       |
-| OpenShift            | 1.10               | >= 3.3.13        | Runs  | No               |                       |
-| Bare metal (kubeadm) | 1.10               | >= 3.3.13        | Runs  | Yes              |                       |
-| Bare metal (kubeadm) | 1.11               | >= 3.3.13        | Runs  | Yes              |                       |
-| Bare metal (kubeadm) | 1.12               | >= 3.3.13        | Runs  | No               |                       |
-| Bare metal (kubeadm) | 1.13               | >= 3.3.13        | Runs  | In progress      |                       |
-| Bare metal (kubeadm) | 1.14               | >= 3.3.13        | Runs  | In progress      |                       |
-| Minikube             | 1.10               | >= 3.3.13        | Runs  | Not intended     |                       |
-| Docker for Mac Edge  | 1.10               | >= 3.3.13        | Runs  | Not intended     |                       |
-| Scaleway Kubernetes  | 1.10               | >= 3.3.13        | ?     | No               |                       |
+| Platform             | Kubernetes version | ArangoDB version | ArangoDB K8s Operator Version | State | Production ready | Remarks               |
+|----------------------|--------------------|------------------|-------------------------------|-------|------------------|-----------------------|
+| Google GKE           | 1.10               | >= 3.3.13        |                               | Runs  | Yes              | Don't use micro nodes |
+| Google GKE           | 1.11               | >= 3.3.13        |                               | Runs  | Yes              | Don't use micro nodes |
+| Amazon EKS           | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
+| Pivotal PKS          | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
+| IBM Cloud            | 1.10               | >= 3.4.5         |          >= 0.3.10            | Runs  | Yes              |                       |
+| IBM Cloud            | 1.11               | >= 3.4.5         |          >= 0.3.10            | Runs  | Yes              |                       |
+| Amazon & Kops        | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |
+| Azure AKS            | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |
+| OpenShift            | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |
+| Bare metal (kubeadm) | 1.10               | >= 3.3.13        |                               | Runs  | Yes              |                       |
+| Bare metal (kubeadm) | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
+| Bare metal (kubeadm) | 1.12               | >= 3.3.13        |                               | Runs  | No               |                       |
+| Bare metal (kubeadm) | 1.13               | >= 3.3.13        |                               | Runs  | In progress      |                       |
+| Bare metal (kubeadm) | 1.14               | >= 3.3.13        |                               | Runs  | In progress      |                       |
+| Minikube             | 1.10               | >= 3.3.13        |                               | Runs  | Not intended     |                       |
+| Docker for Mac Edge  | 1.10               | >= 3.3.13        |                               | Runs  | Not intended     |                       |
+| Scaleway Kubernetes  | 1.10               | >= 3.3.13        | ?                             | No               |                       |
 
 ## Installation of latest release using Helm
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ it is intended to be.
 | Google GKE           | 1.11               | >= 3.3.13        |                               | Runs  | Yes              | Don't use micro nodes |
 | Amazon EKS           | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
 | Pivotal PKS          | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
-| IBM Cloud            | 1.11               | >= 3.4.5         |          >= 0.3.10            | Runs  | Yes              |                       |
+| IBM Cloud            | 1.11               | >= 3.4.5         |          >= 0.3.11            | Runs  | Yes              |                       |
 | Amazon & Kops        | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |
 | Azure AKS            | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |
 | OpenShift            | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ it is intended to be.
 | Bare metal (kubeadm) | 1.14               | >= 3.3.13        |                               | Runs  | In progress      |                       |
 | Minikube             | 1.10               | >= 3.3.13        |                               | Runs  | Not intended     |                       |
 | Docker for Mac Edge  | 1.10               | >= 3.3.13        |                               | Runs  | Not intended     |                       |
-| Scaleway Kubernetes  | 1.10               | >= 3.3.13        | ?                             | No               |                       |
+| Scaleway Kubernetes  | 1.10               | >= 3.3.13        | ?                             | No    |                  |                       |
 
 ## Installation of latest release using Helm
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ it is intended to be.
 | Azure AKS            | 1.10               | >= 3.3.13        | Runs  | No               |                       |
 | OpenShift            | 1.10               | >= 3.3.13        | Runs  | No               |                       |
 | Bare metal (kubeadm) | 1.10               | >= 3.3.13        | Runs  | Yes              |                       |
+| Bare metal (kubeadm) | 1.11               | >= 3.3.13        | Runs  | Yes              |                       |
 | Bare metal (kubeadm) | 1.12               | >= 3.3.13        | Runs  | No               |                       |
 | Bare metal (kubeadm) | 1.13               | >= 3.3.13        | Runs  | No               |                       |
 | Bare metal (kubeadm) | 1.14               | >= 3.3.13        | Runs  | No               |                       |

--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ it is intended to be.
 | Google GKE           | 1.11               | >= 3.3.13        |                               | Runs  | Yes              | Don't use micro nodes |
 | Amazon EKS           | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
 | Pivotal PKS          | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
-| IBM Cloud            | 1.10               | >= 3.4.5         |          >= 0.3.10            | Runs  | Yes              |                       |
 | IBM Cloud            | 1.11               | >= 3.4.5         |          >= 0.3.10            | Runs  | Yes              |                       |
 | Amazon & Kops        | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |
 | Azure AKS            | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |
 | OpenShift            | 1.10               | >= 3.3.13        |                               | Runs  | No               |                       |
 | Bare metal (kubeadm) | 1.10               | >= 3.3.13        |                               | Runs  | Yes              |                       |
 | Bare metal (kubeadm) | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
-| Bare metal (kubeadm) | 1.12               | >= 3.3.13        |                               | Runs  | No               |                       |
+| Bare metal (kubeadm) | 1.12               | >= 3.3.13        |                               | Runs  | In progress      |                       |
 | Bare metal (kubeadm) | 1.13               | >= 3.3.13        |                               | Runs  | In progress      |                       |
 | Bare metal (kubeadm) | 1.14               | >= 3.3.13        |                               | Runs  | In progress      |                       |
 | Minikube             | 1.10               | >= 3.3.13        |                               | Runs  | Not intended     |                       |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ it is intended to be.
 | Bare metal (kubeadm) | 1.10               | >= 3.3.13        |                               | Runs  | Yes              |                       |
 | Bare metal (kubeadm) | 1.11               | >= 3.3.13        |                               | Runs  | Yes              |                       |
 | Bare metal (kubeadm) | 1.12               | >= 3.3.13        |                               | Runs  | In progress      |                       |
-| Bare metal (kubeadm) | 1.13               | >= 3.3.13        |                               | Runs  | In progress      |                       |
+| Bare metal (kubeadm) | 1.13               | >= 3.3.13        |                               | Runs  | Yes              |                       |
 | Bare metal (kubeadm) | 1.14               | >= 3.3.13        |                               | Runs  | In progress      |                       |
 | Minikube             | 1.10               | >= 3.3.13        |                               | Runs  | Not intended     |                       |
 | Docker for Mac Edge  | 1.10               | >= 3.3.13        |                               | Runs  | Not intended     |                       |

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ it is intended to be.
 | Bare metal (kubeadm) | 1.10               | >= 3.3.13        | Runs  | Yes              |                       |
 | Bare metal (kubeadm) | 1.11               | >= 3.3.13        | Runs  | Yes              |                       |
 | Bare metal (kubeadm) | 1.12               | >= 3.3.13        | Runs  | No               |                       |
-| Bare metal (kubeadm) | 1.13               | >= 3.3.13        | Runs  | No               |                       |
-| Bare metal (kubeadm) | 1.14               | >= 3.3.13        | Runs  | No               |                       |
+| Bare metal (kubeadm) | 1.13               | >= 3.3.13        | Runs  | In progress      |                       |
+| Bare metal (kubeadm) | 1.14               | >= 3.3.13        | Runs  | In progress      |                       |
 | Minikube             | 1.10               | >= 3.3.13        | Runs  | Not intended     |                       |
 | Docker for Mac Edge  | 1.10               | >= 3.3.13        | Runs  | Not intended     |                       |
 | Scaleway Kubernetes  | 1.10               | >= 3.3.13        | ?     | No               |                       |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ it is intended to be.
 | Amazon & Kops        | 1.10               | >= 3.3.13        | Runs  | No               |                       |
 | Azure AKS            | 1.10               | >= 3.3.13        | Runs  | No               |                       |
 | OpenShift            | 1.10               | >= 3.3.13        | Runs  | No               |                       |
-| Bare metal (kubeadm) | 1.10               | >= 3.3.13        | Runs  | No               |                       |
+| Bare metal (kubeadm) | 1.10               | >= 3.3.13        | Runs  | Yes              |                       |
+| Bare metal (kubeadm) | 1.12               | >= 3.3.13        | Runs  | No               |                       |
+| Bare metal (kubeadm) | 1.13               | >= 3.3.13        | Runs  | No               |                       |
+| Bare metal (kubeadm) | 1.14               | >= 3.3.13        | Runs  | No               |                       |
 | Minikube             | 1.10               | >= 3.3.13        | Runs  | Not intended     |                       |
 | Docker for Mac Edge  | 1.10               | >= 3.3.13        | Runs  | Not intended     |                       |
 | Scaleway Kubernetes  | 1.10               | >= 3.3.13        | ?     | No               |                       |


### PR DESCRIPTION

**do not merge yet**

---

**Fixes:**
- bare metal 1.10 is production ready

**Other:**
- adds entries for 1.11, 1.12, 1.13 and 1.14 for bare metals
- adds IBM Cloud
- adds operator version

Next steps (for **later**):
- the table should be part of the official doc - a link can be included in the repo readme and the actual content moved to doc/ for integration into the official manual
- we should reconsider 3.3.13 imho, and add a later version instead

Thanks,