### PR TITLE
Change k8s.io version to v1

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -43,7 +43,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/arangodb/kube-arangodb/pkg/client"
-	scheme "github.com/arangodb/kube-arangodb/pkg/generated/clientset/versioned/scheme"
+	"github.com/arangodb/kube-arangodb/pkg/generated/clientset/versioned/scheme"
 	"github.com/arangodb/kube-arangodb/pkg/logging"
 	"github.com/arangodb/kube-arangodb/pkg/operator"
 	"github.com/arangodb/kube-arangodb/pkg/server"
@@ -208,9 +208,9 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 		AdminSecretName:    serverOptions.adminSecretName,
 		AllowAnonymous:     serverOptions.allowAnonymous,
 	}, server.Dependencies{
-		Log:                   logService.MustGetLogger("server"),
-		LivenessProbe:         &livenessProbe,
-		Deployment:            server.OperatorDependency{
+		Log:           logService.MustGetLogger("server"),
+		LivenessProbe: &livenessProbe,
+		Deployment: server.OperatorDependency{
 			Enabled: cfg.EnableDeployment,
 			Probe:   &deploymentProbe,
 		},
@@ -226,9 +226,9 @@ func cmdMainRun(cmd *cobra.Command, args []string) {
 			Enabled: cfg.EnableBackup,
 			Probe:   &backupProbe,
 		},
-		Operators:             o,
+		Operators: o,
 
-		Secrets:               secrets,
+		Secrets: secrets,
 	}); err != nil {
 		cliLog.Fatal().Err(err).Msg("Failed to create HTTP server")
 	} else {
@@ -328,6 +328,6 @@ func createRecorder(log zerolog.Logger, kubecli kubernetes.Interface, name, name
 	combinedScheme := runtime.NewScheme()
 	scheme.AddToScheme(combinedScheme)
 	v1.AddToScheme(combinedScheme)
-	appsv1beta2.AddToScheme(combinedScheme)
+	appsv1.AddToScheme(combinedScheme)
 	return eventBroadcaster.NewRecorder(combinedScheme, v1.EventSource{Component: name})
 }

--- a/pkg/util/k8sutil/owner.go
+++ b/pkg/util/k8sutil/owner.go
@@ -23,18 +23,19 @@
 package k8sutil
 
 import (
-	"k8s.io/api/apps/v1beta2"
-	"k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 // GetPodOwner returns the ReplicaSet that owns the given Pod.
 // If the Pod has no owner of the owner is not a ReplicaSet, nil is returned.
-func GetPodOwner(kubecli kubernetes.Interface, pod *v1.Pod, ns string) (*v1beta2.ReplicaSet, error) {
+func GetPodOwner(kubecli kubernetes.Interface, pod *v1.Pod, ns string) (*appsv1.ReplicaSet, error) {
 	for _, ref := range pod.GetOwnerReferences() {
 		if ref.Kind == "ReplicaSet" {
-			rSets := kubecli.AppsV1beta2().ReplicaSets(pod.GetNamespace())
+			rSets := kubecli.AppsV1().ReplicaSets(pod.GetNamespace())
 			rSet, err := rSets.Get(ref.Name, metav1.GetOptions{})
 			if err != nil {
 				return nil, maskAny(err)
@@ -47,10 +48,10 @@ func GetPodOwner(kubecli kubernetes.Interface, pod *v1.Pod, ns string) (*v1beta2
 
 // GetReplicaSetOwner returns the Deployment that owns the given ReplicaSet.
 // If the ReplicaSet has no owner of the owner is not a Deployment, nil is returned.
-func GetReplicaSetOwner(kubecli kubernetes.Interface, rSet *v1beta2.ReplicaSet, ns string) (*v1beta2.Deployment, error) {
+func GetReplicaSetOwner(kubecli kubernetes.Interface, rSet *appsv1.ReplicaSet, ns string) (*appsv1.Deployment, error) {
 	for _, ref := range rSet.GetOwnerReferences() {
 		if ref.Kind == "Deployment" {
-			depls := kubecli.AppsV1beta2().Deployments(rSet.GetNamespace())
+			depls := kubecli.AppsV1().Deployments(rSet.GetNamespace())
 			depl, err := depls.Get(ref.Name, metav1.GetOptions{})
 			if err != nil {
 				return nil, maskAny(err)


### PR DESCRIPTION
https://github.com/arangodb/kube-arangodb/issues/461

**For the time being, we can not use apiextensions.k8s.io/v1beta1 because it is in k8s.io version 1.16. We are using k8s.io version 1.12**

k8s.io/api/policy/v1beta1 can not be changed because it is the latest version in k8s.io 1.12