### PR TITLE
Fix make manifests-crd-file command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-
+- (Bugfix) Fix make manifests-crd-file command
+ 
 ## [1.2.33](https://github.com/arangodb/kube-arangodb/tree/1.2.33) (2023-09-27)
 - (Maintenance) Bump golang.org/x/net to v0.13.0
 - (Feature) PVCResize action concurrency limit

--- a/Makefile
+++ b/Makefile
@@ -456,10 +456,9 @@ manifests:
 .PHONY: manifests-crd-file
 manifests-crd-file:
 	@echo Building manifests for CRD - $(MANIFESTPATHCRD)
-	@echo -n > $(MANIFESTPATHCRD)
-	@$(foreach FILE,$(CRDS),echo '---\n# File: chart/kube-arangodb/crds/$(FILE).yaml' >> $(MANIFESTPATHCRD) && \
-                           cat '$(ROOT)/chart/kube-arangodb/crds/$(FILE).yaml' >> $(MANIFESTPATHCRD) && \
-                           echo '\n' >> $(MANIFESTPATHCRD);)
+	@printf "" > $(MANIFESTPATHCRD)
+	@$(foreach FILE,$(CRDS),printf '%s\n# File: chart/kube-arangodb/crds/%s.yaml\n' '---' $(FILE) >> $(MANIFESTPATHCRD) && \
+                           cat '$(ROOT)/chart/kube-arangodb/crds/$(FILE).yaml' >> $(MANIFESTPATHCRD);)
 manifests: manifests-crd-file
 
 .PHONY: manifests-crd-kustomize


### PR DESCRIPTION
'echo' command is not portable and should be avoided since it can have different parameters supported depending of the shell