### PR TITLE
Fix arango-crd.yaml - Error in command to create `arangomembers` CRD

### DIFF
--- a/manifests/arango-crd.yaml
+++ b/manifests/arango-crd.yaml
@@ -280,7 +280,7 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    name: arangomembmers.database.arangodb.com
+    name: arangomembers.database.arangodb.com
     labels:
         app.kubernetes.io/name: kube-arangodb-crd
         helm.sh/chart: kube-arangodb-crd-1.1.6


### PR DESCRIPTION
When running `kubectl apply -f https://raw.githubusercontent.com/arangodb/kube-arangodb/1.1.6/manifests/arango-crd.yaml` to install the needed CRDs an error pops up to address a typo:

`The CustomResourceDefinition "arangomembmers.database.arangodb.com" is invalid: metadata.name: Invalid value: "arangomembmers.database.arangodb.com": must be spec.names.plural+"."+spec.group`

Specifically, this means that the CustomResourceDefinition part `arangomembmers` is erroneous and needs to be changed to `arangomembers`.