### PR TITLE
Fix creating sync components with EA type set to Managed and headless svc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - (Bugfix) Discover Arango image during ID phase
 - (Feature) PV Unschedulable condition
 - (Feature) Features startup logging
+- (Bugfix) Fix creating sync components with EA type set to Managed and headless svc
 
 ## [1.2.27](https://github.com/arangodb/kube-arangodb/tree/1.2.27) (2023-04-27)
 - (Feature) Add InSync Cache

--- a/pkg/deployment/resources/pod_creator_sync.go
+++ b/pkg/deployment/resources/pod_creator_sync.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -454,7 +454,7 @@ func (m *MemberSyncPod) syncHostAlias() *core.HostAlias {
 
 	endpoint := k8sutil.CreateSyncMasterClientServiceDNSNameWithDomain(m.apiObject, m.spec.ClusterDomain)
 
-	if svc.Spec.ClusterIP == "" {
+	if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == core.ClusterIPNone {
 		return nil
 	}
 


### PR DESCRIPTION
If customer uses "Type=Managed" for `SyncExternalAccessSpec` AND uses headless service (`ClusterIP=None`) then sync pods won't be created due to an error while creating a HostAlias for pod.

The code in `syncHostAlias` method still not perfect because it assumes that EA service name would be always `<depl-name>-sync`. That should be fixed in separate ticket. 