### PR TITLE
[Refactor] Init pod creator with an error

### DIFF
--- a/pkg/deployment/images.go
+++ b/pkg/deployment/images.go
@@ -225,7 +225,7 @@ func (ib *imagesBuilder) fetchArangoDBImageIDAndVersion(ctx context.Context, cac
 		},
 	}
 
-	pod, err = resources.RenderArangoPod(cachedStatus, ib.APIObject, role, id, podName, &imagePod)
+	pod, err = resources.RenderArangoPod(ctx, cachedStatus, ib.APIObject, role, id, podName, &imagePod)
 	if err != nil {
 		log.Debug().Err(err).Msg("Failed to render image ID pod")
 		return true, errors.WithStack(err)
@@ -259,10 +259,12 @@ func (i *ImageUpdatePod) GetRole() string {
 	return "id"
 }
 
-func (i *ImageUpdatePod) Init(pod *core.Pod) {
+func (i *ImageUpdatePod) Init(_ context.Context, _ interfaces.Inspector, pod *core.Pod) error {
 	terminationGracePeriodSeconds := int64((time.Second * 30).Seconds())
 	pod.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 	pod.Spec.PriorityClassName = i.spec.ID.Get().PriorityClassName
+
+	return nil
 }
 
 func (i *ImageUpdatePod) GetImagePullSecrets() []string {

--- a/pkg/deployment/resources/pod_creator.go
+++ b/pkg/deployment/resources/pod_creator.go
@@ -348,7 +348,7 @@ func (r *Resources) RenderPodForMember(ctx context.Context, cachedStatus inspect
 		// Prepare arguments
 		autoUpgrade := newMember.Conditions.IsTrue(api.ConditionTypeAutoUpgrade) || spec.Upgrade.Get().AutoUpgrade
 
-		memberPod := MemberArangoDPod{
+		podCreator = &MemberArangoDPod{
 			status:           *newMember,
 			groupSpec:        groupSpec,
 			spec:             spec,
@@ -361,11 +361,6 @@ func (r *Resources) RenderPodForMember(ctx context.Context, cachedStatus inspect
 			arangoMember:     *member,
 			cachedStatus:     cachedStatus,
 		}
-
-		if err := memberPod.Validate(cachedStatus); err != nil {
-			return nil, errors.WithStack(errors.Wrapf(err, "Validation of pods resources failed"))
-		}
-		podCreator = &memberPod
 	} else if group.IsArangosync() {
 		// Check image
 		if !imageInfo.Enterprise {
@@ -378,67 +373,21 @@ func (r *Resources) RenderPodForMember(ctx context.Context, cachedStatus inspect
 			imageInfo.Image = spec.Sync.GetSyncImage()
 		}
 
-		var tlsKeyfileSecretName, clientAuthCASecretName, masterJWTSecretName, clusterJWTSecretName string
-		// Check master JWT secret
-
-		masterJWTSecretName = spec.Sync.Authentication.GetJWTSecretName()
-		err := k8sutil.RunWithTimeout(ctx, func(ctxChild context.Context) error {
-			return k8sutil.ValidateTokenSecret(ctxChild, cachedStatus.SecretReadInterface(), masterJWTSecretName)
-		})
-		if err != nil {
-			return nil, errors.WithStack(errors.Wrapf(err, "Master JWT secret validation failed"))
-		}
-
-		monitoringTokenSecretName := spec.Sync.Monitoring.GetTokenSecretName()
-		err = k8sutil.RunWithTimeout(ctx, func(ctxChild context.Context) error {
-			return k8sutil.ValidateTokenSecret(ctxChild, cachedStatus.SecretReadInterface(), monitoringTokenSecretName)
-		})
-		if err != nil {
-			return nil, errors.WithStack(errors.Wrapf(err, "Monitoring token secret validation failed"))
-		}
-
-		if group == api.ServerGroupSyncMasters {
-			// Create TLS secret
-			tlsKeyfileSecretName = k8sutil.CreateTLSKeyfileSecretName(apiObject.GetName(), role, newMember.ID)
-			// Check cluster JWT secret
-			if spec.IsAuthenticated() {
-				clusterJWTSecretName = spec.Authentication.GetJWTSecretName()
-				err = k8sutil.RunWithTimeout(ctx, func(ctxChild context.Context) error {
-					return k8sutil.ValidateTokenSecret(ctxChild, cachedStatus.SecretReadInterface(), clusterJWTSecretName)
-				})
-				if err != nil {
-					return nil, errors.WithStack(errors.Wrapf(err, "Cluster JWT secret validation failed"))
-				}
-			}
-			// Check client-auth CA certificate secret
-			clientAuthCASecretName = spec.Sync.Authentication.GetClientCASecretName()
-			err = k8sutil.RunWithTimeout(ctx, func(ctxChild context.Context) error {
-				return k8sutil.ValidateCACertificateSecret(ctxChild, cachedStatus.SecretReadInterface(), clientAuthCASecretName)
-			})
-			if err != nil {
-				return nil, errors.WithStack(errors.Wrapf(err, "Client authentication CA certificate secret validation failed"))
-			}
-		}
-
 		podCreator = &MemberSyncPod{
-			tlsKeyfileSecretName:   tlsKeyfileSecretName,
-			clientAuthCASecretName: clientAuthCASecretName,
-			masterJWTSecretName:    masterJWTSecretName,
-			clusterJWTSecretName:   clusterJWTSecretName,
-			groupSpec:              groupSpec,
-			spec:                   spec,
-			group:                  group,
-			resources:              r,
-			imageInfo:              imageInfo,
-			arangoMember:           *member,
-			apiObject:              apiObject,
-			memberStatus:           *newMember,
+			groupSpec:    groupSpec,
+			spec:         spec,
+			group:        group,
+			resources:    r,
+			imageInfo:    imageInfo,
+			arangoMember: *member,
+			apiObject:    apiObject,
+			memberStatus: *newMember,
 		}
 	} else {
 		return nil, errors.Newf("unable to render Pod")
 	}
 
-	pod, err := RenderArangoPod(cachedStatus, apiObject, role, newMember.ID, newMember.PodName, podCreator)
+	pod, err := RenderArangoPod(ctx, cachedStatus, apiObject, role, newMember.ID, newMember.PodName, podCreator)
 	if err != nil {
 		return nil, err
 	}
@@ -625,10 +574,15 @@ func (r *Resources) createPodForMember(ctx context.Context, cachedStatus inspect
 }
 
 // RenderArangoPod renders new ArangoD Pod
-func RenderArangoPod(cachedStatus inspectorInterface.Inspector, deployment k8sutil.APIObject, role, id, podName string,
-	podCreator interfaces.PodCreator) (*core.Pod, error) {
+func RenderArangoPod(ctx context.Context, cachedStatus inspectorInterface.Inspector, deployment k8sutil.APIObject,
+	role, id, podName string, podCreator interfaces.PodCreator) (*core.Pod, error) {
 
-	// Prepare basic pod
+	// Validate if the pod can be created.
+	if err := podCreator.Validate(cachedStatus); err != nil {
+		return nil, errors.Wrapf(err, "Validation of pods resources failed")
+	}
+
+	// Prepare basic pod.
 	p := k8sutil.NewPod(deployment.GetName(), role, id, podName, podCreator)
 
 	for k, v := range podCreator.Annotations() {
@@ -647,7 +601,9 @@ func RenderArangoPod(cachedStatus inspectorInterface.Inspector, deployment k8sut
 		p.Labels[k] = v
 	}
 
-	podCreator.Init(&p)
+	if err := podCreator.Init(ctx, cachedStatus, &p); err != nil {
+		return nil, errors.Wrapf(err, "failed to init the pod")
+	}
 
 	if initContainers, err := podCreator.GetInitContainers(cachedStatus); err != nil {
 		return nil, errors.WithStack(err)

--- a/pkg/deployment/resources/pod_creator.go
+++ b/pkg/deployment/resources/pod_creator.go
@@ -602,7 +602,7 @@ func RenderArangoPod(ctx context.Context, cachedStatus inspectorInterface.Inspec
 	}
 
 	if err := podCreator.Init(ctx, cachedStatus, &p); err != nil {
-		return nil, errors.Wrapf(err, "failed to init the pod")
+		return nil, err
 	}
 
 	if initContainers, err := podCreator.GetInitContainers(cachedStatus); err != nil {

--- a/pkg/deployment/resources/pod_creator_arangod.go
+++ b/pkg/deployment/resources/pod_creator_arangod.go
@@ -23,6 +23,7 @@
 package resources
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -252,10 +253,12 @@ func (m *MemberArangoDPod) AsInput() pod.Input {
 	}
 }
 
-func (m *MemberArangoDPod) Init(pod *core.Pod) {
+func (m *MemberArangoDPod) Init(_ context.Context, _ interfaces.Inspector, pod *core.Pod) error {
 	terminationGracePeriodSeconds := int64(math.Ceil(m.group.DefaultTerminationGracePeriod().Seconds()))
 	pod.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
 	pod.Spec.PriorityClassName = m.groupSpec.PriorityClassName
+
+	return nil
 }
 
 func (m *MemberArangoDPod) Validate(cachedStatus interfaces.Inspector) error {

--- a/pkg/deployment/resources/pod_creator_sync.go
+++ b/pkg/deployment/resources/pod_creator_sync.go
@@ -312,7 +312,7 @@ func (m *MemberSyncPod) Init(ctx context.Context, cachedStatus interfaces.Inspec
 		return k8sutil.ValidateTokenSecret(ctxChild, cachedStatus.SecretReadInterface(), m.masterJWTSecretName)
 	})
 	if err != nil {
-		return errors.Wrapf(err, "ArangoSync master JWT secret validation failed")
+		return errors.Wrapf(err, "Master JWT secret validation failed")
 	}
 
 	monitoringTokenSecretName := m.spec.Sync.Monitoring.GetTokenSecretName()
@@ -320,7 +320,7 @@ func (m *MemberSyncPod) Init(ctx context.Context, cachedStatus interfaces.Inspec
 		return k8sutil.ValidateTokenSecret(ctxChild, cachedStatus.SecretReadInterface(), monitoringTokenSecretName)
 	})
 	if err != nil {
-		return errors.Wrapf(err, "ArangoSync monitoring token secret validation failed")
+		return errors.Wrapf(err, "Monitoring token secret validation failed")
 	}
 
 	if m.group == api.ServerGroupSyncMasters {
@@ -333,7 +333,7 @@ func (m *MemberSyncPod) Init(ctx context.Context, cachedStatus interfaces.Inspec
 				return k8sutil.ValidateTokenSecret(ctxChild, cachedStatus.SecretReadInterface(), m.clusterJWTSecretName)
 			})
 			if err != nil {
-				return errors.Wrapf(err, "ArangoSync cluster JWT secret validation failed")
+				return errors.Wrapf(err, "Cluster JWT secret validation failed")
 			}
 		}
 		// Check client-auth CA certificate secret
@@ -342,7 +342,7 @@ func (m *MemberSyncPod) Init(ctx context.Context, cachedStatus interfaces.Inspec
 			return k8sutil.ValidateCACertificateSecret(ctxChild, cachedStatus.SecretReadInterface(), m.clientAuthCASecretName)
 		})
 		if err != nil {
-			return errors.Wrapf(err, "ArangoSync client authentication CA certificate secret validation failed")
+			return errors.Wrapf(err, "Client authentication CA certificate secret validation failed")
 		}
 	}
 

--- a/pkg/util/k8sutil/interfaces/pod_creator.go
+++ b/pkg/util/k8sutil/interfaces/pod_creator.go
@@ -23,6 +23,8 @@
 package interfaces
 
 import (
+	"context"
+
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/secret"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/service"
 	core "k8s.io/api/core/v1"
@@ -38,7 +40,7 @@ type PodModifier interface {
 }
 
 type PodCreator interface {
-	Init(*core.Pod)
+	Init(context.Context, Inspector, *core.Pod) error
 	GetName() string
 	GetRole() string
 	GetVolumes() []core.Volume


### PR DESCRIPTION
This PR will help to use the function:
```
func (m *MemberArangoDPod) Init(_ context.Context, _ interfaces.Inspector, pod *core.Pod) error {
```
in the future to recognize if the worker sidecar can be created together with the DB server