### PR TITLE
GT-137 image validation for AMD64 arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - (Dependencies) Bump K8S Dependencies to 1.22.15
 - (Bugfix) Unlock broken inspectors
 - (Debug) Allow to send package to stdout
+- (Improvement) ArangoDB image validation (=>3.10) for ARM64 architecture
 
 ## [1.2.20](https://github.com/arangodb/kube-arangodb/tree/1.2.20) (2022-10-25)
 - (Feature) Add action progress

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ ifndef KEEP_GOPATH
 endif
 
 GOBUILDARGS ?=
-GOVERSION := 1.17-alpine3.15
+GOBASEVERSION := 1.17
+GOVERSION := $(GOBASEVERSION)-alpine3.15
 DISTRIBUTION := alpine:3.15
 
 PULSAR := $(GOBUILDDIR)/bin/pulsar$(shell go env GOEXE)
@@ -482,7 +483,7 @@ patch-chart:
 
 .PHONY: tidy
 tidy:
-	@go mod tidy
+	@go mod tidy -compat=$(GOBASEVERSION)
 
 .PHONY: deps-reload
 deps-reload: tidy init

--- a/pkg/apis/deployment/v1/conditions.go
+++ b/pkg/apis/deployment/v1/conditions.go
@@ -78,6 +78,8 @@ const (
 	ConditionTypeUpgradeFailed ConditionType = "UpgradeFailed"
 	// ConditionTypeArchitectureMismatch indicates that the member has a different architecture than the deployment.
 	ConditionTypeArchitectureMismatch ConditionType = "ArchitectureMismatch"
+	// ConditionTypeArchitectureARM64CannotBeApplied indicates that the member has a different architecture than the requested one.
+	ConditionTypeArchitectureARM64CannotBeApplied ConditionType = "ArchitectureARM64CannotBeApplied"
 
 	// ConditionTypeMemberMaintenanceMode indicates that Maintenance is enabled on particular member
 	ConditionTypeMemberMaintenanceMode ConditionType = "MemberMaintenanceMode"

--- a/pkg/apis/deployment/v1/conditions.go
+++ b/pkg/apis/deployment/v1/conditions.go
@@ -78,8 +78,8 @@ const (
 	ConditionTypeUpgradeFailed ConditionType = "UpgradeFailed"
 	// ConditionTypeArchitectureMismatch indicates that the member has a different architecture than the deployment.
 	ConditionTypeArchitectureMismatch ConditionType = "ArchitectureMismatch"
-	// ConditionTypeArchitectureARM64CannotBeApplied indicates that the member has a different architecture than the requested one.
-	ConditionTypeArchitectureARM64CannotBeApplied ConditionType = "ArchitectureARM64CannotBeApplied"
+	// ConditionTypeArchitectureChangeCannotBeApplied indicates that the member has a different architecture than the requested one.
+	ConditionTypeArchitectureChangeCannotBeApplied ConditionType = "ArchitectureChangeCannotBeApplied"
 
 	// ConditionTypeMemberMaintenanceMode indicates that Maintenance is enabled on particular member
 	ConditionTypeMemberMaintenanceMode ConditionType = "MemberMaintenanceMode"

--- a/pkg/deployment/member/phase_updates.go
+++ b/pkg/deployment/member/phase_updates.go
@@ -103,6 +103,7 @@ func removeMemberConditionsMapFunc(m *api.MemberStatus) {
 	m.Conditions.Remove(api.MemberReplacementRequired)
 	m.Conditions.Remove(api.ConditionTypePVCResizePending)
 	m.Conditions.Remove(api.ConditionTypeArchitectureMismatch)
+	m.Conditions.Remove(api.ConditionTypeArchitectureARM64CannotBeApplied)
 
 	m.RemoveTerminationsBefore(time.Now().Add(-1 * recentTerminationsKeepPeriod))
 

--- a/pkg/deployment/member/phase_updates.go
+++ b/pkg/deployment/member/phase_updates.go
@@ -103,7 +103,7 @@ func removeMemberConditionsMapFunc(m *api.MemberStatus) {
 	m.Conditions.Remove(api.MemberReplacementRequired)
 	m.Conditions.Remove(api.ConditionTypePVCResizePending)
 	m.Conditions.Remove(api.ConditionTypeArchitectureMismatch)
-	m.Conditions.Remove(api.ConditionTypeArchitectureARM64CannotBeApplied)
+	m.Conditions.Remove(api.ConditionTypeArchitectureChangeCannotBeApplied)
 
 	m.RemoveTerminationsBefore(time.Now().Add(-1 * recentTerminationsKeepPeriod))
 

--- a/pkg/deployment/members.go
+++ b/pkg/deployment/members.go
@@ -130,9 +130,9 @@ func (d *Deployment) renderMember(spec api.DeploymentSpec, status *api.Deploymen
 	role := group.AsRole()
 
 	arch := apiObject.GetAcceptedSpec().Architecture.GetDefault()
-	if arch == api.ArangoDeploymentArchitectureARM64 && apiObject.Status.CurrentImage.ArangoDBVersion.CompareTo("3.10.0") < 0 {
+	if arch != api.ArangoDeploymentArchitectureAMD64 && apiObject.Status.CurrentImage.ArangoDBVersion.CompareTo("3.10.0") < 0 {
 		arch = api.ArangoDeploymentArchitectureAMD64
-		d.log.Str("arch", id).Warn("Cannot render pod with ARM64 arch. It's not supported in ArangoDB < 3.10.0. Defaulting architecture to AMD64")
+		d.log.Str("arch", string(arch)).Warn("Cannot render pod with requested arch. It's not supported in ArangoDB < 3.10.0. Defaulting architecture to AMD64")
 		d.CreateEvent(k8sutil.NewCannotSetArchitectureARM64Event(d.GetAPIObject(), id))
 	}
 

--- a/pkg/deployment/members.go
+++ b/pkg/deployment/members.go
@@ -133,7 +133,7 @@ func (d *Deployment) renderMember(spec api.DeploymentSpec, status *api.Deploymen
 	if arch != api.ArangoDeploymentArchitectureAMD64 && apiObject.Status.CurrentImage.ArangoDBVersion.CompareTo("3.10.0") < 0 {
 		arch = api.ArangoDeploymentArchitectureAMD64
 		d.log.Str("arch", string(arch)).Warn("Cannot render pod with requested arch. It's not supported in ArangoDB < 3.10.0. Defaulting architecture to AMD64")
-		d.CreateEvent(k8sutil.NewCannotSetArchitectureARM64Event(d.GetAPIObject(), id))
+		d.CreateEvent(k8sutil.NewCannotSetArchitectureEvent(d.GetAPIObject(), string(arch), id))
 	}
 
 	switch group {

--- a/pkg/deployment/members.go
+++ b/pkg/deployment/members.go
@@ -30,6 +30,7 @@ import (
 	"github.com/arangodb/kube-arangodb/pkg/apis/shared"
 	"github.com/arangodb/kube-arangodb/pkg/deployment/reconcile"
 	"github.com/arangodb/kube-arangodb/pkg/util/errors"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil"
 )
 
 func (d *Deployment) createAgencyMapping(ctx context.Context) error {
@@ -127,7 +128,13 @@ func (d *Deployment) renderMember(spec api.DeploymentSpec, status *api.Deploymen
 	}
 	deploymentName := apiObject.GetName()
 	role := group.AsRole()
+
 	arch := apiObject.GetAcceptedSpec().Architecture.GetDefault()
+	if arch == api.ArangoDeploymentArchitectureARM64 && apiObject.Status.CurrentImage.ArangoDBVersion.CompareTo("3.10.0") < 0 {
+		arch = api.ArangoDeploymentArchitectureAMD64
+		d.log.Str("arch", id).Warn("Cannot render pod with ARM64 arch. It's not supported in ArangoDB < 3.10.0. Defaulting architecture to AMD64")
+		d.CreateEvent(k8sutil.NewCannotSetArchitectureARM64Event(d.GetAPIObject(), id))
+	}
 
 	switch group {
 	case api.ServerGroupSingle:

--- a/pkg/deployment/reconcile/plan_builder_context.go
+++ b/pkg/deployment/reconcile/plan_builder_context.go
@@ -32,6 +32,8 @@ import (
 
 // PlanBuilderContext contains context methods provided to plan builders.
 type PlanBuilderContext interface {
+	reconciler.DeploymentStatusUpdate
+
 	reconciler.DeploymentInfoGetter
 	reconciler.DeploymentAgencyMaintenance
 	reconciler.ArangoMemberContext

--- a/pkg/deployment/reconcile/plan_builder_rotate_arch.go
+++ b/pkg/deployment/reconcile/plan_builder_rotate_arch.go
@@ -22,6 +22,7 @@ package reconcile
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/arangodb/kube-arangodb/pkg/apis/deployment"
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
@@ -49,7 +50,7 @@ func (r *Reconciler) createChangeMemberArchPlan(ctx context.Context,
 				if archToApply.IsArchMismatch(spec.Architecture, member.Architecture) {
 					if archToApply != api.ArangoDeploymentArchitectureAMD64 && status.CurrentImage.ArangoDBVersion.CompareTo("3.10.0") < 0 {
 						if member.Conditions.Update(api.ConditionTypeArchitectureChangeCannotBeApplied, true,
-							"Member has ArangoDB in version which not supports Architecture change", "") {
+							fmt.Sprintf("Member has ArangoDB in version which not supports Architecture change (%s)", archToApply), "") {
 							r.log.Warn("Cannot apply 'arch' annotation changes. It's not supported in ArangoDB < 3.10.0")
 							context.CreateEvent(k8sutil.NewCannotSetArchitectureARM64Event(apiObject, member.ID))
 							context.CreateEvent(k8sutil.NewCannotSetArchitectureARM64Event(pod, member.ID))

--- a/pkg/deployment/reconcile/plan_builder_rotate_arch.go
+++ b/pkg/deployment/reconcile/plan_builder_rotate_arch.go
@@ -52,8 +52,8 @@ func (r *Reconciler) createChangeMemberArchPlan(ctx context.Context,
 						if member.Conditions.Update(api.ConditionTypeArchitectureChangeCannotBeApplied, true,
 							fmt.Sprintf("Member has ArangoDB in version which not supports Architecture change (%s)", archToApply), "") {
 							r.log.Warn("Cannot apply 'arch' annotation changes. It's not supported in ArangoDB < 3.10.0")
-							context.CreateEvent(k8sutil.NewCannotSetArchitectureARM64Event(apiObject, member.ID))
-							context.CreateEvent(k8sutil.NewCannotSetArchitectureARM64Event(pod, member.ID))
+							context.CreateEvent(k8sutil.NewCannotSetArchitectureEvent(apiObject, string(archToApply), member.ID))
+							context.CreateEvent(k8sutil.NewCannotSetArchitectureEvent(pod, string(archToApply), member.ID))
 
 							if err := context.UpdateMember(ctx, member); err != nil {
 								r.log.Error("Can not save member condition", member.ID, api.ConditionTypeArchitectureChangeCannotBeApplied, err)

--- a/pkg/util/k8sutil/events.go
+++ b/pkg/util/k8sutil/events.go
@@ -284,11 +284,11 @@ func NewOperatorEngineOpsAlertEvent(reason string, apiObject APIObject) *Event {
 	return event
 }
 
-// NewCannotSetArchitectureARM64Event creates an even of type CannotSetArchitectureARM64.
-func NewCannotSetArchitectureARM64Event(apiObject runtime.Object, memberId string) *Event {
+// NewCannotSetArchitectureEvent creates an even of type CannotSetArchitectureEvent.
+func NewCannotSetArchitectureEvent(apiObject runtime.Object, arch, memberId string) *Event {
 	event := newDeploymentEvent(apiObject)
 	event.Type = core.EventTypeWarning
-	event.Reason = "Can not set architecture ARM64"
-	event.Message = fmt.Sprintf("Can not apply ARM64 arch for member %s. It is not supported for ArangoDB < 3.10.0", memberId)
+	event.Reason = "Can not set architecture"
+	event.Message = fmt.Sprintf("Can not apply %s arch for member %s. It is not supported in current ArangoDB version", arch, memberId)
 	return event
 }

--- a/pkg/util/k8sutil/events.go
+++ b/pkg/util/k8sutil/events.go
@@ -283,3 +283,12 @@ func NewOperatorEngineOpsAlertEvent(reason string, apiObject APIObject) *Event {
 	event.Message = fmt.Sprintf("Event OperatorEngineOpsAlert raised, investigation needed: %s", reason)
 	return event
 }
+
+// NewCannotSetArchitectureARM64Event creates an even of type CannotSetArchitectureARM64.
+func NewCannotSetArchitectureARM64Event(apiObject runtime.Object, memberId string) *Event {
+	event := newDeploymentEvent(apiObject)
+	event.Type = core.EventTypeWarning
+	event.Reason = "Can not set architecture ARM64"
+	event.Message = fmt.Sprintf("Can not apply ARM64 arch for member %s. It is not supported for ArangoDB < 3.10.0", memberId)
+	return event
+}


### PR DESCRIPTION
This validation handles two cases:
1. `arch` annotation - we will not let the change arch in member if ArangoDB image is below 3.10
2. member creation - we will change the member arch to the AMD64 if ArangoDB image is below 3.10