### PR TITLE
Add 'create' for backup operator role and remove namespace from cluster-wide resources

### DIFF
--- a/chart/kube-arangodb-test/templates/cluster-role-binding.yaml
+++ b/chart/kube-arangodb-test/templates/cluster-role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: {{ template "kube-arangodb-test.fullName" . }}
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb-test.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/kube-arangodb/templates/backup-operator/cluster-role-binding.yaml
+++ b/chart/kube-arangodb/templates/backup-operator/cluster-role-binding.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: {{ template "kube-arangodb.rbac" . }}-storage
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/kube-arangodb/templates/backup-operator/cluster-role.yaml
+++ b/chart/kube-arangodb/templates/backup-operator/cluster-role.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: {{ template "kube-arangodb.rbac" . }}-backup
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/kube-arangodb/templates/backup-operator/role.yaml
+++ b/chart/kube-arangodb/templates/backup-operator/role.yaml
@@ -15,7 +15,7 @@ metadata:
 rules:
     - apiGroups: [""]
       resources: ["pods", "services", "endpoints"]
-      verbs: ["get", "update"]
+      verbs: ["get", "update", "create"]
     - apiGroups: [""]
       resources: ["events"]
       verbs: ["*"]

--- a/chart/kube-arangodb/templates/deployment-operator/cluster-role-binding.yaml
+++ b/chart/kube-arangodb/templates/deployment-operator/cluster-role-binding.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: {{ template "kube-arangodb.rbac" . }}-deployment
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/kube-arangodb/templates/deployment-operator/cluster-role.yaml
+++ b/chart/kube-arangodb/templates/deployment-operator/cluster-role.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: {{ template "kube-arangodb.rbac" . }}-deployment
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/kube-arangodb/templates/deployment-replications-operator/cluster-role-binding.yaml
+++ b/chart/kube-arangodb/templates/deployment-replications-operator/cluster-role-binding.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: {{ template "kube-arangodb.rbac" . }}-deployment-replication
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/kube-arangodb/templates/deployment-replications-operator/cluster-role.yaml
+++ b/chart/kube-arangodb/templates/deployment-replications-operator/cluster-role.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: {{ template "kube-arangodb.rbac" . }}-deployment-replication
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/kube-arangodb/templates/storage-operator/cluster-role-binding.yaml
+++ b/chart/kube-arangodb/templates/storage-operator/cluster-role-binding.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: {{ template "kube-arangodb.rbac" . }}-storage
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/chart/kube-arangodb/templates/storage-operator/cluster-role.yaml
+++ b/chart/kube-arangodb/templates/storage-operator/cluster-role.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: {{ template "kube-arangodb.rbac" . }}-storage
-    namespace: {{ .Release.Namespace }}
     labels:
         app.kubernetes.io/name: {{ template "kube-arangodb.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/manifests/arango-backup.yaml
+++ b/manifests/arango-backup.yaml
@@ -17,7 +17,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: arango-backup-operator-rbac-backup
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb
         helm.sh/chart: kube-arangodb-1.0.3
@@ -34,7 +33,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: arango-backup-operator-rbac-storage
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb
         helm.sh/chart: kube-arangodb-1.0.3
@@ -145,7 +143,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb

--- a/manifests/arango-deployment-replication.yaml
+++ b/manifests/arango-deployment-replication.yaml
@@ -17,7 +17,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: arango-deployment-replication-operator-rbac-deployment-replication
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb
         helm.sh/chart: kube-arangodb-1.0.3
@@ -37,7 +36,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: arango-deployment-replication-operator-rbac-deployment-replication
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb
         helm.sh/chart: kube-arangodb-1.0.3
@@ -142,7 +140,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb

--- a/manifests/arango-deployment.yaml
+++ b/manifests/arango-deployment.yaml
@@ -17,7 +17,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: arango-deployment-operator-rbac-deployment
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb
         helm.sh/chart: kube-arangodb-1.0.3
@@ -40,7 +39,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: arango-deployment-operator-rbac-deployment
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb
         helm.sh/chart: kube-arangodb-1.0.3
@@ -189,7 +187,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb

--- a/manifests/arango-storage.yaml
+++ b/manifests/arango-storage.yaml
@@ -40,7 +40,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
     name: arango-storage-operator-rbac-storage
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb
         helm.sh/chart: kube-arangodb-1.0.3
@@ -69,7 +68,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: arango-storage-operator-rbac-storage
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb
         helm.sh/chart: kube-arangodb-1.0.3
@@ -174,7 +172,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb

--- a/manifests/arango-test.yaml
+++ b/manifests/arango-test.yaml
@@ -17,7 +17,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
     name: kube-arangodb-test-arangodb-test
-    namespace: default
     labels:
         app.kubernetes.io/name: kube-arangodb-test
         helm.sh/chart: kube-arangodb-test-1.0.3


### PR DESCRIPTION
Fixes backup operator complaining:

`E0527 13:24:20.300949       1 leaderelection.go:328] error initially creating leader election record: endpoints is forbidden: User "system:serviceaccount:arangodb:arango-backup-operator" cannot create resource "endpoints" in API group "" in the namespace "arangodb"`
