### PR TITLE
helm: disable arangolocalstorage crds when enableCRDManagement is false

### DIFF
--- a/chart/kube-arangodb/templates/storage-operator/crd.yaml
+++ b/chart/kube-arangodb/templates/storage-operator/crd.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.operator.features.storage -}}
+{{ if .Values.operator.enableCRDManagement -}}
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -29,4 +30,5 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
 
+{{- end }}
 {{- end }}


### PR DESCRIPTION
As a user of the operator, when I set `operator.enableCRDManagement` to false, I expected that the helm chart will not try to manage CRDs. However, if I set `operator.features.storage` to true, that enables CRD for that specific operator. This is causing conflicts for me because CRDs are defined cluster-wide, but I want to have the operator deployed into multiple namespaces.

This changes the behavior to only install the CRDs for the storage operator when both `operator.features.storage` is true _and_ `operator.enableCRDManagement` is true.

I do not see a test suite for the Helm charts in this repo, but feel free to point me at one if there is. I checked it locally with:

```shell
$ helm template . --set operator.features.storage=true | grep arangolocalstorages.storage.arangodb.com
    name: arangolocalstorages.storage.arangodb.com
$ helm template . --set operator.enableCRDManagement=false --set operator.features.storage=true | grep arangolocalstorages.storage.arangodb.com
```