### PR TITLE
Enable metrics exporter to work without authorization

### DIFF
--- a/pkg/deployment/resources/exporter.go
+++ b/pkg/deployment/resources/exporter.go
@@ -62,10 +62,12 @@ func ArangodbExporterContainer(image string, args []string, livenessProbe *probe
 }
 
 func createInternalExporterArgs(spec api.DeploymentSpec, groupSpec api.ServerGroupSpec, version driver.Version) []string {
-	tokenpath := filepath.Join(k8sutil.ExporterJWTVolumeMountDir, constants.SecretKeyToken)
 	options := k8sutil.CreateOptionPairs(64)
 
-	options.Add("--arangodb.jwt-file", tokenpath)
+	if spec.Authentication.IsAuthenticated() && spec.Metrics.GetJWTTokenSecretName() != "" {
+		tokenpath := filepath.Join(k8sutil.ExporterJWTVolumeMountDir, constants.SecretKeyToken)
+		options.Add("--arangodb.jwt-file", tokenpath)
+	}
 
 	path := k8sutil.ArangoExporterInternalEndpoint
 	if version.CompareTo("3.8.0") >= 0 {


### PR DESCRIPTION
Before it metrics require arangodb jwt token authorization
Now authorization is not necessary for metrics exporter