### PR TITLE
Add metrics spec to example deployments to use with Prometheus/Grafana

### DIFF
--- a/examples/production-cluster-with-metrics.yaml
+++ b/examples/production-cluster-with-metrics.yaml
@@ -1,0 +1,17 @@
+apiVersion: "database.arangodb.com/v1alpha"
+kind: "ArangoDeployment"
+metadata:
+  name: "production-cluster"
+spec:
+  metrics:
+    mode: sidecar
+    enabled: true
+    image: arangodb/arangodb-exporter:0.1.7
+    tls: false
+  annotations:                                                                                                                                                  
+    prometheus.io/scrape: 'true'                                                                                                                               
+    prometheus.io/port: '9101'                                                                                                                                 
+    prometheus.io/scrape_interval: '5s'
+  mode: Cluster
+  image: arangodb/arangodb:3.6.1
+  environment: Production

--- a/examples/simple-cluster-with-metrics.yaml
+++ b/examples/simple-cluster-with-metrics.yaml
@@ -1,0 +1,16 @@
+apiVersion: "database.arangodb.com/v1alpha"
+kind: "ArangoDeployment"
+metadata:
+  name: "example-simple-cluster"
+spec:
+  metrics:
+    mode: sidecar
+    enabled: true
+    image: arangodb/arangodb-exporter:0.1.7
+    tls: false
+  annotations:                                                                                                                                                  
+    prometheus.io/scrape: 'true'                                                                                                                               
+    prometheus.io/port: '9101'                                                                                                                                 
+    prometheus.io/scrape_interval: '5s'
+  mode: Cluster
+  image: arangodb/arangodb:3.6.1


### PR DESCRIPTION
This example files PR adds the needed "internals" used for our Grafana/Prometheus setup. Currently, this is only being added for a simple cluster and a production cluster deployment but this can easily be added to other types of deployments. Adding it to the examples gives customers an option to easier roll it out.

Added functionality:

```
metrics:
    mode: sidecar
    enabled: true
    image: arangodb/arangodb-exporter:0.1.7
    tls: false
  annotations:                                                                                                                                                  
    prometheus.io/scrape: 'true'                                                                                                                               
    prometheus.io/port: '9101'                                                                                                                                 
    prometheus.io/scrape_interval: '5s'
```