### PR TITLE
[Feature] GT-40 Add 'crd install' subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - (Bugfix) Infinite loop fix in ArangoD AsyncClient
 - (Bugfix) Add Panic Handler
 - (Bugfix) Unify yaml packages
+- (Feature) Add 'crd install' subcommand
 
 ## [1.2.13](https://github.com/arangodb/kube-arangodb/tree/1.2.13) (2022-06-07)
 - (Bugfix) Fix arangosync members state inspection

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -289,7 +289,7 @@ func executeMain(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			crd.EnsureCRD(ctx, client)
+			_ = crd.EnsureCRD(ctx, client, true)
 		}
 
 		secrets := client.Kubernetes().CoreV1().Secrets(namespace)


### PR DESCRIPTION
The `EnsureCRD` implementation was slightly adjusted to return error if requested, so the command can exit with 1 if the problem occurs.