### PR TITLE
Patch arango-local-storage.yaml

### DIFF
--- a/examples/arango-local-storage.yaml
+++ b/examples/arango-local-storage.yaml
@@ -1,4 +1,4 @@
-apiVersion: "storage.arangodb.com/v1"
+apiVersion: "storage.arangodb.com/v1alpha"
 kind: "ArangoLocalStorage"
 metadata:
   name: "arangodb-local-storage"


### PR DESCRIPTION
Fix a typo/error from `apiVersion: "storage.arangodb.com/v1"` to `apiVersion: "storage.arangodb.com/v1alpha"`