### PR TITLE
Only check shard sync status for cluster deployments.

### DIFF
--- a/pkg/deployment/resources/deployment_health.go
+++ b/pkg/deployment/resources/deployment_health.go
@@ -180,5 +180,9 @@ dbloop:
 func (r *Resources) GetShardSyncStatus() bool {
 	r.shardSync.mutex.Lock()
 	defer r.shardSync.mutex.Unlock()
+	if r.context.GetSpec().GetMode() != api.DeploymentModeCluster {
+		// Shard sync status is only applicable for clusters
+		return true
+	}
 	return r.shardSync.allInSync
 }

--- a/pkg/deployment/resources/deployment_health.go
+++ b/pkg/deployment/resources/deployment_health.go
@@ -178,11 +178,11 @@ dbloop:
 
 // GetShardSyncStatus returns true if all shards are in sync
 func (r *Resources) GetShardSyncStatus() bool {
-	r.shardSync.mutex.Lock()
-	defer r.shardSync.mutex.Unlock()
 	if r.context.GetSpec().GetMode() != api.DeploymentModeCluster {
 		// Shard sync status is only applicable for clusters
 		return true
 	}
+	r.shardSync.mutex.Lock()
+	defer r.shardSync.mutex.Unlock()
 	return r.shardSync.allInSync
 }


### PR DESCRIPTION
This fixes a test and is benficial otherwise, too.