### PR TITLE
Patched examples for latest ArangoDB & exporter

### DIFF
--- a/examples/cluster1-with-sync.yaml
+++ b/examples/cluster1-with-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "cluster1-with-sync"
 spec:
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.7.11'
   tls:
     altNames: ["kube-01", "kube-02", "kube-03"]
   sync:

--- a/examples/cluster2-with-sync.yaml
+++ b/examples/cluster2-with-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "cluster2-with-sync"
 spec:
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.7.11'
   tls:
     altNames: ["kube-01", "kube-02", "kube-03"]
   sync:

--- a/examples/production-cluster-with-metrics.yaml
+++ b/examples/production-cluster-with-metrics.yaml
@@ -6,12 +6,12 @@ spec:
   metrics:
     mode: sidecar
     enabled: true
-    image: 'arangodb/arangodb-exporter:0.1.7'
+    image: 'arangodb/arangodb-exporter:0.1.8'
     tls: false
   annotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '9101'
     prometheus.io/scrape_interval: '5s'
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.7.11'
   environment: Production

--- a/examples/production-cluster.yaml
+++ b/examples/production-cluster.yaml
@@ -4,5 +4,5 @@ metadata:
   name: "production-cluster"
 spec:
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.7.11'
   environment: Production

--- a/examples/reboot-pod.yaml
+++ b/examples/reboot-pod.yaml
@@ -11,7 +11,7 @@ spec:
       command: ["arangodb_operator", "reboot"]
       args:
         - --deployment-name=my-arangodb-cluster
-        - --image-name=arangodb/enterprise:3.7.10
+        - --image-name=arangodb/enterprise:3.7.11
         - --license-secret-name=arangodb-license-key
         - --coordinators=3
         - pvc-9aa241f7-df94-11e9-b74c-42010aac0044

--- a/examples/simple-cluster-with-metrics.yaml
+++ b/examples/simple-cluster-with-metrics.yaml
@@ -6,11 +6,11 @@ spec:
   metrics:
     mode: sidecar
     enabled: true
-    image: 'arangodb/arangodb-exporter:0.1.7'
+    image: 'arangodb/arangodb-exporter:0.1.8'
     tls: false
   annotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '9101'
     prometheus.io/scrape_interval: '5s'
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.7.11'

--- a/examples/simple-cluster.yaml
+++ b/examples/simple-cluster.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example-simple-cluster"
 spec:
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.7.11'

--- a/examples/single-server.yaml
+++ b/examples/single-server.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example-simple-single"
 spec:
   mode: Single
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.7.11'


### PR DESCRIPTION
Patched the examples for kube-arangodb to ArangoDB version `3.7.11` and the metrics exporter to version `0.1.8`