### PR TITLE
(Documentation) Use Jekyll-compatible markers for section injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ The ArangoDB Kubernetes Operator is Production ready.
 
 ### Limits
 
-<!-- START(limits) -->
+[START_INJECT]: # (limits)
+
 | Limit              | Description                                                                  | Community | Enterprise |
 |:-------------------|:-----------------------------------------------------------------------------|:----------|:-----------|
 | Cluster size limit | Limits of the nodes (DBServers & Coordinators) supported in the Cluster mode | 64        | 1024       |
 
-<!-- END(limits) -->
+[END_INJECT]: # (limits)
 
 ### Production readiness state
 
@@ -38,7 +39,8 @@ Kubernetes versions starting from 1.18 are supported and tested, charts and mani
 The following table has the general readiness state, the table below
 covers individual newer features separately.
 
-<!-- START(kubernetesVersionsTable) -->
+[START_INJECT]: # (kubernetesVersionsTable)
+
 | Platform            | Kubernetes Version | ArangoDB Version | State      | Remarks                                   | Provider Remarks                   |
 |:--------------------|:-------------------|:-----------------|:-----------|:------------------------------------------|:-----------------------------------|
 | Google GKE          | 1.21-1.26          | >= 3.6.0         | Production | Don't use micro nodes                     |                                    |
@@ -53,11 +55,12 @@ covers individual newer features separately.
 | Minikube            | 1.21-1.27          | >= 3.6.0         | Devel Only |                                           |                                    |
 | Other               | 1.21-1.27          | >= 3.6.0         | Devel Only |                                           |                                    |
 
-<!-- END(kubernetesVersionsTable) -->
+[END_INJECT]: # (kubernetesVersionsTable)
 
 #### Operator Features
 
-<!-- START(featuresCommunityTable) -->
+[START_INJECT]: # (featuresCommunityTable)
+
 | Feature                                                                       | Operator Version | Introduced | ArangoDB Version | ArangoDB Edition      | State        | Enabled | Flag                                                  | Remarks                                                                            |
 |:------------------------------------------------------------------------------|:-----------------|:-----------|:-----------------|:----------------------|:-------------|:--------|:------------------------------------------------------|:-----------------------------------------------------------------------------------|
 | Enforced ResignLeadership                                                     | 1.2.34           | 1.2.34     | >= 3.8.0         | Community, Enterprise | Production   | True    | --deployment.feature.enforced-resign-leadership       | Enforce ResignLeadership and ensure that Leaders are moved from restarted DBServer |
@@ -86,13 +89,14 @@ covers individual newer features separately.
 | Volume Claim Templates                                                        | 0.3.11           | 0.3.10     | >= 3.8.0         | Community, Enterprise | Production   | True    | N/A                                                   | N/A                                                                                |
 | Volume Resizing                                                               | 0.3.11           | 0.3.10     | >= 3.8.0         | Community, Enterprise | Production   | True    | N/A                                                   | N/A                                                                                |
 
-<!-- END(featuresCommunityTable) -->
+[END_INJECT]: # (featuresCommunityTable)
 
 #### Operator Enterprise Only Features
 
 To upgrade to the Enterprise Edition, you need to get in touch with the ArangoDB team. [Contact us](https://www.arangodb.com/contact/) for more details.
 
-<!-- START(featuresEnterpriseTable) -->
+[START_INJECT]: # (featuresEnterpriseTable)
+
 | Feature                                                | Operator Version | Introduced | ArangoDB Version | ArangoDB Edition | State      | Enabled | Flag | Remarks                                                                     |
 |:-------------------------------------------------------|:-----------------|:-----------|:-----------------|:-----------------|:-----------|:--------|:-----|:----------------------------------------------------------------------------|
 | AgencyCache                                            | 1.2.30           | 1.2.30     | >= 3.8.0         | Enterprise       | Production | True    | N/A  | Enable Agency Cache mechanism in the Operator (Increase limit of the nodes) |
@@ -100,7 +104,7 @@ To upgrade to the Enterprise Edition, you need to get in touch with the ArangoDB
 | [Rebalancer](docs/features/rebalancer.md)              | 1.2.15           | 1.2.5      | >= 3.8.0         | Enterprise       | Production | True    | N/A  | N/A                                                                         |
 | [TopologyAwareness](docs/design/topology_awareness.md) | 1.2.4            | 1.2.4      | >= 3.8.0         | Enterprise       | Production | True    | N/A  | N/A                                                                         |
 
-<!-- END(featuresEnterpriseTable) -->
+[END_INJECT]: # (featuresEnterpriseTable)
 
 ## Installation and Usage
 

--- a/docs/generated/actions.md
+++ b/docs/generated/actions.md
@@ -1,8 +1,9 @@
-# ArangoDB Operator Metrics
+# ArangoDB Operator Actions
 
 ## List
 
-<!-- START(actionsTable) -->
+[START_INJECT]: # (actionsTable)
+
 |               Action               | Internal | Timeout | Optional |        Edition         |                                                    Description                                                     |
 |:----------------------------------:|:--------:|:-------:|:--------:|:----------------------:|:------------------------------------------------------------------------------------------------------------------:|
 |             AddMember              |    no    |  10m0s  |    no    | Community & Enterprise |                                         Adds new member to the Member list                                         |
@@ -90,11 +91,12 @@
 |         WaitForMemberReady         |    no    |  30m0s  |    no    | Community & Enterprise |                                          Wait for member Ready condition                                           |
 |          WaitForMemberUp           |    no    |  30m0s  |    no    | Community & Enterprise |                                          Wait for member to be responsive                                          |
 
-<!-- END(actionsTable) -->
+[END_INJECT]: # (actionsTable)
 
 ## ArangoDeployment spec
 
-<!-- START(actionsModYaml) -->
+[START_INJECT]: # (actionsModYaml)
+
 ```yaml
 spec:
   timeouts:
@@ -185,4 +187,5 @@ spec:
       WaitForMemberUp: 30m0s
 
 ```
-<!-- END(actionsModYaml) -->
+
+[END_INJECT]: # (actionsModYaml)

--- a/docs/generated/metrics/README.md
+++ b/docs/generated/metrics/README.md
@@ -2,7 +2,8 @@
 
 ## List of the Operator metrics
 
-<!-- START(metricsTable) -->
+[START_INJECT]: # (metricsTable)
+
 |                                                                 Name                                                                  |     Namespace     |       Group       |  Type   | Description                                                                           |
 |:-------------------------------------------------------------------------------------------------------------------------------------:|:-----------------:|:-----------------:|:-------:|:--------------------------------------------------------------------------------------|
 |                                [arangodb_operator_agency_errors](./arangodb_operator_agency_errors.md)                                | arangodb_operator |      agency       | Counter | Current count of agency cache fetch errors                                            |
@@ -35,4 +36,4 @@
 | [arangodb_operator_resources_arangodeploymentreplication_active](./arangodb_operator_resources_arangodeploymentreplication_active.md) | arangodb_operator |     resources     |  Gauge  | Defines if ArangoDeploymentReplication is configured and running                      |
 | [arangodb_operator_resources_arangodeploymentreplication_failed](./arangodb_operator_resources_arangodeploymentreplication_failed.md) | arangodb_operator |     resources     |  Gauge  | Defines if ArangoDeploymentReplication is in Failed phase                             |
 
-<!-- END(metricsTable) -->
+[END_INJECT]: # (metricsTable)

--- a/internal/md/sections.go
+++ b/internal/md/sections.go
@@ -56,7 +56,7 @@ func ReplaceSections(in string, sections map[string]string) (string, error) {
 }
 
 func ReplaceSection(in, replace, section string) (string, error) {
-	start, end := fmt.Sprintf("<!-- START(%s) -->", section), fmt.Sprintf("<!-- END(%s) -->", section)
+	start, end := fmt.Sprintf("\n[START_INJECT]: # (%s)\n", section), fmt.Sprintf("[END_INJECT]: # (%s)\n", section)
 
 	b := bytes.NewBuffer(nil)
 
@@ -78,7 +78,14 @@ func ReplaceSection(in, replace, section string) (string, error) {
 
 		endID := strings.Index(in, end)
 		if endID == -1 {
-			return "", errors.Newf("END sections is missing")
+			return "", errors.Newf("END_INJECT sections is missing for section %s. Note that newline is required at the end and before tag", section)
+		}
+
+		if strings.HasSuffix(replace, "\n\n") {
+			// if section ends with empty line, we don't need to write newline for END marker
+			end = strings.TrimLeft(end, "\n")
+		} else {
+			end = "\n" + end
 		}
 
 		b.WriteString(end)


### PR DESCRIPTION
Reason: old markers `<!-- START(limits) -->` are not compatible with Jekyll static site generator, e.g. see https://arangodb.github.io/kube-arangodb/ page. First table is generated with new markers `[START_INJECT]: # (limits)` and other tables are generated with old markers.

Please note that new markers require an empty line before and after the marker.