### PR TITLE
Patch manifests to `v1` api & typos

### DIFF
--- a/manifests/arango-all.yaml
+++ b/manifests/arango-all.yaml
@@ -13,7 +13,7 @@ metadata:
       release: all
 ---
 # Source: kube-arangodb/templates/storage-operator/crd.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     name: arangolocalstorages.storage.arangodb.com

--- a/manifests/arango-storage.yaml
+++ b/manifests/arango-storage.yaml
@@ -13,7 +13,7 @@ metadata:
       release: storage
 ---
 # Source: kube-arangodb/templates/storage-operator/crd.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     name: arangolocalstorages.storage.arangodb.com

--- a/manifests/kustomize/all/arango-all.yaml
+++ b/manifests/kustomize/all/arango-all.yaml
@@ -13,7 +13,7 @@ metadata:
       release: all
 ---
 # Source: kube-arangodb/templates/storage-operator/crd.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     name: arangolocalstorages.storage.arangodb.com

--- a/manifests/kustomize/all/kustomization.yaml
+++ b/manifests/kustomize/all/kustomization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
+apiVersion: kustomize.config.k8s.io/v1
 kind: Kustomization
 
 resources:

--- a/manifests/kustomize/backup/kustomization.yaml
+++ b/manifests/kustomize/backup/kustomization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
+apiVersion: kustomize.config.k8s.io/v1
 kind: Kustomization
 
 resources:

--- a/manifests/kustomize/crd/kustomization.yaml
+++ b/manifests/kustomize/crd/kustomization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
+apiVersion: kustomize.config.k8s.io/v1
 kind: Kustomization
 
 resources:

--- a/manifests/kustomize/deployment/kustomization.yaml
+++ b/manifests/kustomize/deployment/kustomization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
+apiVersion: kustomize.config.k8s.io/v1
 kind: Kustomization
 
 resources:

--- a/pkg/apis/deployment/v1/server_group_spec.go
+++ b/pkg/apis/deployment/v1/server_group_spec.go
@@ -246,7 +246,7 @@ type ServerGroupProbesSpec struct {
 
 	// OldReadinessProbeDisabled if true readinessProbes are disabled
 	//
-	// Deprecated: This field is deprecated, keept only for backward compatibility.
+	// Deprecated: This field is deprecated, kept only for backward compatibility.
 	OldReadinessProbeDisabled *bool `json:"ReadinessProbeDisabled,omitempty"`
 	// ReadinessProbeDisabled override flag for probe disabled in good manner (lowercase) with backward compatibility
 	ReadinessProbeDisabled *bool `json:"readinessProbeDisabled,omitempty"`

--- a/pkg/apis/deployment/v2alpha1/server_group_spec.go
+++ b/pkg/apis/deployment/v2alpha1/server_group_spec.go
@@ -244,7 +244,7 @@ type ServerGroupProbesSpec struct {
 
 	// OldReadinessProbeDisabled if true readinessProbes are disabled
 	//
-	// Deprecated: This field is deprecated, keept only for backward compatibility.
+	// Deprecated: This field is deprecated, kept only for backward compatibility.
 	OldReadinessProbeDisabled *bool `json:"ReadinessProbeDisabled,omitempty"`
 	// ReadinessProbeDisabled override flag for probe disabled in good manner (lowercase) with backward compatibility
 	ReadinessProbeDisabled *bool `json:"readinessProbeDisabled,omitempty"`


### PR DESCRIPTION
To future proof the k8s manifests I've changed the `apiVersion` for a few manifests from `v1beta1` to `v1`

And I've fixed a minor typo in `server_group_spec.go` which does not require testing as it belongs in the comments of this file.