### PR TITLE
Replace deprecated node labels

### DIFF
--- a/chart/arangodb-ingress-proxy/templates/deployment.yaml
+++ b/chart/arangodb-ingress-proxy/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
                     requiredDuringSchedulingIgnoredDuringExecution:
                         nodeSelectorTerms:
                             - matchExpressions:
-                                  - key: beta.kubernetes.io/arch
+                                  - key: kubernetes.io/arch
                                     operator: In
                                     values:
                                         - amd64

--- a/chart/kube-arangodb/templates/deployment.yaml
+++ b/chart/kube-arangodb/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/arango-all.yaml
+++ b/manifests/arango-all.yaml
@@ -478,7 +478,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -500,7 +500,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/arango-backup.yaml
+++ b/manifests/arango-backup.yaml
@@ -144,7 +144,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -166,7 +166,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/arango-deployment-replication.yaml
+++ b/manifests/arango-deployment-replication.yaml
@@ -141,7 +141,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -163,7 +163,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/arango-deployment.yaml
+++ b/manifests/arango-deployment.yaml
@@ -185,7 +185,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -207,7 +207,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/arango-storage.yaml
+++ b/manifests/arango-storage.yaml
@@ -173,7 +173,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -195,7 +195,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/kustomize/all/arango-all.yaml
+++ b/manifests/kustomize/all/arango-all.yaml
@@ -478,7 +478,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -500,7 +500,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/kustomize/backup/arango-backup.yaml
+++ b/manifests/kustomize/backup/arango-backup.yaml
@@ -144,7 +144,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -166,7 +166,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/kustomize/deployment-replication/arango-deployment-replication.yaml
+++ b/manifests/kustomize/deployment-replication/arango-deployment-replication.yaml
@@ -141,7 +141,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -163,7 +163,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/kustomize/deployment/arango-deployment.yaml
+++ b/manifests/kustomize/deployment/arango-deployment.yaml
@@ -185,7 +185,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -207,7 +207,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/manifests/kustomize/storage/arango-storage.yaml
+++ b/manifests/kustomize/storage/arango-storage.yaml
@@ -173,7 +173,7 @@ spec:
     replicas: 2
     strategy:
         type: Recreate
-        
+
     selector:
         matchLabels:
             app.kubernetes.io/name: kube-arangodb
@@ -195,7 +195,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                             - amd64

--- a/pkg/deployment/pod/affinity.go
+++ b/pkg/deployment/pod/affinity.go
@@ -59,7 +59,7 @@ func AppendNodeSelector(a *core.NodeAffinity) {
 	a.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(a.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, core.NodeSelectorTerm{
 		MatchExpressions: []core.NodeSelectorRequirement{
 			{
-				Key:      "beta.kubernetes.io/arch",
+				Key:      "kubernetes.io/arch",
 				Operator: "In",
 				Values:   []string{"amd64"},
 			},

--- a/pkg/util/k8sutil/affinity.go
+++ b/pkg/util/k8sutil/affinity.go
@@ -38,7 +38,7 @@ func CreateAffinity(deploymentName, role string, required bool, affinityWithRole
 					{
 						MatchExpressions: []v1.NodeSelectorRequirement{
 							{
-								Key:      "beta.kubernetes.io/arch",
+								Key:      "kubernetes.io/arch",
 								Operator: "In",
 								Values:   []string{"amd64"},
 							},

--- a/pkg/util/k8sutil/affinity_test.go
+++ b/pkg/util/k8sutil/affinity_test.go
@@ -38,7 +38,7 @@ func TestCreateAffinity(t *testing.T) {
 				{
 					MatchExpressions: []v1.NodeSelectorRequirement{
 						{
-							Key:      "beta.kubernetes.io/arch",
+							Key:      "kubernetes.io/arch",
 							Operator: "In",
 							Values:   []string{"amd64"},
 						},


### PR DESCRIPTION
Closes #751

This commit updates all references to `beta.kubernetes.io/arch` with `kubernetes.io/arch`. The `beta` prefixed
label is [deprecated](https://kubernetes.io/docs/reference/labels-annotations-taints/#beta-kubernetes-io-arch-deprecated) and causes issues when trying to deploy onto a GKE autopilot cluster which maintains strict rules around which node labels can be used for affinity.

Signed-off-by: David Bond <davidsbond93@gmail.com>