### PR TITLE
[Maintenance] Remove support for RELATED_IMAGE_xxx env vars | GT-486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
 - (Bugfix) Fix make manifests-crd-file command
 - (Improvement) Allow tcp:// and ssl:// protocols in endpoints for members
-- (Maintenance) Reorganize package imports / move common code to separate repos 
+- (Maintenance) Reorganize package imports / move common code to separate repos
+- (Maintenance) Remove support for RELATED_IMAGE_UBI, RELATED_IMAGE_DATABASE and RELATED_IMAGE_METRICSEXPORTER env vars
  
 ## [1.2.33](https://github.com/arangodb/kube-arangodb/tree/1.2.33) (2023-09-27)
 - (Maintenance) Bump golang.org/x/net to v0.13.0

--- a/chart/kube-arangodb/templates/deployment.yaml
+++ b/chart/kube-arangodb/templates/deployment.yaml
@@ -133,12 +133,6 @@ spec:
                         valueFrom:
                             fieldRef:
                                 fieldPath: status.podIP
-                      - name: RELATED_IMAGE_UBI
-                        value: "{{ .Values.operator.images.base }}"
-                      - name: RELATED_IMAGE_METRICSEXPORTER
-                        value: "{{ .Values.operator.images.metricsExporter }}"
-                      - name: RELATED_IMAGE_DATABASE
-                        value: "{{ .Values.operator.images.arango }}"
 {{- if .Values.operator.features.apps }}
                       - name: ARANGOJOB_SA_NAME
                         value: "{{ template "kube-arangodb.operatorName" . }}-job"

--- a/chart/kube-arangodb/values.yaml
+++ b/chart/kube-arangodb/values.yaml
@@ -32,10 +32,6 @@ operator:
     backup: false
     apps: false
     k8sToK8sClusterSync: false
-  images:
-    base: alpine:3.11
-    metricsExporter: arangodb/arangodb-exporter:0.1.7
-    arango: arangodb/arangodb:latest
   tolerations: []
 rbac:
   enabled: true

--- a/manifests/arango-all.yaml
+++ b/manifests/arango-all.yaml
@@ -847,12 +847,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
             - name: ARANGOJOB_SA_NAME
               value: "arango-all-operator-job"
           ports:

--- a/manifests/arango-apps.yaml
+++ b/manifests/arango-apps.yaml
@@ -317,12 +317,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
             - name: ARANGOJOB_SA_NAME
               value: "arango-apps-operator-job"
           ports:

--- a/manifests/arango-backup.yaml
+++ b/manifests/arango-backup.yaml
@@ -265,12 +265,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/arango-deployment-replication.yaml
+++ b/manifests/arango-deployment-replication.yaml
@@ -262,12 +262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/arango-deployment.yaml
+++ b/manifests/arango-deployment.yaml
@@ -315,12 +315,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/arango-k2kclustersync.yaml
+++ b/manifests/arango-k2kclustersync.yaml
@@ -262,12 +262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/arango-storage.yaml
+++ b/manifests/arango-storage.yaml
@@ -301,12 +301,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/enterprise-all.yaml
+++ b/manifests/enterprise-all.yaml
@@ -847,12 +847,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
             - name: ARANGOJOB_SA_NAME
               value: "arango-all-operator-job"
           ports:

--- a/manifests/enterprise-apps.yaml
+++ b/manifests/enterprise-apps.yaml
@@ -317,12 +317,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
             - name: ARANGOJOB_SA_NAME
               value: "arango-apps-operator-job"
           ports:

--- a/manifests/enterprise-backup.yaml
+++ b/manifests/enterprise-backup.yaml
@@ -265,12 +265,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/enterprise-deployment-replication.yaml
+++ b/manifests/enterprise-deployment-replication.yaml
@@ -262,12 +262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/enterprise-deployment.yaml
+++ b/manifests/enterprise-deployment.yaml
@@ -315,12 +315,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/enterprise-k2kclustersync.yaml
+++ b/manifests/enterprise-k2kclustersync.yaml
@@ -262,12 +262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/enterprise-storage.yaml
+++ b/manifests/enterprise-storage.yaml
@@ -301,12 +301,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize-enterprise/all/enterprise-all.yaml
+++ b/manifests/kustomize-enterprise/all/enterprise-all.yaml
@@ -847,12 +847,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
             - name: ARANGOJOB_SA_NAME
               value: "arango-all-operator-job"
           ports:

--- a/manifests/kustomize-enterprise/apps/enterprise-apps.yaml
+++ b/manifests/kustomize-enterprise/apps/enterprise-apps.yaml
@@ -317,12 +317,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
             - name: ARANGOJOB_SA_NAME
               value: "arango-apps-operator-job"
           ports:

--- a/manifests/kustomize-enterprise/backup/enterprise-backup.yaml
+++ b/manifests/kustomize-enterprise/backup/enterprise-backup.yaml
@@ -265,12 +265,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize-enterprise/deployment-replication/enterprise-deployment-replication.yaml
+++ b/manifests/kustomize-enterprise/deployment-replication/enterprise-deployment-replication.yaml
@@ -262,12 +262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize-enterprise/deployment/enterprise-deployment.yaml
+++ b/manifests/kustomize-enterprise/deployment/enterprise-deployment.yaml
@@ -315,12 +315,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize-enterprise/k2kclustersync/enterprise-k2kclustersync.yaml
+++ b/manifests/kustomize-enterprise/k2kclustersync/enterprise-k2kclustersync.yaml
@@ -262,12 +262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize-enterprise/k2kclustersync/kustomization.yaml
+++ b/manifests/kustomize-enterprise/k2kclustersync/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - enterprise-k2kclustersync.yaml

--- a/manifests/kustomize-enterprise/storage/enterprise-storage.yaml
+++ b/manifests/kustomize-enterprise/storage/enterprise-storage.yaml
@@ -301,12 +301,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize/all/arango-all.yaml
+++ b/manifests/kustomize/all/arango-all.yaml
@@ -847,12 +847,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
             - name: ARANGOJOB_SA_NAME
               value: "arango-all-operator-job"
           ports:

--- a/manifests/kustomize/apps/arango-apps.yaml
+++ b/manifests/kustomize/apps/arango-apps.yaml
@@ -317,12 +317,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
             - name: ARANGOJOB_SA_NAME
               value: "arango-apps-operator-job"
           ports:

--- a/manifests/kustomize/backup/arango-backup.yaml
+++ b/manifests/kustomize/backup/arango-backup.yaml
@@ -265,12 +265,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize/deployment-replication/arango-deployment-replication.yaml
+++ b/manifests/kustomize/deployment-replication/arango-deployment-replication.yaml
@@ -262,12 +262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize/deployment/arango-deployment.yaml
+++ b/manifests/kustomize/deployment/arango-deployment.yaml
@@ -315,12 +315,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize/k2kclustersync/arango-k2kclustersync.yaml
+++ b/manifests/kustomize/k2kclustersync/arango-k2kclustersync.yaml
@@ -262,12 +262,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/manifests/kustomize/storage/arango-storage.yaml
+++ b/manifests/kustomize/storage/arango-storage.yaml
@@ -301,12 +301,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: RELATED_IMAGE_UBI
-              value: "alpine:3.11"
-            - name: RELATED_IMAGE_METRICSEXPORTER
-              value: "arangodb/arangodb-exporter:0.1.7"
-            - name: RELATED_IMAGE_DATABASE
-              value: "arangodb/arangodb:latest"
           ports:
             - name: metrics
               containerPort: 8528

--- a/pkg/deployment/context_impl.go
+++ b/pkg/deployment/context_impl.go
@@ -553,10 +553,6 @@ func (d *Deployment) SelectImageForMember(spec api.DeploymentSpec, status api.De
 	return d.resources.SelectImageForMember(spec, status, member)
 }
 
-func (d *Deployment) GetArangoImage() string {
-	return d.config.ArangoImage
-}
-
 func (d *Deployment) WithStatusUpdateErr(ctx context.Context, action reconciler.DeploymentStatusUpdateErrFunc) error {
 	status := d.GetStatus()
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -70,7 +70,6 @@ type Config struct {
 	AllowChaos                bool
 	ScalingIntegrationEnabled bool
 	OperatorImage             string
-	ArangoImage               string
 	ReconciliationDelay       time.Duration
 	Scope                     scope.Scope
 }

--- a/pkg/deployment/resources/context.go
+++ b/pkg/deployment/resources/context.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,8 +52,6 @@ type Context interface {
 	GetServerGroupIterator() reconciler.ServerGroupIterator
 	// GetOperatorImage returns the image name of operator image
 	GetOperatorImage() string
-	// GetArangoImage returns the image name containing the default arango image
-	GetArangoImage() string
 	// CreateEvent creates a given event.
 	// On error, the error is logged.
 	CreateEvent(evt *k8sutil.Event)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -95,7 +95,6 @@ type Config struct {
 	PodName                     string
 	ServiceAccount              string
 	OperatorImage               string
-	ArangoImage                 string
 	EnableDeployment            bool
 	EnableDeploymentReplication bool
 	EnableStorage               bool

--- a/pkg/operator/operator_deployment.go
+++ b/pkg/operator/operator_deployment.go
@@ -198,7 +198,6 @@ func (o *Operator) makeDeploymentConfigAndDeps() (deployment.Config, deployment.
 	cfg := deployment.Config{
 		ServiceAccount:            o.Config.ServiceAccount,
 		OperatorImage:             o.Config.OperatorImage,
-		ArangoImage:               o.ArangoImage,
 		AllowChaos:                o.Config.AllowChaos,
 		ScalingIntegrationEnabled: o.Config.ScalingIntegrationEnabled,
 		ReconciliationDelay:       o.Config.ReconciliationDelay,


### PR DESCRIPTION
RELATED_IMAGE_UBI, RELATED_IMAGE_DATABASE and RELATED_IMAGE_METRICSEXPORTER