### PR TITLE
Drop all capabilities for security context

### DIFF
--- a/pkg/util/k8sutil/pods.go
+++ b/pkg/util/k8sutil/pods.go
@@ -340,7 +340,8 @@ func arangodContainer(image string, imagePullPolicy v1.PullPolicy, args []string
 				Protocol:      v1.ProtocolTCP,
 			},
 		},
-		VolumeMounts: arangodVolumeMounts(),
+		VolumeMounts:    arangodVolumeMounts(),
+		SecurityContext: SecurityContextWithoutCapabilities(),
 	}
 	if noFilterResources {
 		c.Resources = resources // if volumeclaimtemplate is specified
@@ -381,7 +382,8 @@ func arangosyncContainer(image string, imagePullPolicy v1.PullPolicy, args []str
 				Protocol:      v1.ProtocolTCP,
 			},
 		},
-		Resources: resources,
+		Resources:       resources,
+		SecurityContext: SecurityContextWithoutCapabilities(),
 	}
 	for k, v := range env {
 		c.Env = append(c.Env, v.CreateEnvVar(k))
@@ -824,4 +826,12 @@ func createPod(kubecli kubernetes.Interface, pod *v1.Pod, ns string, owner metav
 		return maskAny(err)
 	}
 	return nil
+}
+
+func SecurityContextWithoutCapabilities() *v1.SecurityContext {
+	return &v1.SecurityContext{
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{"all"},
+		},
+	}
 }

--- a/scripts/kube_create_backup_remote_secret.sh
+++ b/scripts/kube_create_backup_remote_secret.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 NS=$1
 
@@ -12,7 +12,14 @@ if [ -z "$2" ]; then
     exit 0
 fi
 
-SECRET=$(echo -n $2 | base64 -w 0)
+case $(uname) in
+    Darwin)
+        SECRET=$(echo -n $2 | base64 -b 0)
+        ;;
+    *)
+        SECRET=$(echo -n $2 | base64 -w 0)
+        ;;
+esac
 
 kubectl apply -f - <<EOF
 apiVersion: v1

--- a/scripts/kube_create_license_key_secret.sh
+++ b/scripts/kube_create_license_key_secret.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 NS=$1
 
@@ -12,7 +12,14 @@ if [ -z "$2" ]; then
     exit 0
 fi
 
-LICENSE=$(echo -n "$2" | base64 -w 0)
+case $(uname) in
+    Darwin)
+        LICENSE=$(echo -n "$2" | base64 -b 0)
+        ;;
+    *)
+        LICENSE=$(echo -n "$2" | base64 -w 0)
+        ;;
+esac
 
 kubectl apply -f - <<EOF
 apiVersion: v1

--- a/tests/backup_test.go
+++ b/tests/backup_test.go
@@ -25,11 +25,12 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/arangodb/kube-arangodb/pkg/backup/utils"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/arangodb/kube-arangodb/pkg/backup/utils"
 
 	backupClient "github.com/arangodb/kube-arangodb/pkg/generated/clientset/versioned/typed/backup/v1"
 
@@ -434,6 +435,8 @@ func TestBackupCluster(t *testing.T) {
 	})
 
 	t.Run("create-upload backup", func(t *testing.T) {
+		skipOrRemotePath(t)
+
 		backup := newBackup(fmt.Sprintf("my-backup-%s", uniuri.NewLen(4)), depl.GetName(), nil)
 		_, err := backupClient.Create(backup)
 		require.NoError(t, err, "failed to create backup: %s", err)
@@ -669,7 +672,7 @@ func TestBackupCluster(t *testing.T) {
 		// Assert that all of the backups are in valid state
 		backups, err = backupClient.List(metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(&labels)})
 		require.NoError(t, err)
-		require.Len(t, backups.Items, size + 1)
+		require.Len(t, backups.Items, size+1)
 
 		for _, b := range backups.Items {
 			require.Equal(t, backupApi.ArangoBackupStateReady, b.Status.State, b.Status.Message)

--- a/tests/load_balancer_test.go
+++ b/tests/load_balancer_test.go
@@ -33,7 +33,6 @@ import (
 	driver "github.com/arangodb/go-driver"
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
 	"github.com/arangodb/kube-arangodb/pkg/client"
-	"github.com/arangodb/kube-arangodb/pkg/util"
 )
 
 func TestLoadBalancingCursorVST(t *testing.T) {
@@ -68,7 +67,6 @@ func loadBalancingCursorSubtest(t *testing.T, useVst bool) {
 	}
 	depl := newDeployment(namePrefix + uniuri.NewLen(4))
 	depl.Spec.Mode = api.NewMode(api.DeploymentModeCluster)
-	depl.Spec.Image = util.NewString("arangodb/arangodb:3.3.13") // Note: 3.3.13 is the first version supporting the cursor forwarding feature.
 
 	// Create deployment
 	_, err := c.DatabaseV1().ArangoDeployments(ns).Create(depl)

--- a/tests/pc_test.go
+++ b/tests/pc_test.go
@@ -36,7 +36,7 @@ func waitForPriorityOfServerGroup(kube kubernetes.Interface, c versioned.Interfa
 			}
 
 			if *pod.Spec.Priority != priority {
-				return fmt.Errorf("Wrong pod priority, expected %d, found %d", priority, pod.Spec.Priority)
+				return fmt.Errorf("Wrong pod priority, expected %d, found %d", priority, *pod.Spec.Priority)
 			}
 		}
 


### PR DESCRIPTION
IBM CV requires that created pods need to have dropped all capabilities.
Tested on arangodb/enterprise:3.5.2 with full integration test.