### PR TITLE
[bugfix] Fix golangci-lint tool local installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ init: tools update-generated $(BIN) vendor
 .PHONY: tools
 tools: update-vendor
 	@echo ">> Fetching golangci-lint linter"
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+	@GOBIN=$(GOPATH)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 	@echo ">> Fetching goimports"
 	@GOBIN=$(GOPATH)/bin go install golang.org/x/tools/cmd/goimports@0bb7e5c47b1a31f85d4f173edc878a8e049764a5
 	@echo ">> Fetching license check"


### PR DESCRIPTION
It was installing globally instead of installing into .gobuild subdir.

The problem was introduced here: https://github.com/arangodb/kube-arangodb/commit/071c837f2bc6111ade71efd17afb457a199659b0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L394