### PR TITLE
Don't serialize and deprecate two DeploymentReplicationStatus fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - (Improvement) Use inspector for ArangoMember
 - (DebugPackage) Collect logs from pods
 - (Bugfix) Move Agency CommitIndex log message to Trace
+- (Improvement) Don't serialize and deprecate two DeploymentReplicationStatus fields
 
 ## [1.2.20](https://github.com/arangodb/kube-arangodb/tree/1.2.20) (2022-10-25)
 - (Feature) Add action progress

--- a/pkg/apis/replication/v1/collection_status.go
+++ b/pkg/apis/replication/v1/collection_status.go
@@ -21,6 +21,7 @@
 package v1
 
 // CollectionStatus contains the status of a single collection.
+// Deprecated
 type CollectionStatus struct {
 	// Name of the collection
 	Name string `json:"name"`

--- a/pkg/apis/replication/v1/database_status.go
+++ b/pkg/apis/replication/v1/database_status.go
@@ -21,6 +21,7 @@
 package v1
 
 // DatabaseStatus contains the status of a single database.
+// Deprecated
 type DatabaseStatus struct {
 	// Name of the database
 	Name string `json:"name"`

--- a/pkg/apis/replication/v1/endpoint_status.go
+++ b/pkg/apis/replication/v1/endpoint_status.go
@@ -21,6 +21,7 @@
 package v1
 
 // EndpointStatus contains the status of either the source or destination endpoint.
+// Deprecated
 type EndpointStatus struct {
 	// Databases holds the replication status of all databases from the point of view of this endpoint.
 	// List is ordered by name of the database.

--- a/pkg/apis/replication/v1/replication_status.go
+++ b/pkg/apis/replication/v1/replication_status.go
@@ -31,8 +31,11 @@ type DeploymentReplicationStatus struct {
 	// Conditions specific to the entire deployment replication
 	Conditions ConditionList `json:"conditions,omitempty"`
 
+	// Deprecated: this field will be removed in future versions
 	// Source contains the detailed status of the source endpoint
 	Source EndpointStatus `json:"source"`
+
+	// Deprecated: this field will be removed in future versions
 	// Destination contains the detailed status of the destination endpoint
 	Destination EndpointStatus `json:"destination"`
 

--- a/pkg/apis/replication/v1/shard_status.go
+++ b/pkg/apis/replication/v1/shard_status.go
@@ -21,6 +21,7 @@
 package v1
 
 // ShardStatus contains the status of a single shard.
+// Deprecated
 type ShardStatus struct {
 	Status string `json:"status"`
 }

--- a/pkg/apis/replication/v2alpha1/collection_status.go
+++ b/pkg/apis/replication/v2alpha1/collection_status.go
@@ -21,6 +21,7 @@
 package v2alpha1
 
 // CollectionStatus contains the status of a single collection.
+// Deprecated
 type CollectionStatus struct {
 	// Name of the collection
 	Name string `json:"name"`

--- a/pkg/apis/replication/v2alpha1/database_status.go
+++ b/pkg/apis/replication/v2alpha1/database_status.go
@@ -21,6 +21,7 @@
 package v2alpha1
 
 // DatabaseStatus contains the status of a single database.
+// Deprecated
 type DatabaseStatus struct {
 	// Name of the database
 	Name string `json:"name"`

--- a/pkg/apis/replication/v2alpha1/endpoint_status.go
+++ b/pkg/apis/replication/v2alpha1/endpoint_status.go
@@ -21,6 +21,7 @@
 package v2alpha1
 
 // EndpointStatus contains the status of either the source or destination endpoint.
+// Deprecated
 type EndpointStatus struct {
 	// Databases holds the replication status of all databases from the point of view of this endpoint.
 	// List is ordered by name of the database.

--- a/pkg/apis/replication/v2alpha1/replication_status.go
+++ b/pkg/apis/replication/v2alpha1/replication_status.go
@@ -31,8 +31,11 @@ type DeploymentReplicationStatus struct {
 	// Conditions specific to the entire deployment replication
 	Conditions ConditionList `json:"conditions,omitempty"`
 
+	// Deprecated: this field will be removed in future versions
 	// Source contains the detailed status of the source endpoint
 	Source EndpointStatus `json:"source"`
+
+	// Deprecated: this field will be removed in future versions
 	// Destination contains the detailed status of the destination endpoint
 	Destination EndpointStatus `json:"destination"`
 

--- a/pkg/apis/replication/v2alpha1/shard_status.go
+++ b/pkg/apis/replication/v2alpha1/shard_status.go
@@ -21,6 +21,7 @@
 package v2alpha1
 
 // ShardStatus contains the status of a single shard.
+// Deprecated
 type ShardStatus struct {
 	Status string `json:"status"`
 }


### PR DESCRIPTION
These two fields might be too big - exceeding k8s limits. e.g. one of customers has 10k shards - there will be at least about `10000*2*50=1MB` of data