### PR TITLE
[Improvement] GT-228 Add new field to CR for more precise calculation of DC2DC replication progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - (Improvement) Change Operator default ReplicasCount to 1
 - (Maintenance) Change MD content injection method
 - (Maintenance) Generate README Platforms
+- (Improvement) Add new field to CR for more precise calculation of DC2DC replication progress
 
 ## [1.2.24](https://github.com/arangodb/kube-arangodb/tree/1.2.24) (2023-01-25)
 - (Bugfix) Fix deployment creation on ARM64

--- a/pkg/apis/replication/v1/database_synchronization_status.go
+++ b/pkg/apis/replication/v1/database_synchronization_status.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@ package v1
 
 // DatabaseSynchronizationStatus contains the synchronization status of replication for database
 type DatabaseSynchronizationStatus struct {
+	// Deprecated
 	// ShardsTotal shows how many shards are expected to be in-sync
 	ShardsTotal int `json:"shards-total"`
+	// Deprecated
 	// ShardsInSync shows how many shards are already in-sync
 	ShardsInSync int `json:"shards-in-sync"`
 	// Errors contains a list of errors if there were unexpected errors during synchronization

--- a/pkg/apis/replication/v1/synchronization_status.go
+++ b/pkg/apis/replication/v1/synchronization_status.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ package v1
 type SynchronizationStatus struct {
 	// Databases holds the synchronization status for each database.
 	Databases map[string]DatabaseSynchronizationStatus `json:"databases,omitempty"`
-	// AllInSync is true if all shards listed in 'databases' are in sync
-	AllInSync bool   `json:"allInSync,omitempty"`
-	Error     string `json:"error,omitempty"`
+	// Progress the value in percents showing the progress of synchronization
+	Progress float32 `json:"progress,omitempty"`
+	// AllInSync is true if target cluster is fully in-sync with source cluster
+	AllInSync bool `json:"allInSync,omitempty"`
+	// Error contains an error description if there is an error preventing synchronization
+	Error string `json:"error,omitempty"`
 }

--- a/pkg/apis/replication/v2alpha1/database_synchronization_status.go
+++ b/pkg/apis/replication/v2alpha1/database_synchronization_status.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@ package v2alpha1
 
 // DatabaseSynchronizationStatus contains the synchronization status of replication for database
 type DatabaseSynchronizationStatus struct {
+	// Deprecated
 	// ShardsTotal shows how many shards are expected to be in-sync
 	ShardsTotal int `json:"shards-total"`
+	// Deprecated
 	// ShardsInSync shows how many shards are already in-sync
 	ShardsInSync int `json:"shards-in-sync"`
 	// Errors contains a list of errors if there were unexpected errors during synchronization

--- a/pkg/apis/replication/v2alpha1/synchronization_status.go
+++ b/pkg/apis/replication/v2alpha1/synchronization_status.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ package v2alpha1
 type SynchronizationStatus struct {
 	// Databases holds the synchronization status for each database.
 	Databases map[string]DatabaseSynchronizationStatus `json:"databases,omitempty"`
-	// AllInSync is true if all shards listed in 'databases' are in sync
-	AllInSync bool   `json:"allInSync,omitempty"`
-	Error     string `json:"error,omitempty"`
+	// Progress the value in percents showing the progress of synchronization
+	Progress float32 `json:"progress,omitempty"`
+	// AllInSync is true if target cluster is fully in-sync with source cluster
+	AllInSync bool `json:"allInSync,omitempty"`
+	// Error contains an error description if there is an error preventing synchronization
+	Error string `json:"error,omitempty"`
 }

--- a/pkg/replication/sync_inspector.go
+++ b/pkg/replication/sync_inspector.go
@@ -266,9 +266,12 @@ func (dr *DeploymentReplication) inspectIncomingSynchronizationStatus(destStatus
 		// can be zero for old versions of arangosync
 		totalShards = totalShardsFromStatus
 	}
-
+	progress := float32(0.0)
+	if shardsInSync > 0.0 {
+		progress = float32(totalShards) / float32(shardsInSync)
+	}
 	return api.SynchronizationStatus{
-		Progress:  float32(totalShards) / float32(shardsInSync),
+		Progress:  progress,
 		AllInSync: destStatus.Status == client.SyncStatusRunning,
 		Databases: dbs,
 		Error:     "",

--- a/pkg/replication/sync_inspector.go
+++ b/pkg/replication/sync_inspector.go
@@ -267,8 +267,8 @@ func (dr *DeploymentReplication) inspectIncomingSynchronizationStatus(destStatus
 		totalShards = totalShardsFromStatus
 	}
 	progress := float32(0.0)
-	if shardsInSync > 0.0 {
-		progress = float32(totalShards) / float32(shardsInSync)
+	if totalShards > 0 {
+		progress = float32(shardsInSync) / float32(totalShards)
 	}
 	return api.SynchronizationStatus{
 		Progress:  progress,


### PR DESCRIPTION
Deprecate `ShardsTotal` and `ShardsInSync`  fields. Clients should use new `Progress` field directly instead of calculating it. (also ShardsTotal might have incorrect value when starting replication of huge dataset)