### PR TITLE
[Bugfix] Use persistent name and namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- Use persistent name and namespace in ArangoDeployment reconcilation loop
 
 ## [1.1.9](https://github.com/arangodb/kube-arangodb/tree/1.1.9) (2021-05-28)
 - Add IP, DNS, ShortDNS, HeadlessService (Default) communication methods

--- a/pkg/apis/deployment/v2alpha1/deployment_spec.go
+++ b/pkg/apis/deployment/v2alpha1/deployment_spec.go
@@ -50,6 +50,46 @@ func validatePullPolicy(v core.PullPolicy) error {
 	}
 }
 
+// DeploymentCommunicationMethod define communication method used for inter-cluster communication
+type DeploymentCommunicationMethod string
+
+// Get returns communication method from pointer. If pointer is nil default is returned.
+func (d *DeploymentCommunicationMethod) Get() DeploymentCommunicationMethod {
+	if d == nil {
+		return DefaultDeploymentCommunicationMethod
+	}
+
+	switch v := *d; v {
+	case DeploymentCommunicationMethodHeadlessService, DeploymentCommunicationMethodDNS, DeploymentCommunicationMethodIP, DeploymentCommunicationMethodShortDNS:
+		return v
+	default:
+		return DefaultDeploymentCommunicationMethod
+	}
+}
+
+// String returns string representation of method.
+func (d DeploymentCommunicationMethod) String() string {
+	return string(d)
+}
+
+// New returns pointer.
+func (d DeploymentCommunicationMethod) New() *DeploymentCommunicationMethod {
+	return &d
+}
+
+const (
+	// DefaultDeploymentCommunicationMethod define default communication method.
+	DefaultDeploymentCommunicationMethod = DeploymentCommunicationMethodHeadlessService
+	// DeploymentCommunicationMethodHeadlessService define old communication mechanism, based on headless service.
+	DeploymentCommunicationMethodHeadlessService DeploymentCommunicationMethod = "headless"
+	// DeploymentCommunicationMethodDNS define ClusterIP Service DNS based communication.
+	DeploymentCommunicationMethodDNS DeploymentCommunicationMethod = "dns"
+	// DeploymentCommunicationMethodDNS define ClusterIP Service DNS based communication. Use namespaced short DNS (used in migration)
+	DeploymentCommunicationMethodShortDNS DeploymentCommunicationMethod = "short-dns"
+	// DeploymentCommunicationMethodIP define ClusterIP Servce IP based communication.
+	DeploymentCommunicationMethodIP DeploymentCommunicationMethod = "ip"
+)
+
 // DeploymentSpec contains the spec part of a ArangoDeployment resource.
 type DeploymentSpec struct {
 	Mode               *DeploymentMode                   `json:"mode,omitempty"`
@@ -118,6 +158,9 @@ type DeploymentSpec struct {
 	Timeouts *Timeouts `json:"timeouts,omitempty"`
 
 	ClusterDomain *string `json:"ClusterDomain,omitempty"`
+
+	// CommunicationMethod define communication method used in deployment
+	CommunicationMethod *DeploymentCommunicationMethod `json:"communicationMethod,omitempty"`
 }
 
 // GetRestoreFrom returns the restore from string or empty string if not set

--- a/pkg/apis/deployment/v2alpha1/server_group.go
+++ b/pkg/apis/deployment/v2alpha1/server_group.go
@@ -35,6 +35,16 @@ func (g *ServerGroup) UnmarshalJSON(bytes []byte) error {
 		return nil
 	}
 
+	{
+		// Try with int
+		var s int
+
+		if err := json.Unmarshal(bytes, &s); err == nil {
+			*g = ServerGroupFromRole(ServerGroup(s).AsRole())
+			return nil
+		}
+	}
+
 	var s string
 
 	if err := json.Unmarshal(bytes, &s); err != nil {

--- a/pkg/apis/deployment/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/deployment/v2alpha1/zz_generated.deepcopy.go
@@ -567,6 +567,11 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CommunicationMethod != nil {
+		in, out := &in.CommunicationMethod, &out.CommunicationMethod
+		*out = new(DeploymentCommunicationMethod)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -107,6 +107,9 @@ const (
 
 // Deployment is the in process state of an ArangoDeployment.
 type Deployment struct {
+	name      string
+	namespace string
+
 	apiObject *api.ArangoDeployment // API object
 	status    struct {
 		mutex   sync.Mutex
@@ -143,6 +146,8 @@ func New(config Config, deps Dependencies, apiObject *api.ArangoDeployment) (*De
 
 	d := &Deployment{
 		apiObject: apiObject,
+		name:      apiObject.GetName(),
+		namespace: apiObject.GetNamespace(),
 		config:    config,
 		deps:      deps,
 		eventCh:   make(chan *deploymentEvent, deploymentEventQueueSize),

--- a/pkg/deployment/deployment_inspector.go
+++ b/pkg/deployment/deployment_inspector.go
@@ -99,7 +99,7 @@ func (d *Deployment) inspectDeployment(lastInterval util.Interval) util.Interval
 	nextInterval := lastInterval
 	hasError := false
 
-	deploymentName := d.apiObject.GetName()
+	deploymentName := d.GetName()
 	defer metrics.SetDuration(inspectDeploymentDurationGauges.WithLabelValues(deploymentName), start)
 
 	cachedStatus, err := inspector.NewInspector(d.GetKubeCli(), d.GetMonitoringV1Cli(), d.GetArangoCli(), d.GetNamespace())
@@ -112,7 +112,7 @@ func (d *Deployment) inspectDeployment(lastInterval util.Interval) util.Interval
 	var updated *api.ArangoDeployment
 	err = k8sutil.RunWithTimeout(ctxReconciliation, func(ctxChild context.Context) error {
 		var err error
-		updated, err = d.deps.DatabaseCRCli.DatabaseV1().ArangoDeployments(d.apiObject.GetNamespace()).Get(ctxChild, deploymentName, metav1.GetOptions{})
+		updated, err = d.deps.DatabaseCRCli.DatabaseV1().ArangoDeployments(d.GetNamespace()).Get(ctxChild, deploymentName, metav1.GetOptions{})
 		return err
 	})
 	if k8sutil.IsNotFound(err) {

--- a/pkg/deployment/deployment_suite_test.go
+++ b/pkg/deployment/deployment_suite_test.go
@@ -465,6 +465,8 @@ func createTestDeployment(config Config, arangoDeployment *api.ArangoDeployment)
 
 	d := &Deployment{
 		apiObject: arangoDeployment,
+		name:      arangoDeployment.GetName(),
+		namespace: arangoDeployment.GetNamespace(),
 		config:    config,
 		deps:      deps,
 		eventCh:   make(chan *deploymentEvent, deploymentEventQueueSize),

--- a/pkg/deployment/resources/context.go
+++ b/pkg/deployment/resources/context.go
@@ -81,6 +81,8 @@ type Context interface {
 	GetMetricsExporterImage() string
 	// GetArangoImage returns the image name containing the default arango image
 	GetArangoImage() string
+	// GetName returns the name of the deployment
+	GetName() string
 	// GetNamespace returns the namespace that contains the deployment
 	GetNamespace() string
 	// CreateEvent creates a given event.


### PR DESCRIPTION
Persist name and namespace of deployment to prevent issues when K8S API cannot be contacted