### PR TITLE
[Bugfix] Move Agency CommitIndex log message to Trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - (Improvement) ArangoDB image validation (=>3.10) for ARM64 architecture
 - (Improvement) Use inspector for ArangoMember
 - (DebugPackage) Collect logs from pods
+- (Bugfix) Move Agency CommitIndex log message to Trace
 
 ## [1.2.20](https://github.com/arangodb/kube-arangodb/tree/1.2.20) (2022-10-25)
 - (Feature) Add action progress

--- a/pkg/deployment/agency/cache.go
+++ b/pkg/deployment/agency/cache.go
@@ -336,12 +336,14 @@ func (c *cache) getLeader(ctx context.Context, size int, clients map[string]agen
 			}
 		}
 	}
+
 	if err := h.Serving(); err != nil {
 		c.log.Err(err).Warn("Agency Not serving")
 		return nil, nil, h, err
 	}
+
 	if err := h.Healthy(); err != nil {
-		c.log.Err(err).Debug("Agency Not healthy")
+		c.log.Err(err).Trace("Agency Not healthy")
 	}
 
 	for id := range names {


### PR DESCRIPTION
Covers: https://github.com/arangodb/kube-arangodb/issues/1174