### PR TITLE
[Feature] Abort resignation of leadership when dbserver restarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - (Feature) Run secured containers as a feature
 - (Feature) Expose core.PodSecurityContext Sysctl options
 - (Bugfix) Skip Collection check for missing Database
+- (Feature) Abort resignation of leadership when DB server is restared
 
 ## [1.2.31](https://github.com/arangodb/kube-arangodb/tree/1.2.31) (2023-07-14)
 - (Improvement) Block traffic on the services if there is more than 1 active leader in ActiveFailover mode

--- a/pkg/apis/deployment/v1/plan_locals.go
+++ b/pkg/apis/deployment/v1/plan_locals.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/deployment/v1/plan_locals.go
+++ b/pkg/apis/deployment/v1/plan_locals.go
@@ -20,10 +20,16 @@
 
 package v1
 
+import "fmt"
+
 type PlanLocalKey string
 
 func (p PlanLocalKey) String() string {
 	return string(p)
+}
+
+func (p PlanLocalKey) Register(action Action, format string, args ...interface{}) Action {
+	return action.AddParam(p.String(), fmt.Sprintf(format, args...))
 }
 
 type PlanLocals map[PlanLocalKey]string

--- a/pkg/apis/deployment/v2alpha1/plan_locals.go
+++ b/pkg/apis/deployment/v2alpha1/plan_locals.go
@@ -20,10 +20,16 @@
 
 package v2alpha1
 
+import "fmt"
+
 type PlanLocalKey string
 
 func (p PlanLocalKey) String() string {
 	return string(p)
+}
+
+func (p PlanLocalKey) Register(action Action, format string, args ...interface{}) Action {
+	return action.AddParam(p.String(), fmt.Sprintf(format, args...))
 }
 
 type PlanLocals map[PlanLocalKey]string

--- a/pkg/apis/deployment/v2alpha1/plan_locals.go
+++ b/pkg/apis/deployment/v2alpha1/plan_locals.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/deployment/agency/definitions.go
+++ b/pkg/deployment/agency/definitions.go
@@ -36,6 +36,7 @@ const (
 	TargetKey  = "Target"
 
 	CurrentMaintenanceServers = "MaintenanceServers"
+	CurrentServersKnown       = "ServersKnown"
 
 	TargetHotBackupKey = "HotBackup"
 

--- a/pkg/deployment/agency/definitions.go
+++ b/pkg/deployment/agency/definitions.go
@@ -65,10 +65,6 @@ func GetAgencyKey(parts ...string) string {
 	return fmt.Sprintf("/%s", strings.Join(parts, "/"))
 }
 
-func GetAgencyReadKey(elements ...string) []string {
-	return elements
-}
-
 func GetAgencyReadRequest(elements ...[]string) ReadRequest {
 	return elements
 }
@@ -79,6 +75,7 @@ func GetAgencyReadRequestFields() ReadRequest {
 		GetAgencyKey(ArangoKey, PlanKey, PlanCollectionsKey),
 		GetAgencyKey(ArangoKey, PlanKey, PlanDatabasesKey),
 		GetAgencyKey(ArangoKey, CurrentKey, PlanCollectionsKey),
+		GetAgencyKey(ArangoKey, CurrentKey, CurrentServersKnown),
 		GetAgencyKey(ArangoKey, CurrentKey, CurrentMaintenanceServers),
 		GetAgencyKey(ArangoKey, TargetKey, TargetHotBackupKey),
 		GetAgencyKey(ArangoKey, TargetKey, TargetJobToDoKey),

--- a/pkg/deployment/agency/state/state_test.go
+++ b/pkg/deployment/agency/state/state_test.go
@@ -373,3 +373,20 @@ func Test_MissingDatabaseCase(t *testing.T) {
 
 	require.Len(t, GetDBServerBlockingRestartShards(s, "PRMR-1e4bxazq"), 0)
 }
+
+func Test_GetRebootID(t *testing.T) {
+	var s DumpState
+	require.NoError(t, json.Unmarshal(agencyDump39, &s))
+
+	t.Run("Existing", func(t *testing.T) {
+		id, ok := s.Agency.Arango.GetRebootID("PRMR-n92yizyp")
+		require.True(t, ok)
+		require.Equal(t, 1, id)
+	})
+
+	t.Run("Missing", func(t *testing.T) {
+		id, ok := s.Agency.Arango.GetRebootID("PRMR-n92yiz")
+		require.False(t, ok)
+		require.Equal(t, 0, id)
+	})
+}

--- a/pkg/deployment/reconcile/helper_wrap.go
+++ b/pkg/deployment/reconcile/helper_wrap.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/deployment/reconcile/helper_wrap.go
+++ b/pkg/deployment/reconcile/helper_wrap.go
@@ -59,12 +59,17 @@ func withMemberMaintenance(group api.ServerGroup, member api.MemberStatus, reaso
 		actions.NewAction(api.ActionTypeDisableMemberMaintenance, group, member, reason))
 }
 
-func withResignLeadership(group api.ServerGroup, member api.MemberStatus, reason string, plan api.Plan) api.Plan {
+func withResignLeadership(group api.ServerGroup, member api.MemberStatus, reason string, plan api.Plan, rebootID *int) api.Plan {
 	if member.Image == nil {
 		return plan
 	}
 
-	return api.AsPlan(plan).Before(actions.NewAction(api.ActionTypeResignLeadership, group, member, reason))
+	action := actions.NewAction(api.ActionTypeResignLeadership, group, member, reason)
+	if rebootID != nil {
+		action = actionResignLeadershipRebootID.Register(action, "%d", *rebootID)
+	}
+
+	return api.AsPlan(plan).Before(action)
 }
 
 func cleanOutMember(group api.ServerGroup, m api.MemberStatus) api.Plan {

--- a/pkg/deployment/reconcile/plan_builder_rotate_upgrade_decision.go
+++ b/pkg/deployment/reconcile/plan_builder_rotate_upgrade_decision.go
@@ -56,7 +56,6 @@ type updateUpgradeDecision struct {
 	updateAllowed       bool
 	updateMessage       string
 	update              bool
-	restartRequired     bool
 }
 
 func (r *Reconciler) createRotateOrUpgradeDecision(spec api.DeploymentSpec, status api.DeploymentStatus, context PlanBuilderContext) updateUpgradeDecisionMap {
@@ -89,7 +88,6 @@ func (r *Reconciler) createRotateOrUpgradeDecisionMember(spec api.DeploymentSpec
 	if rotation.CheckPossible(element.Member) {
 		if element.Member.Conditions.IsTrue(api.ConditionTypeRestart) {
 			d.update = true
-			d.restartRequired = true
 		} else if element.Member.Conditions.IsTrue(api.ConditionTypePendingUpdate) {
 			if !element.Member.Conditions.IsTrue(api.ConditionTypeUpdating) && !element.Member.Conditions.IsTrue(api.ConditionTypeUpdateFailed) {
 				d.update = true

--- a/pkg/deployment/reconcile/plan_builder_utils.go
+++ b/pkg/deployment/reconcile/plan_builder_utils.go
@@ -31,24 +31,24 @@ import (
 // createRotateMemberPlan creates a plan to rotate (stop-recreate-start) an existing
 // member.
 func (r *Reconciler) createRotateMemberPlan(member api.MemberStatus,
-	group api.ServerGroup, spec api.DeploymentSpec, reason string) api.Plan {
+	group api.ServerGroup, spec api.DeploymentSpec, reason string, rebootId *int) api.Plan {
 	r.log.
 		Str("id", member.ID).
 		Str("role", group.AsRole()).
 		Str("reason", reason).
 		Debug("Creating rotation plan")
-	return createRotateMemberPlanWithAction(member, group, api.ActionTypeRotateMember, spec, reason)
+	return createRotateMemberPlanWithAction(member, group, api.ActionTypeRotateMember, spec, reason, rebootId)
 }
 
 // createRotateMemberPlanWithAction creates a plan to rotate (stop-<action>>-start) an existing
 // member.
 func createRotateMemberPlanWithAction(member api.MemberStatus,
-	group api.ServerGroup, action api.ActionType, spec api.DeploymentSpec, reason string) api.Plan {
+	group api.ServerGroup, action api.ActionType, spec api.DeploymentSpec, reason string, rebootId *int) api.Plan {
 
 	var plan = api.Plan{
 		actions.NewAction(api.ActionTypeCleanTLSKeyfileCertificate, group, member, "Remove server keyfile and enforce renewal/recreation"),
 	}
-	plan = withSecureWrap(member, group, spec, plan...)
+	plan = withSecureWrap(member, group, spec, rebootId, plan...)
 
 	plan = plan.After(
 		actions.NewAction(api.ActionTypeKillMemberPod, group, member, reason),

--- a/pkg/util/refs.go
+++ b/pkg/util/refs.go
@@ -64,3 +64,22 @@ func InitType[T interface{}](in *T) *T {
 	var q T
 	return &q
 }
+
+type ConditionalFunction[T interface{}] func() (T, bool)
+type ConditionalP1Function[T, P1 interface{}] func(p1 P1) (T, bool)
+
+func CheckConditionalNil[T interface{}](in ConditionalFunction[T]) *T {
+	if v, ok := in(); ok {
+		return &v
+	}
+
+	return nil
+}
+
+func CheckConditionalP1Nil[T, P1 interface{}](in ConditionalP1Function[T, P1], p1 P1) *T {
+	if v, ok := in(p1); ok {
+		return &v
+	}
+
+	return nil
+}

--- a/pkg/util/refs_test.go
+++ b/pkg/util/refs_test.go
@@ -116,3 +116,40 @@ func Test_Refs(t *testing.T) {
 	testRefs[time.Duration](t, time.Duration(500), time.Duration(1500), time.Duration(0))
 	testRefs[core.PullPolicy](t, core.PullAlways, core.PullNever, "")
 }
+
+func generateConditionalP0Function[T interface{}](ret T, ok bool) *T {
+	return CheckConditionalNil[T](func() (T, bool) {
+		return ret, ok
+	})
+}
+
+func generateConditionalP1Function[T interface{}](ret T, ok bool) *T {
+	return CheckConditionalP1Nil[T, int](func(in int) (T, bool) {
+		return ret, ok
+	}, 1)
+}
+
+func Test_CheckConditionalNil(t *testing.T) {
+	t.Run("P0", func(t *testing.T) {
+		t.Run("Nil if false", func(t *testing.T) {
+			v := generateConditionalP0Function(0, false)
+			require.Nil(t, v)
+		})
+		t.Run("NotNil if true", func(t *testing.T) {
+			v := generateConditionalP0Function(0, true)
+			require.NotNil(t, v)
+			require.EqualValues(t, 0, *v)
+		})
+	})
+	t.Run("P1", func(t *testing.T) {
+		t.Run("Nil if false", func(t *testing.T) {
+			v := generateConditionalP1Function(0, false)
+			require.Nil(t, v)
+		})
+		t.Run("NotNil if true", func(t *testing.T) {
+			v := generateConditionalP1Function(0, true)
+			require.NotNil(t, v)
+			require.EqualValues(t, 0, *v)
+		})
+	})
+}


### PR DESCRIPTION
no automated tests for it. I did some manual tests where I restarted DB server when it was in restarting phase, so operator was able to log information about this fact.

When leader's shards must be moved from one DB server to another, then resign leadership action must be performed.
Operator requests for it and checks progress. In the meantime, it may occur that DB server is restarted and action will not be finished in some timeout ~1 hour. With this PR, this action will be removed immediately whenever it occurs.