### PR TITLE
Allow having one operator for all namespaces

### DIFF
--- a/manifests/arango-deployment.yaml
+++ b/manifests/arango-deployment.yaml
@@ -34,6 +34,24 @@ rules:
     - apiGroups: ["storage.k8s.io"]
       resources: ["storageclasses"]
       verbs: ["get", "list"]
+    - apiGroups: ["database.arangodb.com"]
+      resources: ["arangodeployments"]
+      verbs: ["*"]
+    - apiGroups: [""]
+      resources: ["pods", "services", "endpoints", "persistentvolumeclaims", "events", "secrets", "serviceaccounts"]
+      verbs: ["*"]
+    - apiGroups: ["apps"]
+      resources: ["deployments", "replicasets"]
+      verbs: ["get"]
+    - apiGroups: ["policy"]
+      resources: ["poddisruptionbudgets"]
+      verbs: ["*"]
+    - apiGroups: ["backup.arangodb.com"]
+      resources: ["arangobackuppolicies", "arangobackups"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["monitoring.coreos.com"]
+      resources: ["servicemonitors"]
+      verbs: ["get", "create", "delete"]
 ---
 # Source: kube-arangodb/templates/deployment-operator/cluster-role-binding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -58,7 +76,7 @@ subjects:
 ---
 # Source: kube-arangodb/templates/deployment-operator/default-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
     name: arango-deployment-operator-rbac-default
     namespace: default
@@ -73,41 +91,9 @@ rules:
       resources: ["pods"]
       verbs: ["get"]
 ---
-# Source: kube-arangodb/templates/deployment-operator/role.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-    name: arango-deployment-operator-rbac-deployment
-    namespace: default
-    labels:
-        app.kubernetes.io/name: kube-arangodb
-        helm.sh/chart: kube-arangodb-1.0.1
-        app.kubernetes.io/managed-by: Tiller
-        app.kubernetes.io/instance: deployment
-        release: deployment
-rules:
-    - apiGroups: ["database.arangodb.com"]
-      resources: ["arangodeployments"]
-      verbs: ["*"]
-    - apiGroups: [""]
-      resources: ["pods", "services", "endpoints", "persistentvolumeclaims", "events", "secrets", "serviceaccounts"]
-      verbs: ["*"]
-    - apiGroups: ["apps"]
-      resources: ["deployments", "replicasets"]
-      verbs: ["get"]
-    - apiGroups: ["policy"]
-      resources: ["poddisruptionbudgets"]
-      verbs: ["*"]
-    - apiGroups: ["backup.arangodb.com"]
-      resources: ["arangobackuppolicies", "arangobackups"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["monitoring.coreos.com"]
-      resources: ["servicemonitors"]
-      verbs: ["get", "create", "delete"]
----
 # Source: kube-arangodb/templates/deployment-operator/default-role-binding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
     name: arango-deployment-operator-rbac-default
     namespace: default
@@ -119,32 +105,11 @@ metadata:
         release: deployment
 roleRef:
     apiGroup: rbac.authorization.k8s.io
-    kind: Role
+    kind: ClusterRole
     name: arango-deployment-operator-rbac-default
 subjects:
     - kind: ServiceAccount
       name: default
-      namespace: default
----
-# Source: kube-arangodb/templates/deployment-operator/role-binding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-    name: arango-deployment-operator-rbac-deployment
-    namespace: default
-    labels:
-        app.kubernetes.io/name: kube-arangodb
-        helm.sh/chart: kube-arangodb-1.0.1
-        app.kubernetes.io/managed-by: Tiller
-        app.kubernetes.io/instance: deployment
-        release: deployment
-roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: arango-deployment-operator-rbac-deployment
-subjects:
-    - kind: ServiceAccount
-      name: arango-deployment-operator
       namespace: default
 ---
 # Source: kube-arangodb/templates/service.yaml

--- a/pkg/util/k8sutil/informer.go
+++ b/pkg/util/k8sutil/informer.go
@@ -23,6 +23,7 @@
 package k8sutil
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/rs/zerolog"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,7 +43,7 @@ func NewResourceWatcher(log zerolog.Logger, getter cache.Getter, resource, names
 	source := cache.NewListWatchFromClient(
 		getter,
 		resource,
-		namespace,
+		v1.NamespaceAll,
 		fields.Everything())
 
 	_, informer := cache.NewIndexerInformer(source, objType, 0, cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
This commit change the behavior of the operator to listen to all namespaces for the custom resources.

Before this commit you needed to install the deployment operator on each namespace you wanted to create a `ArangoDeployment`