### PR TITLE
[Maintenance] GT-435 | Update ArangoDB version used in examples YAMLs

### DIFF
--- a/examples/cluster1-with-sync.yaml
+++ b/examples/cluster1-with-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "cluster1-with-sync"
 spec:
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.10.6'
   tls:
     altNames: ["kube-01", "kube-02", "kube-03"]
   sync:

--- a/examples/cluster2-with-sync.yaml
+++ b/examples/cluster2-with-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "cluster2-with-sync"
 spec:
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.10.6'
   tls:
     altNames: ["kube-01", "kube-02", "kube-03"]
   sync:

--- a/examples/production-cluster-with-metrics.yaml
+++ b/examples/production-cluster-with-metrics.yaml
@@ -13,5 +13,5 @@ spec:
     prometheus.io/port: '9101'
     prometheus.io/scrape_interval: '5s'
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.10.6'
   environment: Production

--- a/examples/production-cluster.yaml
+++ b/examples/production-cluster.yaml
@@ -4,5 +4,5 @@ metadata:
   name: "production-cluster"
 spec:
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.10.6'
   environment: Production

--- a/examples/reboot-pod.yaml
+++ b/examples/reboot-pod.yaml
@@ -11,7 +11,7 @@ spec:
       command: ["arangodb_operator", "reboot"]
       args:
         - --deployment-name=my-arangodb-cluster
-        - --image-name=arangodb/enterprise:3.7.10
+        - --image-name=arangodb/enterprise:3.10.6
         - --license-secret-name=arangodb-license-key
         - --coordinators=3
         - pvc-9aa241f7-df94-11e9-b74c-42010aac0044

--- a/examples/simple-cluster-with-metrics.yaml
+++ b/examples/simple-cluster-with-metrics.yaml
@@ -13,4 +13,4 @@ spec:
     prometheus.io/port: '9101'
     prometheus.io/scrape_interval: '5s'
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.10.6'

--- a/examples/simple-cluster.yaml
+++ b/examples/simple-cluster.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example-simple-cluster"
 spec:
   mode: Cluster
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.10.6'

--- a/examples/single-server.yaml
+++ b/examples/single-server.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example-simple-single"
 spec:
   mode: Single
-  image: 'arangodb/arangodb:3.7.10'
+  image: 'arangodb/arangodb:3.10.6'

--- a/scripts/patch_examples.sh
+++ b/scripts/patch_examples.sh
@@ -9,7 +9,7 @@ if [ -z $VERSION ]; then
     exit 1
 fi
 
-ARANGODB_VERSION=3.7.10
+ARANGODB_VERSION=3.10.6
 
 function replaceInFile {
     local EXPR=$1


### PR DESCRIPTION
set to 3.10.6 because 3.11.0 has some known issues. In most cases it is better to use 3.10 branch until 3.11.1 is not released.