### PR TITLE
Fix construction of arangosync member endpoint URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
 - (Bugfix) Orphan PVC are not removed
+- (Bugfix) Fix ArangoSync member endpoint URLs used by operator
 
 ## [1.2.10](https://github.com/arangodb/kube-arangodb/tree/1.2.10) (2022-04-27)
 - (Feature) Allow configuration for securityContext.runAsUser value

--- a/pkg/deployment/resources/pod_creator.go
+++ b/pkg/deployment/resources/pod_creator.go
@@ -192,7 +192,7 @@ func createArangoSyncArgs(apiObject meta.Object, spec api.DeploymentSpec, group 
 	groupSpec api.ServerGroupSpec, member api.MemberStatus) []string {
 	options := k8sutil.CreateOptionPairs(64)
 	var runCmd string
-	var port int
+	var port = GetServerGroupPort(group)
 
 	/*if config.DebugCluster {
 		options = append(options,
@@ -208,7 +208,6 @@ func createArangoSyncArgs(apiObject meta.Object, spec api.DeploymentSpec, group 
 	switch group {
 	case api.ServerGroupSyncMasters:
 		runCmd = "master"
-		port = shared.ArangoSyncMasterPort
 		masterEndpoint = spec.Sync.ExternalAccess.ResolveMasterEndpoint(k8sutil.CreateSyncMasterClientServiceDNSNameWithDomain(apiObject, spec.ClusterDomain), port)
 		keyPath := filepath.Join(shared.TLSKeyfileVolumeMountDir, constants.SecretTLSKeyfile)
 		clientCAPath := filepath.Join(shared.ClientAuthCAVolumeMountDir, constants.SecretCACertificate)
@@ -227,7 +226,6 @@ func createArangoSyncArgs(apiObject meta.Object, spec api.DeploymentSpec, group 
 		options.Addf("--cluster.endpoint", "%s://%s:%d", scheme, dbServiceName, shared.ArangoPort)
 	case api.ServerGroupSyncWorkers:
 		runCmd = "worker"
-		port = shared.ArangoSyncWorkerPort
 		masterEndpointHost := k8sutil.CreateSyncMasterClientServiceName(apiObject.GetName())
 		masterEndpoint = []string{"https://" + net.JoinHostPort(masterEndpointHost, strconv.Itoa(shared.ArangoSyncMasterPort))}
 	}

--- a/pkg/deployment/resources/service_port.go
+++ b/pkg/deployment/resources/service_port.go
@@ -1,0 +1,37 @@
+//
+// DISCLAIMER
+//
+// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package resources
+
+import (
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/apis/shared"
+)
+
+func GetServerGroupPort(group api.ServerGroup) int {
+	var targetPort = shared.ArangoPort
+	switch group {
+	case api.ServerGroupSyncMasters:
+		targetPort = shared.ArangoSyncMasterPort
+	case api.ServerGroupSyncWorkers:
+		targetPort = shared.ArangoSyncWorkerPort
+	}
+	return targetPort
+}


### PR DESCRIPTION
Some refactorings done to have single point truth for ServerGroup->service port mapping

Only the port is updated, the operator will still use incorrect endpoint in some cases.