### PR TITLE
Remove unsafe removal of $ORGDIR from system $GOPATH/src dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,6 @@ update-vendor:
 
 .PHONY: update-generated
 update-generated:
-	@rm -fr $(ORGDIR)
-	@mkdir -p $(ORGDIR)
-	@ln -s -f $(SCRIPTDIR) $(ORGDIR)/kube-arangodb
 	GOPATH=$(GOBUILDDIR) $(VENDORDIR)/k8s.io/code-generator/generate-groups.sh  \
 			"all" \
 			"github.com/arangodb/kube-arangodb/pkg/generated" \


### PR DESCRIPTION
The problem:
if you have any changes under `$GOPATH/src/github.com/arangodb`  you will lose all data and history if you execute `make init` in kube-arangodb project.

These commands actually seems to be unnecessary. All generated files are under kube-arangodb directory.
I think the project should not modify external environment in such way.
