### PR TITLE
Improved metrics exporter

### DIFF
--- a/pkg/deployment/agency/agency.go
+++ b/pkg/deployment/agency/agency.go
@@ -34,11 +34,7 @@ type Fetcher func(ctx context.Context, i interface{}, keyParts ...string) error
 
 func NewFetcher(a agency.Agency) Fetcher {
 	return func(ctx context.Context, i interface{}, keyParts ...string) error {
-		if err := a.ReadKey(ctx, []string{
-			ArangoKey,
-			PlanKey,
-			PlanCollectionsKey,
-		}, i); err != nil {
+		if err := a.ReadKey(ctx, keyParts, i); err != nil {
 			return errors.WithStack(err)
 		}
 

--- a/pkg/deployment/agency/database.go
+++ b/pkg/deployment/agency/database.go
@@ -61,7 +61,18 @@ func (a ArangoPlanCollections) IsDBServerInCollections(name string) bool {
 }
 
 type ArangoPlanCollection struct {
-	Shards ArangoPlanShard `json:"shards"`
+	Name              *string         `json:"name"`
+	Shards            ArangoPlanShard `json:"shards"`
+	WriteConcern      *int            `json:"writeConcern,omitempty"`
+	ReplicationFactor *int            `json:"replicationFactor,omitempty"`
+}
+
+func (a ArangoPlanCollection) GetName(d string) string {
+	if a.Name == nil {
+		return d
+	}
+
+	return *a.Name
 }
 
 func (a ArangoPlanCollection) IsDBServerInShards(name string) bool {
@@ -76,3 +87,23 @@ func (a ArangoPlanCollection) IsDBServerInShards(name string) bool {
 }
 
 type ArangoPlanShard map[string][]string
+
+func GetCurrentCollections(ctx context.Context, f Fetcher) (*ArangoCurrentDatabases, error) {
+	ret := &ArangoCurrentDatabases{}
+
+	if err := f(ctx, ret, ArangoKey, CurrentKey, PlanCollectionsKey); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return ret, nil
+}
+
+type ArangoCurrentDatabases map[string]ArangoCurrentCollections
+
+type ArangoCurrentCollections map[string]ArangoCurrentShards
+
+type ArangoCurrentShards map[string]ArangoCurrentShard
+
+type ArangoCurrentShard struct {
+	Servers []string `json:"servers"`
+}

--- a/pkg/deployment/client/auth.go
+++ b/pkg/deployment/client/auth.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package client
 
 import (

--- a/pkg/deployment/client/auth.go
+++ b/pkg/deployment/client/auth.go
@@ -1,0 +1,106 @@
+package client
+
+import (
+	"crypto/tls"
+	"net"
+	nhttp "net/http"
+	"time"
+
+	"github.com/arangodb/go-driver"
+	"github.com/arangodb/go-driver/http"
+	"github.com/arangodb/go-driver/jwt"
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/pod"
+	"github.com/arangodb/kube-arangodb/pkg/util/arangod/conn"
+	"github.com/arangodb/kube-arangodb/pkg/util/constants"
+	"github.com/arangodb/kube-arangodb/pkg/util/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type DeploymentGetter func() *api.ArangoDeployment
+
+func NewAuth(client kubernetes.Interface, g DeploymentGetter) conn.Auth {
+	return func() (driver.Authentication, error) {
+		d := g()
+
+		if !d.Spec.Authentication.IsAuthenticated() {
+			return nil, nil
+		}
+
+		secrets := client.CoreV1().Secrets(d.GetNamespace())
+
+		var secret string
+		if i := d.Status.CurrentImage; i == nil || !features.JWTRotation().Supported(i.ArangoDBVersion, i.Enterprise) {
+			s, err := secrets.Get(d.Spec.Authentication.GetJWTSecretName(), meta.GetOptions{})
+			if err != nil {
+				return nil, errors.Newf("JWT Secret is missing")
+			}
+
+			jwt, ok := s.Data[constants.SecretKeyToken]
+			if !ok {
+				return nil, errors.Newf("JWT Secret is invalid")
+			}
+
+			secret = string(jwt)
+		} else {
+			s, err := secrets.Get(pod.JWTSecretFolder(d.GetName()), meta.GetOptions{})
+			if err != nil {
+				return nil, errors.Newf("JWT Folder Secret is missing")
+			}
+
+			if len(s.Data) == 0 {
+				return nil, errors.Newf("JWT Folder Secret is empty")
+			}
+
+			if q, ok := s.Data[pod.ActiveJWTKey]; ok {
+				secret = string(q)
+			} else {
+				for _, q := range s.Data {
+					secret = string(q)
+					break
+				}
+			}
+		}
+
+		jwt, err := jwt.CreateArangodJwtAuthorizationHeader(secret, "kube-arangodb")
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		return driver.RawAuthentication(jwt), nil
+	}
+}
+
+func NewConfig(g DeploymentGetter) conn.Config {
+	return func() (http.ConnectionConfig, error) {
+		d := g()
+
+		transport := &nhttp.Transport{
+			Proxy: nhttp.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 100 * time.Millisecond,
+				DualStack: true,
+			}).DialContext,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       100 * time.Millisecond,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+
+		if d.Spec.TLS.IsSecure() {
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		}
+
+		connConfig := http.ConnectionConfig{
+			Transport:          transport,
+			DontFollowRedirect: true,
+		}
+
+		return connConfig, nil
+	}
+}

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -145,7 +145,7 @@ func New(config Config, deps Dependencies, apiObject *api.ArangoDeployment) (*De
 		stopCh:    make(chan struct{}),
 	}
 
-	d.clientCache = deploymentClient.NewClientCache(d.getArangoDeployment, conn.NewFactory(d.getAuth, d.getConnConfig))
+	d.clientCache = deploymentClient.NewClientCache(d.getArangoDeployment, conn.NewFactory(deploymentClient.NewAuth(deps.KubeCli, d.getArangoDeployment), deploymentClient.NewConfig(d.getArangoDeployment)))
 
 	d.status.last = *(apiObject.Status.DeepCopy())
 	d.reconciler = reconcile.NewReconciler(deps.Log, d)

--- a/pkg/deployment/deployment_suite_test.go
+++ b/pkg/deployment/deployment_suite_test.go
@@ -478,7 +478,7 @@ func createTestDeployment(config Config, arangoDeployment *api.ArangoDeployment)
 		eventCh:   make(chan *deploymentEvent, deploymentEventQueueSize),
 		stopCh:    make(chan struct{}),
 	}
-	d.clientCache = client.NewClientCache(d.getArangoDeployment, conn.NewFactory(d.getAuth, d.getConnConfig))
+	d.clientCache = client.NewClientCache(d.getArangoDeployment, conn.NewFactory(client.NewAuth(kubernetesClientSet, d.getArangoDeployment), client.NewConfig(d.getArangoDeployment)))
 
 	arangoDeployment.Spec.SetDefaults(arangoDeployment.GetName())
 	d.resources = resources.NewResources(deps.Log, d)

--- a/pkg/deployment/features/metrics.go
+++ b/pkg/deployment/features/metrics.go
@@ -20,11 +20,20 @@
 // Author Adam Janikowski
 //
 
-package agency
+package features
 
-const (
-	ArangoKey          = "arango"
-	PlanKey            = "Plan"
-	CurrentKey         = "Current"
-	PlanCollectionsKey = "Collections"
-)
+func init() {
+	registerFeature(metrics)
+}
+
+var metrics = &feature{
+	name:               "metrics",
+	description:        "Database Advanced metrics",
+	version:            "3.5.0",
+	enterpriseRequired: false,
+	enabledByDefault:   false,
+}
+
+func Metrics() Feature {
+	return metrics
+}

--- a/pkg/deployment/metrics/collector.go
+++ b/pkg/deployment/metrics/collector.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 type Collector interface {

--- a/pkg/deployment/metrics/collector.go
+++ b/pkg/deployment/metrics/collector.go
@@ -1,0 +1,5 @@
+package metrics
+
+type Collector interface {
+	Collect(metrics MetricCollector) error
+}

--- a/pkg/deployment/metrics/deployment.go
+++ b/pkg/deployment/metrics/deployment.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 import (

--- a/pkg/deployment/metrics/deployment.go
+++ b/pkg/deployment/metrics/deployment.go
@@ -1,0 +1,61 @@
+package metrics
+
+import (
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/client"
+	"github.com/arangodb/kube-arangodb/pkg/util/arangod/conn"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Deployment interface {
+	prometheus.Collector
+}
+
+func NewDeployment(metrics MetricDefinition, cli kubernetes.Interface, d *api.ArangoDeployment) Deployment {
+	depl := &deployment{
+		MetricDefinition: metrics,
+		deployment:       d,
+	}
+
+	depl.cache = client.NewClientCache(depl.getDeployment, conn.NewFactory(client.NewAuth(cli, depl.getDeployment), client.NewConfig(depl.getDeployment)))
+
+	depl.distribution = newDeploymentDistribution(depl)
+	depl.structure = newDeploymentStructure(depl)
+
+	return depl
+}
+
+type deployment struct {
+	MetricDefinition
+
+	deployment *api.ArangoDeployment
+
+	cache client.Cache
+
+	distribution Collector
+	structure    Collector
+}
+
+func (d *deployment) getDeployment() *api.ArangoDeployment {
+	return d.deployment
+}
+
+func (d *deployment) Collect(metrics chan<- prometheus.Metric) {
+	collector := NewMetricsCollector(metrics)
+
+	if err := d.distribution.Collect(collector); err != nil {
+		d.Error.Add()
+	}
+
+	if err := d.structure.Collect(collector); err != nil {
+		d.Error.Add()
+	}
+}
+
+func (d *deployment) labels(labels ...string) []string {
+	return append([]string{
+		d.deployment.GetName(),
+		d.deployment.GetNamespace(),
+	}, labels...)
+}

--- a/pkg/deployment/metrics/deployment_distribution.go
+++ b/pkg/deployment/metrics/deployment_distribution.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 import (

--- a/pkg/deployment/metrics/deployment_distribution.go
+++ b/pkg/deployment/metrics/deployment_distribution.go
@@ -1,0 +1,193 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+
+	"github.com/arangodb/kube-arangodb/pkg/deployment/agency"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func newDeploymentDistribution(deployment *deployment) Collector {
+	d := &deploymentDistribution{
+		deployment: deployment,
+	}
+
+	return d
+}
+
+type deploymentDistribution struct {
+	deployment *deployment
+}
+
+type servers map[string]serverDetails
+
+func (s *servers) update(member string, f func(m *serverDetails)) {
+	if d, ok := (*s)[member]; ok {
+		f(&d)
+		(*s)[member] = d
+	} else {
+		d = serverDetails{}
+		f(&d)
+		(*s)[member] = d
+	}
+}
+
+func (s *servers) AddCurrentShard(member string) {
+	s.update(member, func(m *serverDetails) {
+		m.CurrentShards++
+	})
+}
+
+func (s *servers) AddPlannedShard(member string) {
+	s.update(member, func(m *serverDetails) {
+		m.PlannedShards++
+	})
+}
+
+func (s *servers) AddLeaderShards(member string) {
+	s.update(member, func(m *serverDetails) {
+		m.LeaderShards++
+	})
+}
+
+type serverDetails struct {
+	PlannedShards int
+	CurrentShards int
+	LeaderShards  int
+}
+
+func (d deploymentDistribution) Collect(metrics MetricCollector) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	c, err := d.deployment.cache.GetAgency(ctx)
+	if err != nil {
+		return err
+	}
+
+	fetcher := agency.NewFetcher(c)
+
+	plan, err := agency.GetAgencyCollections(ctx, fetcher)
+	if err != nil {
+		return err
+	}
+
+	current, err := agency.GetCurrentCollections(ctx, fetcher)
+	if err != nil {
+		return err
+	}
+
+	clusterServers := servers{}
+
+	d.deployment.deployment.Status.Members.ForeachServerInGroups(func(group api.ServerGroup, list api.MemberStatusList) error {
+		for _, m := range list {
+			clusterServers[m.ID] = serverDetails{}
+		}
+		return nil
+	}, api.ServerGroupDBServers)
+
+	plannedShards := map[string]map[string]bool{}
+
+	for dbName, db := range *plan {
+		for collectionID, collection := range db {
+			if collection.WriteConcern != nil {
+				metrics.Collect(d.deployment.DeploymentCollectionConfig, prometheus.GaugeValue, float64(*collection.WriteConcern), d.deployment.labels(dbName, collection.GetName(collectionID), "WriteConcern")...)
+			}
+			if collection.ReplicationFactor != nil {
+				metrics.Collect(d.deployment.DeploymentCollectionConfig, prometheus.GaugeValue, float64(*collection.ReplicationFactor), d.deployment.labels(dbName, collection.GetName(collectionID), "ReplicationFactor")...)
+			}
+
+			for shardName, servers := range collection.Shards {
+				for _, server := range servers {
+					clusterServers.AddPlannedShard(server)
+
+					if _, ok := plannedShards[shardName]; ok {
+						if _, ok := plannedShards[shardName][server]; !ok {
+							plannedShards[shardName][server] = true
+						}
+					} else {
+						plannedShards[shardName] = map[string]bool{
+							server: true,
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for dbName, db := range *current {
+		planDB, ok := (*plan)[dbName]
+		if !ok {
+			continue
+		}
+
+		for collectionID, collection := range db {
+			planCol, ok := planDB[collectionID]
+			if !ok {
+				continue
+			}
+			name := planCol.GetName(collectionID)
+
+			for shardName, shard := range collection {
+				if len(shard.Servers) > 0 {
+					clusterServers.AddLeaderShards(shard.Servers[0])
+				}
+
+				for id, server := range shard.Servers {
+					clusterServers.AddCurrentShard(server)
+
+					var r float64 = 0
+					var leader = "false"
+					if id == 0 {
+						leader = "true"
+					}
+					if p, ok := plannedShards[shardName]; ok {
+						if s, ok := p[server]; ok {
+							if s {
+								r = 1
+							}
+						}
+					}
+					metrics.Collect(d.deployment.DeploymentShardDistribution, prometheus.GaugeValue, r, d.deployment.labels(dbName, name, shardName, server, leader)...)
+				}
+
+				if planCol.WriteConcern != nil {
+					minReplicationFactor := *planCol.WriteConcern
+					if len(shard.Servers) > minReplicationFactor {
+						metrics.Collect(d.deployment.DeploymentShardConditions, prometheus.GaugeValue, 1, d.deployment.labels(dbName, name, shardName, "Healthy")...)
+					} else if len(shard.Servers) == minReplicationFactor {
+						metrics.Collect(d.deployment.DeploymentShardConditions, prometheus.GaugeValue, 1, d.deployment.labels(dbName, name, shardName, "AtMinReplicationFactor")...)
+					} else {
+						metrics.Collect(d.deployment.DeploymentShardConditions, prometheus.GaugeValue, 1, d.deployment.labels(dbName, name, shardName, "Offline")...)
+					}
+				}
+			}
+		}
+	}
+
+	globalDetails := serverDetails{}
+
+	for _, details := range clusterServers {
+		globalDetails.LeaderShards += details.LeaderShards
+		globalDetails.CurrentShards += details.CurrentShards
+		globalDetails.PlannedShards += details.PlannedShards
+	}
+
+	for member, details := range clusterServers {
+		metrics.Collect(d.deployment.DeploymentServerShards, prometheus.GaugeValue, float64(details.PlannedShards), d.deployment.labels(member, "Planned")...)
+		metrics.Collect(d.deployment.DeploymentServerShards, prometheus.GaugeValue, float64(details.CurrentShards), d.deployment.labels(member, "Current")...)
+		metrics.Collect(d.deployment.DeploymentServerShards, prometheus.GaugeValue, float64(details.LeaderShards), d.deployment.labels(member, "Leader")...)
+
+		metrics.Collect(d.deployment.DeploymentServerShards, prometheus.GaugeValue, float64(details.PlannedShards)/float64(globalDetails.PlannedShards), d.deployment.labels(member, "PercentagePlanned")...)
+		metrics.Collect(d.deployment.DeploymentServerShards, prometheus.GaugeValue, float64(details.CurrentShards)/float64(globalDetails.CurrentShards), d.deployment.labels(member, "PercentageCurrent")...)
+		metrics.Collect(d.deployment.DeploymentServerShards, prometheus.GaugeValue, float64(details.LeaderShards)/float64(globalDetails.LeaderShards), d.deployment.labels(member, "PercentageLeader")...)
+	}
+
+	metrics.Collect(d.deployment.Deployment, prometheus.GaugeValue, float64(globalDetails.PlannedShards), d.deployment.labels("Shards", "Planned")...)
+	metrics.Collect(d.deployment.Deployment, prometheus.GaugeValue, float64(globalDetails.CurrentShards), d.deployment.labels("Shards", "Current")...)
+	metrics.Collect(d.deployment.Deployment, prometheus.GaugeValue, float64(globalDetails.LeaderShards), d.deployment.labels("Shards", "Leader")...)
+
+	return nil
+}

--- a/pkg/deployment/metrics/deployment_structure.go
+++ b/pkg/deployment/metrics/deployment_structure.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func newDeploymentStructure(deployment *deployment) Collector {
+	d := &deploymentStructure{
+		deployment: deployment,
+	}
+
+	return d
+}
+
+type deploymentStructure struct {
+	deployment *deployment
+}
+
+func (d deploymentStructure) Collect(metrics MetricCollector) error {
+	d.deployment.deployment.Status.Members.ForeachServerGroup(func(group api.ServerGroup, list api.MemberStatusList) error {
+		for _, member := range list {
+			metrics.Collect(d.deployment.DeploymentMembers, prometheus.GaugeValue, 1, d.deployment.labels(group.AsRole(), member.ID)...)
+		}
+
+		return nil
+	})
+	return nil
+}

--- a/pkg/deployment/metrics/deployment_structure.go
+++ b/pkg/deployment/metrics/deployment_structure.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 import (

--- a/pkg/deployment/metrics/deployments.go
+++ b/pkg/deployment/metrics/deployments.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 import (

--- a/pkg/deployment/metrics/deployments.go
+++ b/pkg/deployment/metrics/deployments.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	typedApi "github.com/arangodb/kube-arangodb/pkg/generated/clientset/versioned/typed/deployment/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Deployments interface {
+	prometheus.Collector
+}
+
+func NewDeployments(metrics MetricDefinition, deploymentInterface typedApi.ArangoDeploymentInterface, cli kubernetes.Interface) Deployments {
+	d := &deployments{
+		deploymentInterface: deploymentInterface,
+		cli:                 cli,
+		MetricDefinition:    metrics,
+	}
+
+	return d
+}
+
+type deployments struct {
+	deploymentInterface typedApi.ArangoDeploymentInterface
+	cli                 kubernetes.Interface
+
+	MetricDefinition
+}
+
+func (d deployments) Collect(metrics chan<- prometheus.Metric) {
+	collector := NewMetricsCollector(metrics)
+
+	println("COLLECTING DATA")
+
+	depls, err := d.deploymentInterface.List(v1.ListOptions{})
+
+	defer d.Error.ApplyMetrics(collector)
+	if err != nil {
+		d.Error.Add()
+		collector.Collect(d.DeploymentCount, prometheus.GaugeValue, 0)
+		return
+	}
+
+	collector.Collect(d.DeploymentCount, prometheus.GaugeValue, float64(len(depls.Items)))
+
+	for _, depl := range depls.Items {
+		NewDeployment(d.MetricDefinition, d.cli, &depl).Collect(metrics)
+	}
+}

--- a/pkg/deployment/metrics/desc.go
+++ b/pkg/deployment/metrics/desc.go
@@ -1,0 +1,22 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type DescCollector interface {
+	Collect(m MetricDesc) DescCollector
+}
+
+func NewDesc(descs chan<- *prometheus.Desc) DescCollector {
+	return &desc{
+		descs: descs,
+	}
+}
+
+type desc struct {
+	descs chan<- *prometheus.Desc
+}
+
+func (d *desc) Collect(m MetricDesc) DescCollector {
+	d.descs <- m.Desc()
+	return d
+}

--- a/pkg/deployment/metrics/desc.go
+++ b/pkg/deployment/metrics/desc.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/pkg/deployment/metrics/metric.go
+++ b/pkg/deployment/metrics/metric.go
@@ -1,0 +1,55 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type Counter interface {
+	Add()
+
+	MetricApplier
+	MetricDesc
+}
+
+type counter struct {
+	Metric
+	labels []string
+
+	count int64
+}
+
+func (c *counter) Add() {
+	c.count++
+}
+
+func (c *counter) ApplyMetrics(a MetricCollector) {
+	a.Collect(c, prometheus.CounterValue, float64(c.count), c.labels...)
+}
+
+type MetricDesc interface {
+	Desc() *prometheus.Desc
+}
+
+type Metric interface {
+	MetricDesc
+
+	NewCounter(labels ...string) Counter
+}
+
+func NewMetricDescription(fqName, help string, variableLabels []string) Metric {
+	return metricDescription{prometheus.NewDesc(fqName, help, variableLabels, nil)}
+}
+
+type metricDescription struct {
+	Description *prometheus.Desc
+}
+
+func (m metricDescription) NewCounter(labels ...string) Counter {
+	return &counter{
+		Metric: m,
+		count:  0,
+		labels: labels,
+	}
+}
+
+func (m metricDescription) Desc() *prometheus.Desc {
+	return m.Description
+}

--- a/pkg/deployment/metrics/metric.go
+++ b/pkg/deployment/metrics/metric.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/pkg/deployment/metrics/metric_applier.go
+++ b/pkg/deployment/metrics/metric_applier.go
@@ -1,0 +1,34 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type MetricApplier interface {
+	ApplyMetrics(a MetricCollector)
+}
+
+type MetricCollector interface {
+	Collect(m Metric, valueType prometheus.ValueType, value float64, labelValues ...string) MetricCollector
+
+	CollectInstance(a MetricApplier) MetricCollector
+}
+
+type applier struct {
+	metrics chan<- prometheus.Metric
+}
+
+func (a *applier) CollectInstance(app MetricApplier) MetricCollector {
+	app.ApplyMetrics(a)
+	return a
+}
+
+func (a *applier) Collect(m Metric, valueType prometheus.ValueType, value float64, labelValues ...string) MetricCollector {
+	if metric, err := prometheus.NewConstMetric(m.Desc(), valueType, value, labelValues...); err == nil {
+		a.metrics <- metric
+	}
+
+	return a
+}
+
+func NewMetricsCollector(metrics chan<- prometheus.Metric) MetricCollector {
+	return &applier{metrics: metrics}
+}

--- a/pkg/deployment/metrics/metric_applier.go
+++ b/pkg/deployment/metrics/metric_applier.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/pkg/deployment/metrics/metric_impl.go
+++ b/pkg/deployment/metrics/metric_impl.go
@@ -1,3 +1,23 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
 package metrics
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/pkg/deployment/metrics/metric_impl.go
+++ b/pkg/deployment/metrics/metric_impl.go
@@ -1,0 +1,58 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func NewMetricDefinition() MetricDefinition {
+	return MetricDefinition{
+		Error:                       NewMetricDescription("arango_operator_deployment_scrape_errors", "Deployment Scrape Errors", nil).NewCounter(),
+		DeploymentCount:             NewMetricDescription("arango_operator_deployment_count", "Count of deployments managed by operator", nil),
+		DeploymentCollectionConfig:  NewMetricDescription("arango_operator_deployment_collection_config", "Shard Configuration", coreLabels("database", "collection", "option")),
+		DeploymentShardDistribution: NewMetricDescription("arango_operator_deployment_shard_distribution", "Shard Distribution", coreLabels("database", "collection", "shard", "server", "leader")),
+		DeploymentShardConditions:   NewMetricDescription("arango_operator_deployment_shard_conditions", "Shard Conditions", coreLabels("database", "collection", "shard", "condition")),
+
+		DeploymentServerShards: NewMetricDescription("arango_operator_deployment_server_shards", "Server Shard Distribution", coreLabels("server", "type")),
+
+		DeploymentShards: NewMetricDescription("arango_operator_deployment_shards", "Server Shard Statistics", coreLabels("shard", "type")),
+
+		Deployment: NewMetricDescription("arango_operator_deployment", "Deployment Statistics", coreLabels("kind", "type")),
+
+		DeploymentMembers: NewMetricDescription("arango_operator_deployment_members", "", coreLabels("member_role", "id")),
+	}
+}
+
+func coreLabels(labels ...string) []string {
+	return append([]string{
+		"deployment",
+		"namespace",
+	}, labels...)
+}
+
+type MetricDefinition struct {
+	Error Counter
+
+	DeploymentCount Metric
+
+	DeploymentCollectionConfig  Metric
+	DeploymentShardDistribution Metric
+	DeploymentShardConditions   Metric
+
+	DeploymentServerShards Metric
+	Deployment             Metric
+
+	DeploymentMembers Metric
+	DeploymentShards  Metric
+}
+
+func (m MetricDefinition) Describe(descs chan<- *prometheus.Desc) {
+	collector := NewDesc(descs)
+
+	collector.Collect(m.Error)
+	collector.Collect(m.DeploymentCount)
+	collector.Collect(m.DeploymentCollectionConfig)
+	collector.Collect(m.DeploymentShardDistribution)
+	collector.Collect(m.DeploymentShardConditions)
+	collector.Collect(m.DeploymentServerShards)
+	collector.Collect(m.DeploymentMembers)
+	collector.Collect(m.DeploymentShards)
+	collector.Collect(m.Deployment)
+}

--- a/pkg/generated/informers/externalversions/factory.go
+++ b/pkg/generated/informers/externalversions/factory.go
@@ -106,7 +106,7 @@ func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResy
 		customResync:     make(map[reflect.Type]time.Duration),
 	}
 
-	// Apply all options
+	// Collect all options
 	for _, opt := range options {
 		factory = opt(factory)
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -27,6 +27,9 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
+	metrics "github.com/arangodb/kube-arangodb/pkg/deployment/metrics"
+
 	"github.com/arangodb/kube-arangodb/pkg/operator/scope"
 
 	monitoringClient "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
@@ -172,6 +175,15 @@ func (o *Operator) onStartDeployment(stop <-chan struct{}) {
 			time.Sleep(initRetryWaitTime)
 		}
 	}
+
+	if features.Metrics().Enabled() {
+		o.log.Error().Msgf("COLLECTING ENABLING")
+		metrics := metrics.NewDeployments(metrics.NewMetricDefinition(), o.CRCli.DatabaseV1().ArangoDeployments(o.Namespace), o.KubeCli)
+		prometheus.MustRegister(metrics)
+	} else {
+		o.log.Error().Msgf("COLLECTING DISABLED")
+	}
+
 	o.runDeployments(stop)
 }
 


### PR DESCRIPTION
Generated metrics:
```
# TYPE arango_operator_deployment gauge
arango_operator_deployment{deployment="deployment",kind="Shards",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",type="Current"} 173
arango_operator_deployment{deployment="deployment",kind="Shards",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",type="Leader"} 63
arango_operator_deployment{deployment="deployment",kind="Shards",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",type="Planned"} 173
# HELP arango_operator_deployment_collection_config Shard Configuration
# TYPE arango_operator_deployment_collection_config gauge
arango_operator_deployment_collection_config{collection="TEST",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 5
arango_operator_deployment_collection_config{collection="TEST",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 4
arango_operator_deployment_collection_config{collection="_analyzers",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_analyzers",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_appbundles",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_appbundles",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_apps",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_apps",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_aqlfunctions",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_aqlfunctions",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_fishbowl",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_fishbowl",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_frontend",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_frontend",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_graphs",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_graphs",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_jobs",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_jobs",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_modules",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_modules",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_queues",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_queues",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_statistics",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_statistics",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_statistics15",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_statistics15",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_statisticsRaw",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_statisticsRaw",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="_users",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="_users",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="my_test_collection",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 2
arango_operator_deployment_collection_config{collection="my_test_collection",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
arango_operator_deployment_collection_config{collection="my_test_collection_2",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="ReplicationFactor"} 1
arango_operator_deployment_collection_config{collection="my_test_collection_2",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",option="WriteConcern"} 1
# HELP arango_operator_deployment_count Count of deployments managed by operator
# TYPE arango_operator_deployment_count gauge
arango_operator_deployment_count 1
# HELP arango_operator_deployment_members 
# TYPE arango_operator_deployment_members gauge
arango_operator_deployment_members{deployment="deployment",id="AGNT-9ihwhgyf",member_role="agent",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="AGNT-rj1o14yt",member_role="agent",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="AGNT-txi7uckh",member_role="agent",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="CRDN-bvgoa7ga",member_role="coordinator",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="CRDN-fvzlc5hx",member_role="coordinator",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="PRMR-fct814lu",member_role="dbserver",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="PRMR-ojijc15w",member_role="dbserver",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="PRMR-rhmty9cr",member_role="dbserver",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="PRMR-tfdeddn9",member_role="dbserver",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
arango_operator_deployment_members{deployment="deployment",id="PRMR-ttzjw2nx",member_role="dbserver",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14"} 1
# HELP arango_operator_deployment_scrape_errors Deployment Scrape Errors
# TYPE arango_operator_deployment_scrape_errors counter
arango_operator_deployment_scrape_errors 0
# HELP arango_operator_deployment_server_shards Server Shard Distribution
# TYPE arango_operator_deployment_server_shards gauge
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",type="Current"} 16
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",type="Leader"} 8
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",type="PercentageCurrent"} 0.09248554913294797
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",type="PercentageLeader"} 0.12698412698412698
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",type="PercentagePlanned"} 0.09248554913294797
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",type="Planned"} 16
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",type="Current"} 16
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",type="Leader"} 0
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",type="PercentageCurrent"} 0.09248554913294797
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",type="PercentageLeader"} 0
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",type="PercentagePlanned"} 0.09248554913294797
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",type="Planned"} 16
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",type="Current"} 63
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",type="Leader"} 34
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",type="PercentageCurrent"} 0.36416184971098264
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",type="PercentageLeader"} 0.5396825396825397
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",type="PercentagePlanned"} 0.36416184971098264
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",type="Planned"} 63
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",type="Current"} 62
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",type="Leader"} 21
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",type="PercentageCurrent"} 0.3583815028901734
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",type="PercentageLeader"} 0.3333333333333333
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",type="PercentagePlanned"} 0.3583815028901734
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",type="Planned"} 62
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",type="Current"} 16
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",type="Leader"} 0
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",type="PercentageCurrent"} 0.09248554913294797
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",type="PercentageLeader"} 0
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",type="PercentagePlanned"} 0.09248554913294797
arango_operator_deployment_server_shards{deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",type="Planned"} 16
# HELP arango_operator_deployment_shard_conditions Shard Conditions
# TYPE arango_operator_deployment_shard_conditions gauge
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012643"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012644"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012645"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012646"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012647"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012648"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012649"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012650"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012651"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012652"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012653"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012654"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012655"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012656"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012657"} 1
arango_operator_deployment_shard_conditions{collection="TEST",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s6012658"} 1
arango_operator_deployment_shard_conditions{collection="_analyzers",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010020"} 1
arango_operator_deployment_shard_conditions{collection="_appbundles",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010025"} 1
arango_operator_deployment_shard_conditions{collection="_apps",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010024"} 1
arango_operator_deployment_shard_conditions{collection="_aqlfunctions",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010021"} 1
arango_operator_deployment_shard_conditions{collection="_fishbowl",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010028"} 1
arango_operator_deployment_shard_conditions{collection="_frontend",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010026"} 1
arango_operator_deployment_shard_conditions{collection="_graphs",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010016"} 1
arango_operator_deployment_shard_conditions{collection="_jobs",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010023"} 1
arango_operator_deployment_shard_conditions{collection="_modules",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010027"} 1
arango_operator_deployment_shard_conditions{collection="_queues",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010022"} 1
arango_operator_deployment_shard_conditions{collection="_statistics",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010017"} 1
arango_operator_deployment_shard_conditions{collection="_statistics15",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010018"} 1
arango_operator_deployment_shard_conditions{collection="_statisticsRaw",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010019"} 1
arango_operator_deployment_shard_conditions{collection="_users",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4010002"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012392"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012393"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012394"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012395"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012396"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012397"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012398"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012399"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012400"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012401"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012402"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012403"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012404"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012405"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012406"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012407"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012408"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012409"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012410"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012411"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012412"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012413"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012414"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012415"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012416"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012417"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012418"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012419"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012420"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012421"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012422"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection",condition="Healthy",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012423"} 1
arango_operator_deployment_shard_conditions{collection="my_test_collection_2",condition="AtMinReplicationFactor",database="_system",deployment="deployment",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",shard="s4012439"} 1
# HELP arango_operator_deployment_shard_distribution Shard Distribution
# TYPE arango_operator_deployment_shard_distribution gauge
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012644"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012645"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012647"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012649"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012650"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012652"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012655"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012657"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012643"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012644"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012645"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012646"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012647"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012648"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012649"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012650"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012651"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012652"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012653"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012654"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012655"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012656"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012657"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ojijc15w",shard="s6012658"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012643"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012644"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012645"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012646"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012648"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012649"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012650"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012651"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012653"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012654"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012655"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012656"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012658"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012643"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012646"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012647"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012648"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012651"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012652"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012653"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012654"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012656"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012657"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012658"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012643"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012644"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012645"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012646"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012647"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012648"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012649"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012650"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012651"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012652"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012653"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012654"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012655"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012656"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012657"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-ttzjw2nx",shard="s6012658"} 1
arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012643"} 1
1arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012646"} 1
00arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012648"} 1
 arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012651"} 1
78arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012653"} 1
63arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012654"} 1
7 arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012656"} 1
   arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-fct814lu",shard="s6012658"} 1
0 arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012647"} 1
78arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012652"} 1
63arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s6012657"} 1
7arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012644"} 1
  arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012645"} 1
  arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012649"} 1
0 arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012650"} 1
  arango_operator_deployment_shard_distribution{collection="TEST",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s6012655"} 1
 arango_operator_deployment_shard_distribution{collection="_analyzers",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010020"} 1
 0arango_operator_deployment_shard_distribution{collection="_analyzers",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010020"} 1
  arango_operator_deployment_shard_distribution{collection="_appbundles",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010025"} 1
 1arango_operator_deployment_shard_distribution{collection="_appbundles",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010025"} 1
2arango_operator_deployment_shard_distribution{collection="_apps",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010024"} 1
3karango_operator_deployment_shard_distribution{collection="_apps",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010024"} 1
 arango_operator_deployment_shard_distribution{collection="_aqlfunctions",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010021"} 1
  arango_operator_deployment_shard_distribution{collection="_aqlfunctions",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010021"} 1
  arango_operator_deployment_shard_distribution{collection="_fishbowl",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010028"} 1
 arango_operator_deployment_shard_distribution{collection="_fishbowl",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010028"} 1
0arango_operator_deployment_shard_distribution{collection="_frontend",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010026"} 1
 arango_operator_deployment_shard_distribution{collection="_frontend",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010026"} 1
-arango_operator_deployment_shard_distribution{collection="_graphs",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010016"} 1
-:arango_operator_deployment_shard_distribution{collection="_graphs",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010016"} 1
-arango_operator_deployment_shard_distribution{collection="_jobs",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010023"} 1
-:arango_operator_deployment_shard_distribution{collection="_jobs",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010023"} 1
-arango_operator_deployment_shard_distribution{collection="_modules",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010027"} 1
- arango_operator_deployment_shard_distribution{collection="_modules",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010027"} 1
--arango_operator_deployment_shard_distribution{collection="_queues",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010022"} 1
:-arango_operator_deployment_shard_distribution{collection="_queues",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010022"} 1
-arango_operator_deployment_shard_distribution{collection="_statistics",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010017"} 1
:arango_operator_deployment_shard_distribution{collection="_statistics",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010017"} 1
-arango_operator_deployment_shard_distribution{collection="_statistics15",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010018"} 1
- arango_operator_deployment_shard_distribution{collection="_statistics15",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010018"} 1
-arango_operator_deployment_shard_distribution{collection="_statisticsRaw",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010019"} 1
-:arango_operator_deployment_shard_distribution{collection="_statisticsRaw",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010019"} 1
-arango_operator_deployment_shard_distribution{collection="_users",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4010002"} 1
-:arango_operator_deployment_shard_distribution{collection="_users",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4010002"} 1
--arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012393"} 1
 arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012395"} 1
 arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012397"} 1
12arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012399"} 1
3karango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012401"} 1

arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012403"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012405"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012407"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012409"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012411"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012413"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012415"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012417"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012419"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012421"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012423"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012392"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012394"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012396"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012398"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012400"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012402"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012404"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012406"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012408"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012410"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012412"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012414"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012416"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012418"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012420"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="false",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012422"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012392"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012394"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012396"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012398"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012400"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012402"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012404"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012406"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012408"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012410"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012412"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012414"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012416"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012418"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012420"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012422"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012393"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012395"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012397"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012399"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012401"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012403"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012405"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012407"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012409"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012411"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012413"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012415"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012417"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012419"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012421"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-tfdeddn9",shard="s4012423"} 1
arango_operator_deployment_shard_distribution{collection="my_test_collection_2",database="_system",deployment="deployment",leader="true",namespace="7c4ae4fc-96be-7bc5-801f-b48b4137cd14",server="PRMR-rhmty9cr",shard="s4012439"} 1
# HELP arango_operator_objects_processed Count of the processed objects
# TYPE arango_operator_objects_processed counter
arango_operator_objects_processed{operator_name="arangodb-backup-operator"} 0
# HELP arangodb_operator_controller_deployment_replications Number of deployment replications currently being managed
# TYPE arangodb_operator_controller_deployment_replications gauge
arangodb_operator_controller_deployment_replications 0
# HELP arangodb_operator_controller_deployment_replications_created Number of deployment replications that have been created
# TYPE arangodb_operator_controller_deployment_replications_created counter
arangodb_operator_controller_deployment_replications_created 0
# HELP arangodb_operator_controller_deployment_replications_deleted Number of deployment replications that have been deleted
# TYPE arangodb_operator_controller_deployment_replications_deleted counter
arangodb_operator_controller_deployment_replications_deleted 0
# HELP arangodb_operator_controller_deployment_replications_failed Number of deployment replications that have failed
# TYPE arangodb_operator_controller_deployment_replications_failed counter
arangodb_operator_controller_deployment_replications_failed 0
# HELP arangodb_operator_controller_deployment_replications_modified Number of deployment replication modifications
# TYPE arangodb_operator_controller_deployment_replications_modified counter
arangodb_operator_controller_deployment_replications_modified 0
# HELP arangodb_operator_controller_deployments Number of deployments currently being managed
# TYPE arangodb_operator_controller_deployments gauge
arangodb_operator_controller_deployments 1
# HELP arangodb_operator_controller_deployments_created Number of deployments that have been created
# TYPE arangodb_operator_controller_deployments_created counter
arangodb_operator_controller_deployments_created 1
# HELP arangodb_operator_controller_deployments_deleted Number of deployments that have been deleted
# TYPE arangodb_operator_controller_deployments_deleted counter
arangodb_operator_controller_deployments_deleted 0
# HELP arangodb_operator_controller_deployments_failed Number of deployments that have failed
# TYPE arangodb_operator_controller_deployments_failed counter
arangodb_operator_controller_deployments_failed 0
# HELP arangodb_operator_controller_deployments_modified Number of deployment modifications
# TYPE arangodb_operator_controller_deployments_modified counter
arangodb_operator_controller_deployments_modified 134
# HELP arangodb_operator_controller_local_storages Number of local storages currently being managed
# TYPE arangodb_operator_controller_local_storages gauge
arangodb_operator_controller_local_storages 0
# HELP arangodb_operator_controller_local_storages_created Number of local storages that have been created
# TYPE arangodb_operator_controller_local_storages_created counter
arangodb_operator_controller_local_storages_created 0
# HELP arangodb_operator_controller_local_storages_deleted Number of local storages that have been deleted
# TYPE arangodb_operator_controller_local_storages_deleted counter
arangodb_operator_controller_local_storages_deleted 0
# HELP arangodb_operator_controller_local_storages_failed Number of local storages that have failed
# TYPE arangodb_operator_controller_local_storages_failed counter
arangodb_operator_controller_local_storages_failed 0
# HELP arangodb_operator_controller_local_storages_modified Number of local storage modifications
# TYPE arangodb_operator_controller_local_storages_modified counter
arangodb_operator_controller_local_storages_modified 0
# HELP arangodb_operator_deployment_inspect_deployment_duration Amount of time taken by a single inspection of a deployment (in sec)
# TYPE arangodb_operator_deployment_inspect_deployment_duration gauge
arangodb_operator_deployment_inspect_deployment_duration{deployment="deployment"} 2.22629694
# HELP arangodb_operator_deployment_resources_cleanup_removed_members Number of cleanup-removed-members actions
# TYPE arangodb_operator_deployment_resources_cleanup_removed_members counter
arangodb_operator_deployment_resources_cleanup_removed_members{deployment="deployment",result="success"} 14140
# HELP arangodb_operator_deployment_resources_deployment_health_fetches Number of times the health of the deployment was fetched
# TYPE arangodb_operator_deployment_resources_deployment_health_fetches counter
arangodb_operator_deployment_resources_deployment_health_fetches{deployment="deployment",result="success"} 34633
# HELP arangodb_operator_deployment_resources_deployment_sync_fetches Number of times the sync status of shards of the deplyoment was fetched
# TYPE arangodb_operator_deployment_resources_deployment_sync_fetches counter
arangodb_operator_deployment_resources_deployment_sync_fetches{deployment="deployment",result="success"} 5789
# HELP arangodb_operator_deployment_resources_inspect_pods_duration Amount of time taken by a single inspection of all pods for a deployment (in sec)
# TYPE arangodb_operator_deployment_resources_inspect_pods_duration gauge
arangodb_operator_deployment_resources_inspect_pods_duration{deployment="deployment"} 0.011557499
# HELP arangodb_operator_deployment_resources_inspect_pvcs_duration Amount of time taken by a single inspection of all PVCs for a deployment (in sec)
# TYPE arangodb_operator_deployment_resources_inspect_pvcs_duration gauge
arangodb_operator_deployment_resources_inspect_pvcs_duration{deployment="deployment"} 5.2665e-05
# HELP arangodb_operator_deployment_resources_inspect_secrets_duration Amount of time taken by a single inspection of all Secrets for a deployment (in sec)
# TYPE arangodb_operator_deployment_resources_inspect_secrets_duration gauge
arangodb_operator_deployment_resources_inspect_secrets_duration{deployment="deployment"} 8.3876e-05
# HELP arangodb_operator_deployment_resources_inspect_services_duration Amount of time taken by a single inspection of all Services for a deployment (in sec)
# TYPE arangodb_operator_deployment_resources_inspect_services_duration gauge
arangodb_operator_deployment_resources_inspect_services_duration{deployment="deployment"} 7.603e-06
# HELP arangodb_operator_deployment_resources_inspected_pods Number of pod inspections per deployment
# TYPE arangodb_operator_deployment_resources_inspected_pods counter
arangodb_operator_deployment_resources_inspected_pods{deployment="deployment"} 141658
# HELP arangodb_operator_deployment_resources_inspected_pvcs Number of PVC inspections per deployment
# TYPE arangodb_operator_deployment_resources_inspected_pvcs counter
arangodb_operator_deployment_resources_inspected_pvcs{deployment="deployment"} 113328
# HELP arangodb_operator_deployment_resources_inspected_secrets Number of Secret inspections per deployment
# TYPE arangodb_operator_deployment_resources_inspected_secrets counter
arangodb_operator_deployment_resources_inspected_secrets{deployment="deployment"} 28332
# HELP arangodb_operator_deployment_resources_inspected_services Number of Service inspections per deployment
# TYPE arangodb_operator_deployment_resources_inspected_services counter
arangodb_operator_deployment_resources_inspected_services{deployment="deployment"} 28332
```