### PR TITLE
Feat/localstorage provisioner tolerations

### DIFF
--- a/pkg/apis/storage/v1alpha/local_storage_spec.go
+++ b/pkg/apis/storage/v1alpha/local_storage_spec.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 )
 
 // LocalStorageSpec contains the specification part of
@@ -34,6 +35,7 @@ type LocalStorageSpec struct {
 	StorageClass StorageClassSpec  `json:"storageClass"`
 	LocalPath    []string          `json:"localPath,omitempty"`
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	Tolerations  []v1.Toleration   `json:"tolerations,omitempty"`
 }
 
 // Validate the given spec, returning an error on validation

--- a/pkg/apis/storage/v1alpha/zz_generated.deepcopy.go
+++ b/pkg/apis/storage/v1alpha/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@
 package v1alpha
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -103,6 +104,13 @@ func (in *LocalStorageSpec) DeepCopyInto(out *LocalStorageSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	return

--- a/pkg/storage/daemon_set.go
+++ b/pkg/storage/daemon_set.go
@@ -84,6 +84,7 @@ func (ls *LocalStorage) ensureDaemonSet(apiObject *api.ArangoLocalStorage) error
 					c,
 				},
 				NodeSelector: apiObject.Spec.NodeSelector,
+				Tolerations:  apiObject.Spec.Tolerations,
 			},
 		},
 	}


### PR DESCRIPTION
Hello,

I wanted to deploy the provisioner on specific nodes, but the spec didn't tolerate to specify Tolerations. 

This has been tested on our “test” k8s cluster