### PR TITLE
Replace `beta.kubernetes.io/arch` to `kubernetes.io/arch` in charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - (Feature) (ACS) Improve Reconciliation Loop
 - (Bugfix) Allow missing Monitoring CRD
 - (Feature) (ACS) Add Resource plan
-- (Feature) Allow raw json value for license token-v2 
+- (Feature) Allow raw json value for license token-v2
+- (Update) Replace `beta.kubernetes.io/arch` to `kubernetes.io/arch` in Operator Chart
 
 ## [1.2.12](https://github.com/arangodb/kube-arangodb/tree/1.2.12) (2022-05-10)
 - (Feature) Add CoreV1 Endpoints Inspector

--- a/chart/arangodb-ingress-proxy/templates/deployment.yaml
+++ b/chart/arangodb-ingress-proxy/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
                     requiredDuringSchedulingIgnoredDuringExecution:
                         nodeSelectorTerms:
                             - matchExpressions:
-                                  - key: beta.kubernetes.io/arch
+                                  - key: kubernetes.io/arch
                                     operator: In
                                     values:
                                         - amd64

--- a/chart/kube-arangodb/templates/deployment.yaml
+++ b/chart/kube-arangodb/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                     - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
 {{- range .Values.operator.architectures }}


### PR DESCRIPTION
There is still a backward compatibility support for `beta.kubernetes.io/arch` in v1 and v2alpha APIs (architecture.go)