### PR TITLE
Drop Security Context

### DIFF
--- a/chart/kube-arangodb/templates/NOTES.txt
+++ b/chart/kube-arangodb/templates/NOTES.txt
@@ -1,0 +1,7 @@
+You have installed Kubernetes ArangoDB Operator in version {{ .Chart.Version }}
+
+To access ArangoDeployments you can use:
+
+kubectl --namespace "{{ .Release.Namespace }}" get arangodeployments
+
+More details can be found on https://github.com/arangodb/kube-arangodb/tree/{{ .Chart.Version }}/docs

--- a/chart/kube-arangodb/templates/deployment.yaml
+++ b/chart/kube-arangodb/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
                           operator: In
                           values:
                             - amd64
+            hostNetwork: false
+            hostPID: false
+            hostIPC: false
             containers:
                 - name: operator
                   imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
@@ -78,9 +81,12 @@ spec:
                       - name: metrics
                         containerPort: 8528
                   securityContext:
-                    capabilities:
-                      drop:
-                        - 'ALL'
+                      privileged: false
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - 'ALL'
 {{- if .Values.operator.resources }}
                   resources:
 {{ toYaml .Values.operator.resources | indent 22 }}

--- a/manifests/arango-deployment-replication.yaml
+++ b/manifests/arango-deployment-replication.yaml
@@ -168,6 +168,9 @@ spec:
                           operator: In
                           values:
                             - amd64
+            hostNetwork: false
+            hostPID: false
+            hostIPC: false
             containers:
                 - name: operator
                   imagePullPolicy: Always
@@ -192,9 +195,12 @@ spec:
                       - name: metrics
                         containerPort: 8528
                   securityContext:
-                    capabilities:
-                      drop:
-                        - 'ALL'
+                      privileged: false
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - 'ALL'
                   livenessProbe:
                       httpGet:
                           path: /health

--- a/manifests/arango-deployment.yaml
+++ b/manifests/arango-deployment.yaml
@@ -212,6 +212,9 @@ spec:
                           operator: In
                           values:
                             - amd64
+            hostNetwork: false
+            hostPID: false
+            hostIPC: false
             containers:
                 - name: operator
                   imagePullPolicy: Always
@@ -236,9 +239,12 @@ spec:
                       - name: metrics
                         containerPort: 8528
                   securityContext:
-                    capabilities:
-                      drop:
-                        - 'ALL'
+                      privileged: false
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - 'ALL'
                   livenessProbe:
                       httpGet:
                           path: /health

--- a/manifests/arango-storage.yaml
+++ b/manifests/arango-storage.yaml
@@ -200,6 +200,9 @@ spec:
                           operator: In
                           values:
                             - amd64
+            hostNetwork: false
+            hostPID: false
+            hostIPC: false
             containers:
                 - name: operator
                   imagePullPolicy: Always
@@ -224,9 +227,12 @@ spec:
                       - name: metrics
                         containerPort: 8528
                   securityContext:
-                    capabilities:
-                      drop:
-                        - 'ALL'
+                      privileged: false
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - 'ALL'
                   livenessProbe:
                       httpGet:
                           path: /health


### PR DESCRIPTION
Also created NOTES.txt - example helm output:

```NOTES:
You have installed Kubernetes ArangoDB Operator in version 0.3.16

To access ArangoDeployments you can use:

kubectl --namespace "release-namespace" get arangodeployments

More details can be found on https://github.com/arangodb/kube-arangodb/tree/0.3.16/docs
```

Links gonna be updated using "release" scripts