### PR TITLE
(Documentation) Improvements and fixes for rendered documentation (GH pages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Documentation) Absolute links for code references
 
 ## [1.2.35](https://github.com/arangodb/kube-arangodb/tree/1.2.35) (2023-11-06)
 - (Maintenance) Update go-driver to v1.6.0, update IsNotFound() checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-- (Documentation) Absolute links for code references
+- (Documentation) Improvements and fixes for rendered documentation (GH pages)
 
 ## [1.2.35](https://github.com/arangodb/kube-arangodb/tree/1.2.35) (2023-11-06)
 - (Maintenance) Update go-driver to v1.6.0, update IsNotFound() checks

--- a/docs/api/ArangoBackup.V1.md
+++ b/docs/api/ArangoBackup.V1.md
@@ -6,25 +6,25 @@
 
 Iterations defines number of iterations before reaching MaxDelay. Default to 5
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec_backoff.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec_backoff.go#L31)
 
 ### .spec.backoff.max_delay: integer
 
 MaxDelay defines maximum delay in seconds. Default to 600
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec_backoff.go#L29)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec_backoff.go#L29)
 
 ### .spec.backoff.max_iterations: integer
 
 MaxIterations defines maximum number of iterations after backoff will be disabled. Default to nil (no limit)
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec_backoff.go#L33)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec_backoff.go#L33)
 
 ### .spec.backoff.min_delay: integer
 
 MinDelay defines minimum delay in seconds. Default to 30
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec_backoff.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec_backoff.go#L27)
 
 ### .spec.deployment.name: string
 
@@ -32,7 +32,7 @@ Name of the ArangoDeployment Custom Resource within same namespace as ArangoBack
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L54)
 
 ### .spec.download.credentialsSecretName: string
 
@@ -43,7 +43,7 @@ Links:
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L81)
 
 ### .spec.download.id: string
 
@@ -51,7 +51,7 @@ ID of the ArangoBackup to be downloaded
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L89)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L89)
 
 ### .spec.download.repositoryURL: string
 
@@ -70,34 +70,34 @@ azure://test
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L77)
 
 ### .spec.lifetime: integer
 
 Lifetime is the time after which the backup will be deleted. Format: "1.5h" or "2h45m".
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L47)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L47)
 
 ### .spec.options.allowInconsistent: boolean
 
 AllowInconsistent flag for Backup creation request.
 If this value is set to true, backup is taken even if we are not able to acquire lock.
 
-Default Value: false
+Default Value: `false`
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L66)
 
 ### .spec.options.timeout: number
 
 Timeout for Backup creation request in seconds.
 
-Default Value: 30
+Default Value: `30`
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L61)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L61)
 
 ### .spec.policyName: string
 
@@ -105,7 +105,7 @@ PolicyName name of the ArangoBackupPolicy which created this Custom Resource
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L42)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L42)
 
 ### .spec.upload.credentialsSecretName: string
 
@@ -116,7 +116,7 @@ Links:
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L81)
 
 ### .spec.upload.repositoryURL: string
 
@@ -135,7 +135,7 @@ azure://test
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L77)
 
 ## Status
 
@@ -143,67 +143,67 @@ This field is **immutable**: can't be changed after backup creation
 
 Available Determines if we can restore from ArangoBackup
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L36)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L36)
 
 ### .status.backoff.iterations: integer
 
-[Code Reference](/pkg/apis/backup/v1/backup_status_backoff.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status_backoff.go#L30)
 
 ### .status.backup.downloaded: boolean
 
 Downloaded Determines if ArangoBackup has been downloaded.
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L66)
 
 ### .status.backup.id: string
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L56)
 
 ### .status.backup.imported: boolean
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L67)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L67)
 
 ### .status.backup.keys: array
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L70)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L70)
 
 ### .status.backup.numberOfDBServers: integer
 
 NumberOfDBServers Cluster size of the Backup in ArangoDB
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L62)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L62)
 
 ### .status.backup.potentiallyInconsistent: boolean
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L58)
 
 ### .status.backup.sizeInBytes: integer
 
 SizeInBytes Size of the Backup in ArangoDB.
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L60)
 
 ### .status.backup.uploaded: boolean
 
 Uploaded Determines if ArangoBackup has been uploaded
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L64)
 
 ### .status.backup.version: string
 
-[Code Reference](/pkg/apis/backup/v1/backup_status.go#L57)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_status.go#L57)
 
 ### .status.message: string
 
 Message for the state this object is in.
 
-[Code Reference](/pkg/apis/backup/v1/backup_state.go#L86)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_state.go#L86)
 
 ### .status.progress.jobID: string
 
 JobID ArangoDB job ID for uploading or downloading
 
-[Code Reference](/pkg/apis/backup/v1/backup_state.go#L109)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_state.go#L109)
 
 ### .status.progress.progress: string
 
@@ -214,7 +214,7 @@ Example:
 90%
 ```
 
-[Code Reference](/pkg/apis/backup/v1/backup_state.go#L112)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_state.go#L112)
 
 ### .status.state: string
 
@@ -235,5 +235,5 @@ Possible Values:
 * Failed - state for failure
 * Unavailable - state when Backup is not available on the ArangoDB. It can happen in case of upgrades, node restarts etc.
 
-[Code Reference](/pkg/apis/backup/v1/backup_state.go#L80)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_state.go#L80)
 

--- a/docs/api/ArangoBackupPolicy.V1.md
+++ b/docs/api/ArangoBackupPolicy.V1.md
@@ -6,25 +6,25 @@
 
 AllowConcurrent if false, ArangoBackup will not be created when previous Backups are not finished
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/backup/v1/backup_policy_spec.go#L35)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_policy_spec.go#L35)
 
 ### .spec.maxBackups: integer
 
 MaxBackups defines how many backups should be kept in history (per deployment). Oldest healthy Backups will be deleted.
 If not specified or 0 then no limit is applied
 
-Default Value: 0
+Default Value: `0`
 
-[Code Reference](/pkg/apis/backup/v1/backup_policy_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_policy_spec.go#L43)
 
 ### .spec.schedule: string
 
 Schedule is cron-compatible specification of backup schedule
 Parsed by https://godoc.org/github.com/robfig/cron
 
-[Code Reference](/pkg/apis/backup/v1/backup_policy_spec.go#L32)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_policy_spec.go#L32)
 
 ### .spec.selector: meta.LabelSelector
 
@@ -33,58 +33,58 @@ DeploymentSelector Selector definition for selecting matching ArangoBackup Custo
 Links:
 * [Kubernetes Documentation](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#LabelSelector)
 
-[Code Reference](/pkg/apis/backup/v1/backup_policy_spec.go#L39)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_policy_spec.go#L39)
 
 ### .spec.template.backoff.iterations: integer
 
 Iterations defines number of iterations before reaching MaxDelay. Default to 5
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec_backoff.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec_backoff.go#L31)
 
 ### .spec.template.backoff.max_delay: integer
 
 MaxDelay defines maximum delay in seconds. Default to 600
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec_backoff.go#L29)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec_backoff.go#L29)
 
 ### .spec.template.backoff.max_iterations: integer
 
 MaxIterations defines maximum number of iterations after backoff will be disabled. Default to nil (no limit)
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec_backoff.go#L33)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec_backoff.go#L33)
 
 ### .spec.template.backoff.min_delay: integer
 
 MinDelay defines minimum delay in seconds. Default to 30
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec_backoff.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec_backoff.go#L27)
 
 ### .spec.template.lifetime: integer
 
 Lifetime is the time after which the backup will be deleted. Format: "1.5h" or "2h45m".
 
-[Code Reference](/pkg/apis/backup/v1/backup_policy_spec.go#L61)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_policy_spec.go#L61)
 
 ### .spec.template.options.allowInconsistent: boolean
 
 AllowInconsistent flag for Backup creation request.
 If this value is set to true, backup is taken even if we are not able to acquire lock.
 
-Default Value: false
+Default Value: `false`
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L66)
 
 ### .spec.template.options.timeout: number
 
 Timeout for Backup creation request in seconds.
 
-Default Value: 30
+Default Value: `30`
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L61)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L61)
 
 ### .spec.template.upload.credentialsSecretName: string
 
@@ -95,7 +95,7 @@ Links:
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L81)
 
 ### .spec.template.upload.repositoryURL: string
 
@@ -114,7 +114,7 @@ azure://test
 
 This field is **immutable**: can't be changed after backup creation
 
-[Code Reference](/pkg/apis/backup/v1/backup_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_spec.go#L77)
 
 ## Status
 
@@ -122,11 +122,11 @@ This field is **immutable**: can't be changed after backup creation
 
 Message from the operator in case of failures - schedule not valid, ArangoBackupPolicy not valid
 
-[Code Reference](/pkg/apis/backup/v1/backup_policy_status.go#L33)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_policy_status.go#L33)
 
 ### .status.scheduled: meta.Time
 
 Scheduled Next scheduled time in UTC
 
-[Code Reference](/pkg/apis/backup/v1/backup_policy_status.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/backup/v1/backup_policy_status.go#L31)
 

--- a/docs/api/ArangoDeployment.V1.md
+++ b/docs/api/ArangoDeployment.V1.md
@@ -9,7 +9,7 @@ Affinity specified additional affinity settings in ArangoDB Pod definitions
 Links:
 * [Documentation of core.PodAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L180)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L180)
 
 ### .spec.agents.allowMemberRecreation: boolean
 
@@ -18,26 +18,26 @@ This setting changes the member recreation logic based on group:
 - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
 - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L222)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L222)
 
 ### .spec.agents.annotations: object
 
 Annotations specified the annotations added to Pods in this group.
 Annotations are merged with `spec.annotations`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L125)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L125)
 
 ### .spec.agents.annotationsIgnoreList: array
 
 AnnotationsIgnoreList list regexp or plain definitions which annotations should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L127)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L127)
 
 ### .spec.agents.annotationsMode: string
 
 AnnotationsMode Define annotations mode which should be use while overriding annotations
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L129)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L129)
 
 ### .spec.agents.antiAffinity: core.PodAntiAffinity
 
@@ -46,15 +46,15 @@ AntiAffinity specified additional antiAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of core.Pod.AntiAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podantiaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L176)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L176)
 
 ### .spec.agents.args: []string
 
 Args setting specifies additional command-line arguments passed to all servers of this group.
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L85)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L85)
 
 ### .spec.agents.count: integer
 
@@ -65,21 +65,21 @@ for `spec.mode: Single` and `2` for `spec.mode: ActiveFailover`).
 For the `syncworkers` group, it is highly recommended to use the same number
 as for the `dbservers` group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L77)
 
 ### .spec.agents.entrypoint: string
 
 Entrypoint overrides container executable
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L87)
 
 ### .spec.agents.envs\[int\].name: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L26)
 
 ### .spec.agents.envs\[int\].value: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L27)
 
 ### .spec.agents.ephemeralVolumes.apps.size: resource.Quantity
 
@@ -88,7 +88,7 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.agents.ephemeralVolumes.temp.size: resource.Quantity
 
@@ -97,25 +97,25 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.agents.exporterPort: integer
 
 ExporterPort define Port used by exporter
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L235)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L235)
 
 ### .spec.agents.extendedRotationCheck: boolean
 
 ExtendedRotationCheck extend checks for rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L205)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L205)
 
 ### .spec.agents.externalPortEnabled: boolean
 
 ExternalPortEnabled if external port should be enabled. If is set to false, ports needs to be exposed via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L217)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L217)
 
 ### .spec.agents.indexMethod: string
 
@@ -125,7 +125,7 @@ Possible Values:
 * random (default) - Pick random ID for member. Enforced on the Community Operator.
 * ordered - Use sequential number as Member ID, starting from 0. Enterprise Operator required.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L228)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L228)
 
 ### .spec.agents.initContainers.containers: []core.Container
 
@@ -134,49 +134,49 @@ Containers contains list of containers
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
 
 ### .spec.agents.initContainers.mode: string
 
 Mode keep container replace mode
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
 
 ### .spec.agents.internalPort: integer
 
 InternalPort define port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L213)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L213)
 
 ### .spec.agents.internalPortProtocol: string
 
 InternalPortProtocol define protocol of port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L215)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L215)
 
 ### .spec.agents.labels: object
 
 Labels specified the labels added to Pods in this group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L131)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L131)
 
 ### .spec.agents.labelsIgnoreList: array
 
 LabelsIgnoreList list regexp or plain definitions which labels should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L133)
 
 ### .spec.agents.labelsMode: string
 
 LabelsMode Define labels mode which should be use while overriding labels
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L135)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L135)
 
 ### .spec.agents.maxCount: integer
 
 MaxCount specifies a maximum for the count of servers. If set, a specification is invalid if `count > maxCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L81)
 
 ### .spec.agents.memoryReservation: integer
 
@@ -187,15 +187,15 @@ Accepted Range <0, 50>. If the value is outside the accepted range, it is adjust
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: 0
+Default Value: `0`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L107)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L107)
 
 ### .spec.agents.minCount: integer
 
 MinCount specifies a minimum for the count of servers. If set, a specification is invalid if `count < minCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L79)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L79)
 
 ### .spec.agents.nodeAffinity: core.NodeAffinity
 
@@ -204,7 +204,7 @@ NodeAffinity specified additional nodeAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of code.NodeAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#nodeaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L184)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L184)
 
 ### .spec.agents.nodeSelector: map[string]string
 
@@ -213,31 +213,31 @@ NodeSelector setting specifies a set of labels to be used as `nodeSelector` for 
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L150)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L150)
 
 ### .spec.agents.numactl.args: array
 
 Args define list of the numactl process
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
 
 ### .spec.agents.numactl.enabled: boolean
 
 Enabled define if numactl should be enabled
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
 
 ### .spec.agents.numactl.path: string
 
 Path define numactl path within the container
 
-Default Value: /usr/bin/numactl
+Default Value: `/usr/bin/numactl`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
 
 ### .spec.agents.overrideDetectedNumberOfCores: boolean
 
@@ -249,9 +249,9 @@ If is set to true and Container CPU Limits are set, it sets Container Environmen
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L113)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L113)
 
 ### .spec.agents.overrideDetectedTotalMemory: boolean
 
@@ -263,23 +263,23 @@ If is set to true and Container Memory Limits are set, it sets Container Environ
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L101)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L101)
 
 ### .spec.agents.podModes.network: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
 
 ### .spec.agents.podModes.pid: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
 
 ### .spec.agents.port: integer
 
 Port define Port used by member
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L233)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L233)
 
 ### .spec.agents.priorityClassName: string
 
@@ -289,15 +289,15 @@ Will be forwarded to the pod spec.
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L156)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L156)
 
 ### .spec.agents.probes.livenessProbeDisabled: boolean
 
 LivenessProbeDisabled if set to true, the operator does not generate a liveness probe for new pods belonging to this group
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L245)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L245)
 
 ### .spec.agents.probes.livenessProbeSpec.failureThreshold: integer
 
@@ -305,58 +305,58 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.agents.probes.livenessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.agents.probes.livenessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.agents.probes.livenessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.agents.probes.livenessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.agents.probes.ReadinessProbeDisabled: boolean
 
 OldReadinessProbeDisabled if true readinessProbes are disabled
 Deprecated: This field is deprecated, keept only for backward compatibility.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L252)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L252)
 
 ### .spec.agents.probes.readinessProbeDisabled: boolean
 
 ReadinessProbeDisabled override flag for probe disabled in good manner (lowercase) with backward compatibility
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L254)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L254)
 
 ### .spec.agents.probes.readinessProbeSpec.failureThreshold: integer
 
@@ -364,51 +364,51 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.agents.probes.readinessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.agents.probes.readinessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.agents.probes.readinessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.agents.probes.readinessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.agents.probes.startupProbeDisabled: boolean
 
 StartupProbeDisabled if true startupProbes are disabled
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L259)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L259)
 
 ### .spec.agents.probes.startupProbeSpec.failureThreshold: integer
 
@@ -416,45 +416,45 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.agents.probes.startupProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.agents.probes.startupProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.agents.probes.startupProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.agents.probes.startupProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.agents.pvcResizeMode: string
 
@@ -464,7 +464,7 @@ Possible Values:
 * runtime (default) - PVC will be resized in Pod runtime (EKS, GKE)
 * rotate - Pod will be shutdown and PVC will be resized (AKS)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L170)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L170)
 
 ### .spec.agents.resources: core.ResourceRequirements
 
@@ -473,69 +473,69 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L95)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L95)
 
 ### .spec.agents.schedulerName: string
 
 SchedulerName define scheduler name used for group
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L89)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L89)
 
 ### .spec.agents.securityContext.addCapabilities: []core.Capability
 
 AddCapabilities add new capabilities to containers
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
 
 ### .spec.agents.securityContext.allowPrivilegeEscalation: boolean
 
 AllowPrivilegeEscalation Controls whether a process can gain more privileges than its parent process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
 
 ### .spec.agents.securityContext.dropAllCapabilities: boolean
 
 DropAllCapabilities specifies if capabilities should be dropped for this pod containers
 Deprecated: This field is added for backward compatibility. Will be removed in 1.1.0.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
 
 ### .spec.agents.securityContext.fsGroup: integer
 
 FSGroup is a special supplemental group that applies to all containers in a pod.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
 
 ### .spec.agents.securityContext.privileged: boolean
 
 Privileged If true, runs container in privileged mode. Processes in privileged containers are
 essentially equivalent to root on the host.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
 
 ### .spec.agents.securityContext.readOnlyRootFilesystem: boolean
 
 ReadOnlyRootFilesystem if true, mounts the container's root filesystem as read-only.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
 
 ### .spec.agents.securityContext.runAsGroup: integer
 
 RunAsGroup is the GID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
 
 ### .spec.agents.securityContext.runAsNonRoot: boolean
 
 RunAsNonRoot if true, indicates that the container must run as a non-root user.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
 
 ### .spec.agents.securityContext.runAsUser: integer
 
 RunAsUser is the UID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
 
 ### .spec.agents.securityContext.seccompProfile: core.SeccompProfile
 
@@ -544,7 +544,7 @@ SeccompProfile defines a pod/container's seccomp profile settings. Only one prof
 Links:
 * [Documentation of core.SeccompProfile](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#seccompprofile-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
 
 ### .spec.agents.securityContext.seLinuxOptions: core.SELinuxOptions
 
@@ -553,14 +553,14 @@ SELinuxOptions are the labels to be applied to the container
 Links:
 * [Documentation of core.SELinuxOptions](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#selinuxoptions-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
 
 ### .spec.agents.securityContext.supplementalGroups: array
 
 SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID,
 the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
 
 ### .spec.agents.securityContext.sysctls: map[string]intstr.IntOrString
 
@@ -579,7 +579,7 @@ sysctls:
   "kernel.msgmax": "65536"
 ```
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
 
 ### .spec.agents.serviceAccountName: string
 
@@ -592,26 +592,26 @@ deployment of the operator, we grant the rights to 'get' all 'pod' resources.
 If you are using a different service account, please grant these rights
 to that service account.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L146)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L146)
 
 ### .spec.agents.shutdownDelay: integer
 
 ShutdownDelay define how long operator should delay finalizer removal after shutdown
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L211)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L211)
 
 ### .spec.agents.shutdownMethod: string
 
 ShutdownMethod describe procedure of member shutdown taken by Operator
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L209)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L209)
 
 ### .spec.agents.sidecarCoreNames: array
 
 SidecarCoreNames is a list of sidecar containers which must run in the pod.
 Some names (e.g.: "server", "worker") are reserved, and they don't have any impact.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L187)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L187)
 
 ### .spec.agents.sidecars: []core.Container
 
@@ -620,19 +620,19 @@ Sidecars specifies a list of additional containers to be started
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L191)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L191)
 
 ### .spec.agents.storageClassName: string
 
 StorageClassName specifies the classname for storage of the servers.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L91)
 
 ### .spec.agents.terminationGracePeriodSeconds: integer
 
 TerminationGracePeriodSeconds override default TerminationGracePeriodSeconds for pods - via silent rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L224)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L224)
 
 ### .spec.agents.tolerations: []core.Toleration
 
@@ -646,13 +646,13 @@ For more information on tolerations, consult the https://kubernetes.io/docs/conc
 Links:
 * [Documentation of core.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L122)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L122)
 
 ### .spec.agents.volumeAllowShrink: boolean
 
 Deprecated: VolumeAllowShrink allows shrink the volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L172)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L172)
 
 ### .spec.agents.volumeClaimTemplate: core.PersistentVolumeClaim
 
@@ -666,7 +666,7 @@ and `iops` is not forwarded to the pods resource requirements.
 Links:
 * [Documentation of core.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaim-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L165)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L165)
 
 ### .spec.agents.volumeMounts: []ServerGroupSpecVolumeMount
 
@@ -675,7 +675,7 @@ VolumeMounts define list of volume mounts mounted into server container
 Links:
 * [Documentation of ServerGroupSpecVolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L201)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L201)
 
 ### .spec.agents.volumes\[int\].configMap: core.ConfigMapVolumeSource
 
@@ -684,7 +684,7 @@ ConfigMap which should be mounted into pod
 Links:
 * [Documentation of core.ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#configmapvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L138)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L138)
 
 ### .spec.agents.volumes\[int\].emptyDir: core.EmptyDirVolumeSource
 
@@ -693,7 +693,7 @@ EmptyDir
 Links:
 * [Documentation of core.EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#emptydirvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L143)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L143)
 
 ### .spec.agents.volumes\[int\].hostPath: core.HostPathVolumeSource
 
@@ -702,13 +702,13 @@ HostPath
 Links:
 * [Documentation of core.HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#hostpathvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L148)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L148)
 
 ### .spec.agents.volumes\[int\].name: string
 
 Name of volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L128)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L128)
 
 ### .spec.agents.volumes\[int\].persistentVolumeClaim: core.PersistentVolumeClaimVolumeSource
 
@@ -717,7 +717,7 @@ PersistentVolumeClaim
 Links:
 * [Documentation of core.PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L153)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L153)
 
 ### .spec.agents.volumes\[int\].secret: core.SecretVolumeSource
 
@@ -726,25 +726,25 @@ Secret which should be mounted into pod
 Links:
 * [Documentation of core.SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L133)
 
 ### .spec.allowUnsafeUpgrade: boolean
 
 AllowUnsafeUpgrade determines if upgrade on missing member or with not in sync shards is allowed
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L163)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L163)
 
 ### .spec.annotations: object
 
 Annotations specifies the annotations added to all ArangoDeployment owned resources (pods, services, PVC’s, PDB’s).
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L126)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L126)
 
 ### .spec.annotationsIgnoreList: array
 
 AnnotationsIgnoreList list regexp or plain definitions which annotations should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L129)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L129)
 
 ### .spec.annotationsMode: string
 
@@ -755,7 +755,7 @@ Possible Values:
 * append - Add new annotations/labels without affecting old ones
 * replace - Replace existing annotations/labels
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L135)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L135)
 
 ### .spec.architecture: []string
 
@@ -772,9 +772,9 @@ architecture for the deployment that you want to migrate to.
 Links:
 * [Architecture Change](/docs/how-to/arch_change.md)
 
-Default Value: ['amd64']
+Default Value: `['amd64']`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L265)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L265)
 
 ### .spec.auth.jwtSecretName: string
 
@@ -788,7 +788,7 @@ If you specify a name of a `Secret` that does not exist, a random token is creat
 and stored in a `Secret` with given name.
 Changing a JWT token results in restarting of a whole cluster.
 
-[Code Reference](/pkg/apis/deployment/v1/authentication_spec.go#L40)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/authentication_spec.go#L40)
 
 ### .spec.bootstrap.passwordSecretNames: map[string]string
 
@@ -804,34 +804,34 @@ There are two magic values for the secret name:
 Links:
 * [How to set root user password](/docs/how-to/set_root_user_password.md)
 
-[Code Reference](/pkg/apis/deployment/v1/bootstrap.go#L62)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/bootstrap.go#L62)
 
 ### .spec.chaos.enabled: boolean
 
 Enabled switches the chaos monkey for a deployment on or off.
 
-[Code Reference](/pkg/apis/deployment/v1/chaos_spec.go#L33)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/chaos_spec.go#L33)
 
 ### .spec.chaos.interval: integer
 
 Interval is the time between events
 
-[Code Reference](/pkg/apis/deployment/v1/chaos_spec.go#L35)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/chaos_spec.go#L35)
 
 ### .spec.chaos.kill-pod-probability: integer
 
 KillPodProbability is the chance of a pod being killed during an event
 
-[Code Reference](/pkg/apis/deployment/v1/chaos_spec.go#L37)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/chaos_spec.go#L37)
 
 ### .spec.ClusterDomain: string
 
 ClusterDomain define domain used in the kubernetes cluster.
 Required only of domain is not set to default (cluster.local)
 
-Default Value: cluster.local
+Default Value: `cluster.local`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L237)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L237)
 
 ### .spec.communicationMethod: string
 
@@ -844,7 +844,7 @@ Possible Values:
 * headless-dns - Define Headless Service DNS based communication.
 * ip - Define ClusterIP Service IP based communication.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L245)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L245)
 
 ### .spec.coordinators.affinity: core.PodAffinity
 
@@ -853,7 +853,7 @@ Affinity specified additional affinity settings in ArangoDB Pod definitions
 Links:
 * [Documentation of core.PodAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L180)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L180)
 
 ### .spec.coordinators.allowMemberRecreation: boolean
 
@@ -862,26 +862,26 @@ This setting changes the member recreation logic based on group:
 - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
 - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L222)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L222)
 
 ### .spec.coordinators.annotations: object
 
 Annotations specified the annotations added to Pods in this group.
 Annotations are merged with `spec.annotations`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L125)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L125)
 
 ### .spec.coordinators.annotationsIgnoreList: array
 
 AnnotationsIgnoreList list regexp or plain definitions which annotations should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L127)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L127)
 
 ### .spec.coordinators.annotationsMode: string
 
 AnnotationsMode Define annotations mode which should be use while overriding annotations
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L129)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L129)
 
 ### .spec.coordinators.antiAffinity: core.PodAntiAffinity
 
@@ -890,15 +890,15 @@ AntiAffinity specified additional antiAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of core.Pod.AntiAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podantiaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L176)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L176)
 
 ### .spec.coordinators.args: []string
 
 Args setting specifies additional command-line arguments passed to all servers of this group.
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L85)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L85)
 
 ### .spec.coordinators.count: integer
 
@@ -909,21 +909,21 @@ for `spec.mode: Single` and `2` for `spec.mode: ActiveFailover`).
 For the `syncworkers` group, it is highly recommended to use the same number
 as for the `dbservers` group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L77)
 
 ### .spec.coordinators.entrypoint: string
 
 Entrypoint overrides container executable
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L87)
 
 ### .spec.coordinators.envs\[int\].name: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L26)
 
 ### .spec.coordinators.envs\[int\].value: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L27)
 
 ### .spec.coordinators.ephemeralVolumes.apps.size: resource.Quantity
 
@@ -932,7 +932,7 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.coordinators.ephemeralVolumes.temp.size: resource.Quantity
 
@@ -941,25 +941,25 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.coordinators.exporterPort: integer
 
 ExporterPort define Port used by exporter
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L235)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L235)
 
 ### .spec.coordinators.extendedRotationCheck: boolean
 
 ExtendedRotationCheck extend checks for rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L205)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L205)
 
 ### .spec.coordinators.externalPortEnabled: boolean
 
 ExternalPortEnabled if external port should be enabled. If is set to false, ports needs to be exposed via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L217)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L217)
 
 ### .spec.coordinators.indexMethod: string
 
@@ -969,7 +969,7 @@ Possible Values:
 * random (default) - Pick random ID for member. Enforced on the Community Operator.
 * ordered - Use sequential number as Member ID, starting from 0. Enterprise Operator required.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L228)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L228)
 
 ### .spec.coordinators.initContainers.containers: []core.Container
 
@@ -978,49 +978,49 @@ Containers contains list of containers
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
 
 ### .spec.coordinators.initContainers.mode: string
 
 Mode keep container replace mode
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
 
 ### .spec.coordinators.internalPort: integer
 
 InternalPort define port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L213)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L213)
 
 ### .spec.coordinators.internalPortProtocol: string
 
 InternalPortProtocol define protocol of port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L215)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L215)
 
 ### .spec.coordinators.labels: object
 
 Labels specified the labels added to Pods in this group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L131)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L131)
 
 ### .spec.coordinators.labelsIgnoreList: array
 
 LabelsIgnoreList list regexp or plain definitions which labels should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L133)
 
 ### .spec.coordinators.labelsMode: string
 
 LabelsMode Define labels mode which should be use while overriding labels
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L135)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L135)
 
 ### .spec.coordinators.maxCount: integer
 
 MaxCount specifies a maximum for the count of servers. If set, a specification is invalid if `count > maxCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L81)
 
 ### .spec.coordinators.memoryReservation: integer
 
@@ -1031,15 +1031,15 @@ Accepted Range <0, 50>. If the value is outside the accepted range, it is adjust
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: 0
+Default Value: `0`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L107)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L107)
 
 ### .spec.coordinators.minCount: integer
 
 MinCount specifies a minimum for the count of servers. If set, a specification is invalid if `count < minCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L79)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L79)
 
 ### .spec.coordinators.nodeAffinity: core.NodeAffinity
 
@@ -1048,7 +1048,7 @@ NodeAffinity specified additional nodeAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of code.NodeAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#nodeaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L184)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L184)
 
 ### .spec.coordinators.nodeSelector: map[string]string
 
@@ -1057,31 +1057,31 @@ NodeSelector setting specifies a set of labels to be used as `nodeSelector` for 
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L150)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L150)
 
 ### .spec.coordinators.numactl.args: array
 
 Args define list of the numactl process
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
 
 ### .spec.coordinators.numactl.enabled: boolean
 
 Enabled define if numactl should be enabled
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
 
 ### .spec.coordinators.numactl.path: string
 
 Path define numactl path within the container
 
-Default Value: /usr/bin/numactl
+Default Value: `/usr/bin/numactl`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
 
 ### .spec.coordinators.overrideDetectedNumberOfCores: boolean
 
@@ -1093,9 +1093,9 @@ If is set to true and Container CPU Limits are set, it sets Container Environmen
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L113)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L113)
 
 ### .spec.coordinators.overrideDetectedTotalMemory: boolean
 
@@ -1107,23 +1107,23 @@ If is set to true and Container Memory Limits are set, it sets Container Environ
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L101)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L101)
 
 ### .spec.coordinators.podModes.network: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
 
 ### .spec.coordinators.podModes.pid: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
 
 ### .spec.coordinators.port: integer
 
 Port define Port used by member
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L233)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L233)
 
 ### .spec.coordinators.priorityClassName: string
 
@@ -1133,15 +1133,15 @@ Will be forwarded to the pod spec.
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L156)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L156)
 
 ### .spec.coordinators.probes.livenessProbeDisabled: boolean
 
 LivenessProbeDisabled if set to true, the operator does not generate a liveness probe for new pods belonging to this group
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L245)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L245)
 
 ### .spec.coordinators.probes.livenessProbeSpec.failureThreshold: integer
 
@@ -1149,58 +1149,58 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.coordinators.probes.livenessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.coordinators.probes.livenessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.coordinators.probes.livenessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.coordinators.probes.livenessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.coordinators.probes.ReadinessProbeDisabled: boolean
 
 OldReadinessProbeDisabled if true readinessProbes are disabled
 Deprecated: This field is deprecated, keept only for backward compatibility.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L252)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L252)
 
 ### .spec.coordinators.probes.readinessProbeDisabled: boolean
 
 ReadinessProbeDisabled override flag for probe disabled in good manner (lowercase) with backward compatibility
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L254)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L254)
 
 ### .spec.coordinators.probes.readinessProbeSpec.failureThreshold: integer
 
@@ -1208,51 +1208,51 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.coordinators.probes.readinessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.coordinators.probes.readinessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.coordinators.probes.readinessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.coordinators.probes.readinessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.coordinators.probes.startupProbeDisabled: boolean
 
 StartupProbeDisabled if true startupProbes are disabled
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L259)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L259)
 
 ### .spec.coordinators.probes.startupProbeSpec.failureThreshold: integer
 
@@ -1260,45 +1260,45 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.coordinators.probes.startupProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.coordinators.probes.startupProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.coordinators.probes.startupProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.coordinators.probes.startupProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.coordinators.pvcResizeMode: string
 
@@ -1308,7 +1308,7 @@ Possible Values:
 * runtime (default) - PVC will be resized in Pod runtime (EKS, GKE)
 * rotate - Pod will be shutdown and PVC will be resized (AKS)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L170)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L170)
 
 ### .spec.coordinators.resources: core.ResourceRequirements
 
@@ -1317,69 +1317,69 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L95)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L95)
 
 ### .spec.coordinators.schedulerName: string
 
 SchedulerName define scheduler name used for group
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L89)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L89)
 
 ### .spec.coordinators.securityContext.addCapabilities: []core.Capability
 
 AddCapabilities add new capabilities to containers
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
 
 ### .spec.coordinators.securityContext.allowPrivilegeEscalation: boolean
 
 AllowPrivilegeEscalation Controls whether a process can gain more privileges than its parent process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
 
 ### .spec.coordinators.securityContext.dropAllCapabilities: boolean
 
 DropAllCapabilities specifies if capabilities should be dropped for this pod containers
 Deprecated: This field is added for backward compatibility. Will be removed in 1.1.0.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
 
 ### .spec.coordinators.securityContext.fsGroup: integer
 
 FSGroup is a special supplemental group that applies to all containers in a pod.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
 
 ### .spec.coordinators.securityContext.privileged: boolean
 
 Privileged If true, runs container in privileged mode. Processes in privileged containers are
 essentially equivalent to root on the host.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
 
 ### .spec.coordinators.securityContext.readOnlyRootFilesystem: boolean
 
 ReadOnlyRootFilesystem if true, mounts the container's root filesystem as read-only.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
 
 ### .spec.coordinators.securityContext.runAsGroup: integer
 
 RunAsGroup is the GID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
 
 ### .spec.coordinators.securityContext.runAsNonRoot: boolean
 
 RunAsNonRoot if true, indicates that the container must run as a non-root user.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
 
 ### .spec.coordinators.securityContext.runAsUser: integer
 
 RunAsUser is the UID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
 
 ### .spec.coordinators.securityContext.seccompProfile: core.SeccompProfile
 
@@ -1388,7 +1388,7 @@ SeccompProfile defines a pod/container's seccomp profile settings. Only one prof
 Links:
 * [Documentation of core.SeccompProfile](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#seccompprofile-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
 
 ### .spec.coordinators.securityContext.seLinuxOptions: core.SELinuxOptions
 
@@ -1397,14 +1397,14 @@ SELinuxOptions are the labels to be applied to the container
 Links:
 * [Documentation of core.SELinuxOptions](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#selinuxoptions-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
 
 ### .spec.coordinators.securityContext.supplementalGroups: array
 
 SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID,
 the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
 
 ### .spec.coordinators.securityContext.sysctls: map[string]intstr.IntOrString
 
@@ -1423,7 +1423,7 @@ sysctls:
   "kernel.msgmax": "65536"
 ```
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
 
 ### .spec.coordinators.serviceAccountName: string
 
@@ -1436,26 +1436,26 @@ deployment of the operator, we grant the rights to 'get' all 'pod' resources.
 If you are using a different service account, please grant these rights
 to that service account.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L146)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L146)
 
 ### .spec.coordinators.shutdownDelay: integer
 
 ShutdownDelay define how long operator should delay finalizer removal after shutdown
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L211)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L211)
 
 ### .spec.coordinators.shutdownMethod: string
 
 ShutdownMethod describe procedure of member shutdown taken by Operator
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L209)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L209)
 
 ### .spec.coordinators.sidecarCoreNames: array
 
 SidecarCoreNames is a list of sidecar containers which must run in the pod.
 Some names (e.g.: "server", "worker") are reserved, and they don't have any impact.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L187)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L187)
 
 ### .spec.coordinators.sidecars: []core.Container
 
@@ -1464,19 +1464,19 @@ Sidecars specifies a list of additional containers to be started
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L191)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L191)
 
 ### .spec.coordinators.storageClassName: string
 
 StorageClassName specifies the classname for storage of the servers.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L91)
 
 ### .spec.coordinators.terminationGracePeriodSeconds: integer
 
 TerminationGracePeriodSeconds override default TerminationGracePeriodSeconds for pods - via silent rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L224)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L224)
 
 ### .spec.coordinators.tolerations: []core.Toleration
 
@@ -1490,13 +1490,13 @@ For more information on tolerations, consult the https://kubernetes.io/docs/conc
 Links:
 * [Documentation of core.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L122)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L122)
 
 ### .spec.coordinators.volumeAllowShrink: boolean
 
 Deprecated: VolumeAllowShrink allows shrink the volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L172)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L172)
 
 ### .spec.coordinators.volumeClaimTemplate: core.PersistentVolumeClaim
 
@@ -1510,7 +1510,7 @@ and `iops` is not forwarded to the pods resource requirements.
 Links:
 * [Documentation of core.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaim-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L165)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L165)
 
 ### .spec.coordinators.volumeMounts: []ServerGroupSpecVolumeMount
 
@@ -1519,7 +1519,7 @@ VolumeMounts define list of volume mounts mounted into server container
 Links:
 * [Documentation of ServerGroupSpecVolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L201)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L201)
 
 ### .spec.coordinators.volumes\[int\].configMap: core.ConfigMapVolumeSource
 
@@ -1528,7 +1528,7 @@ ConfigMap which should be mounted into pod
 Links:
 * [Documentation of core.ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#configmapvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L138)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L138)
 
 ### .spec.coordinators.volumes\[int\].emptyDir: core.EmptyDirVolumeSource
 
@@ -1537,7 +1537,7 @@ EmptyDir
 Links:
 * [Documentation of core.EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#emptydirvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L143)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L143)
 
 ### .spec.coordinators.volumes\[int\].hostPath: core.HostPathVolumeSource
 
@@ -1546,13 +1546,13 @@ HostPath
 Links:
 * [Documentation of core.HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#hostpathvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L148)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L148)
 
 ### .spec.coordinators.volumes\[int\].name: string
 
 Name of volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L128)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L128)
 
 ### .spec.coordinators.volumes\[int\].persistentVolumeClaim: core.PersistentVolumeClaimVolumeSource
 
@@ -1561,7 +1561,7 @@ PersistentVolumeClaim
 Links:
 * [Documentation of core.PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L153)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L153)
 
 ### .spec.coordinators.volumes\[int\].secret: core.SecretVolumeSource
 
@@ -1570,13 +1570,13 @@ Secret which should be mounted into pod
 Links:
 * [Documentation of core.SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L133)
 
 ### .spec.database.maintenance: boolean
 
 Maintenance manage maintenance mode on Cluster side. Requires maintenance feature to be enabled
 
-[Code Reference](/pkg/apis/deployment/v1/database_spec.go#L25)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/database_spec.go#L25)
 
 ### .spec.dbservers.affinity: core.PodAffinity
 
@@ -1585,7 +1585,7 @@ Affinity specified additional affinity settings in ArangoDB Pod definitions
 Links:
 * [Documentation of core.PodAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L180)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L180)
 
 ### .spec.dbservers.allowMemberRecreation: boolean
 
@@ -1594,26 +1594,26 @@ This setting changes the member recreation logic based on group:
 - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
 - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L222)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L222)
 
 ### .spec.dbservers.annotations: object
 
 Annotations specified the annotations added to Pods in this group.
 Annotations are merged with `spec.annotations`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L125)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L125)
 
 ### .spec.dbservers.annotationsIgnoreList: array
 
 AnnotationsIgnoreList list regexp or plain definitions which annotations should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L127)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L127)
 
 ### .spec.dbservers.annotationsMode: string
 
 AnnotationsMode Define annotations mode which should be use while overriding annotations
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L129)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L129)
 
 ### .spec.dbservers.antiAffinity: core.PodAntiAffinity
 
@@ -1622,15 +1622,15 @@ AntiAffinity specified additional antiAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of core.Pod.AntiAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podantiaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L176)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L176)
 
 ### .spec.dbservers.args: []string
 
 Args setting specifies additional command-line arguments passed to all servers of this group.
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L85)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L85)
 
 ### .spec.dbservers.count: integer
 
@@ -1641,21 +1641,21 @@ for `spec.mode: Single` and `2` for `spec.mode: ActiveFailover`).
 For the `syncworkers` group, it is highly recommended to use the same number
 as for the `dbservers` group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L77)
 
 ### .spec.dbservers.entrypoint: string
 
 Entrypoint overrides container executable
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L87)
 
 ### .spec.dbservers.envs\[int\].name: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L26)
 
 ### .spec.dbservers.envs\[int\].value: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L27)
 
 ### .spec.dbservers.ephemeralVolumes.apps.size: resource.Quantity
 
@@ -1664,7 +1664,7 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.dbservers.ephemeralVolumes.temp.size: resource.Quantity
 
@@ -1673,25 +1673,25 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.dbservers.exporterPort: integer
 
 ExporterPort define Port used by exporter
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L235)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L235)
 
 ### .spec.dbservers.extendedRotationCheck: boolean
 
 ExtendedRotationCheck extend checks for rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L205)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L205)
 
 ### .spec.dbservers.externalPortEnabled: boolean
 
 ExternalPortEnabled if external port should be enabled. If is set to false, ports needs to be exposed via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L217)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L217)
 
 ### .spec.dbservers.indexMethod: string
 
@@ -1701,7 +1701,7 @@ Possible Values:
 * random (default) - Pick random ID for member. Enforced on the Community Operator.
 * ordered - Use sequential number as Member ID, starting from 0. Enterprise Operator required.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L228)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L228)
 
 ### .spec.dbservers.initContainers.containers: []core.Container
 
@@ -1710,49 +1710,49 @@ Containers contains list of containers
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
 
 ### .spec.dbservers.initContainers.mode: string
 
 Mode keep container replace mode
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
 
 ### .spec.dbservers.internalPort: integer
 
 InternalPort define port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L213)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L213)
 
 ### .spec.dbservers.internalPortProtocol: string
 
 InternalPortProtocol define protocol of port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L215)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L215)
 
 ### .spec.dbservers.labels: object
 
 Labels specified the labels added to Pods in this group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L131)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L131)
 
 ### .spec.dbservers.labelsIgnoreList: array
 
 LabelsIgnoreList list regexp or plain definitions which labels should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L133)
 
 ### .spec.dbservers.labelsMode: string
 
 LabelsMode Define labels mode which should be use while overriding labels
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L135)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L135)
 
 ### .spec.dbservers.maxCount: integer
 
 MaxCount specifies a maximum for the count of servers. If set, a specification is invalid if `count > maxCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L81)
 
 ### .spec.dbservers.memoryReservation: integer
 
@@ -1763,15 +1763,15 @@ Accepted Range <0, 50>. If the value is outside the accepted range, it is adjust
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: 0
+Default Value: `0`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L107)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L107)
 
 ### .spec.dbservers.minCount: integer
 
 MinCount specifies a minimum for the count of servers. If set, a specification is invalid if `count < minCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L79)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L79)
 
 ### .spec.dbservers.nodeAffinity: core.NodeAffinity
 
@@ -1780,7 +1780,7 @@ NodeAffinity specified additional nodeAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of code.NodeAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#nodeaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L184)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L184)
 
 ### .spec.dbservers.nodeSelector: map[string]string
 
@@ -1789,31 +1789,31 @@ NodeSelector setting specifies a set of labels to be used as `nodeSelector` for 
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L150)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L150)
 
 ### .spec.dbservers.numactl.args: array
 
 Args define list of the numactl process
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
 
 ### .spec.dbservers.numactl.enabled: boolean
 
 Enabled define if numactl should be enabled
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
 
 ### .spec.dbservers.numactl.path: string
 
 Path define numactl path within the container
 
-Default Value: /usr/bin/numactl
+Default Value: `/usr/bin/numactl`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
 
 ### .spec.dbservers.overrideDetectedNumberOfCores: boolean
 
@@ -1825,9 +1825,9 @@ If is set to true and Container CPU Limits are set, it sets Container Environmen
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L113)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L113)
 
 ### .spec.dbservers.overrideDetectedTotalMemory: boolean
 
@@ -1839,23 +1839,23 @@ If is set to true and Container Memory Limits are set, it sets Container Environ
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L101)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L101)
 
 ### .spec.dbservers.podModes.network: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
 
 ### .spec.dbservers.podModes.pid: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
 
 ### .spec.dbservers.port: integer
 
 Port define Port used by member
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L233)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L233)
 
 ### .spec.dbservers.priorityClassName: string
 
@@ -1865,15 +1865,15 @@ Will be forwarded to the pod spec.
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L156)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L156)
 
 ### .spec.dbservers.probes.livenessProbeDisabled: boolean
 
 LivenessProbeDisabled if set to true, the operator does not generate a liveness probe for new pods belonging to this group
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L245)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L245)
 
 ### .spec.dbservers.probes.livenessProbeSpec.failureThreshold: integer
 
@@ -1881,58 +1881,58 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.dbservers.probes.livenessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.dbservers.probes.livenessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.dbservers.probes.livenessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.dbservers.probes.livenessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.dbservers.probes.ReadinessProbeDisabled: boolean
 
 OldReadinessProbeDisabled if true readinessProbes are disabled
 Deprecated: This field is deprecated, keept only for backward compatibility.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L252)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L252)
 
 ### .spec.dbservers.probes.readinessProbeDisabled: boolean
 
 ReadinessProbeDisabled override flag for probe disabled in good manner (lowercase) with backward compatibility
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L254)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L254)
 
 ### .spec.dbservers.probes.readinessProbeSpec.failureThreshold: integer
 
@@ -1940,51 +1940,51 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.dbservers.probes.readinessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.dbservers.probes.readinessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.dbservers.probes.readinessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.dbservers.probes.readinessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.dbservers.probes.startupProbeDisabled: boolean
 
 StartupProbeDisabled if true startupProbes are disabled
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L259)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L259)
 
 ### .spec.dbservers.probes.startupProbeSpec.failureThreshold: integer
 
@@ -1992,45 +1992,45 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.dbservers.probes.startupProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.dbservers.probes.startupProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.dbservers.probes.startupProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.dbservers.probes.startupProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.dbservers.pvcResizeMode: string
 
@@ -2040,7 +2040,7 @@ Possible Values:
 * runtime (default) - PVC will be resized in Pod runtime (EKS, GKE)
 * rotate - Pod will be shutdown and PVC will be resized (AKS)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L170)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L170)
 
 ### .spec.dbservers.resources: core.ResourceRequirements
 
@@ -2049,69 +2049,69 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L95)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L95)
 
 ### .spec.dbservers.schedulerName: string
 
 SchedulerName define scheduler name used for group
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L89)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L89)
 
 ### .spec.dbservers.securityContext.addCapabilities: []core.Capability
 
 AddCapabilities add new capabilities to containers
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
 
 ### .spec.dbservers.securityContext.allowPrivilegeEscalation: boolean
 
 AllowPrivilegeEscalation Controls whether a process can gain more privileges than its parent process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
 
 ### .spec.dbservers.securityContext.dropAllCapabilities: boolean
 
 DropAllCapabilities specifies if capabilities should be dropped for this pod containers
 Deprecated: This field is added for backward compatibility. Will be removed in 1.1.0.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
 
 ### .spec.dbservers.securityContext.fsGroup: integer
 
 FSGroup is a special supplemental group that applies to all containers in a pod.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
 
 ### .spec.dbservers.securityContext.privileged: boolean
 
 Privileged If true, runs container in privileged mode. Processes in privileged containers are
 essentially equivalent to root on the host.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
 
 ### .spec.dbservers.securityContext.readOnlyRootFilesystem: boolean
 
 ReadOnlyRootFilesystem if true, mounts the container's root filesystem as read-only.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
 
 ### .spec.dbservers.securityContext.runAsGroup: integer
 
 RunAsGroup is the GID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
 
 ### .spec.dbservers.securityContext.runAsNonRoot: boolean
 
 RunAsNonRoot if true, indicates that the container must run as a non-root user.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
 
 ### .spec.dbservers.securityContext.runAsUser: integer
 
 RunAsUser is the UID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
 
 ### .spec.dbservers.securityContext.seccompProfile: core.SeccompProfile
 
@@ -2120,7 +2120,7 @@ SeccompProfile defines a pod/container's seccomp profile settings. Only one prof
 Links:
 * [Documentation of core.SeccompProfile](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#seccompprofile-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
 
 ### .spec.dbservers.securityContext.seLinuxOptions: core.SELinuxOptions
 
@@ -2129,14 +2129,14 @@ SELinuxOptions are the labels to be applied to the container
 Links:
 * [Documentation of core.SELinuxOptions](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#selinuxoptions-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
 
 ### .spec.dbservers.securityContext.supplementalGroups: array
 
 SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID,
 the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
 
 ### .spec.dbservers.securityContext.sysctls: map[string]intstr.IntOrString
 
@@ -2155,7 +2155,7 @@ sysctls:
   "kernel.msgmax": "65536"
 ```
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
 
 ### .spec.dbservers.serviceAccountName: string
 
@@ -2168,26 +2168,26 @@ deployment of the operator, we grant the rights to 'get' all 'pod' resources.
 If you are using a different service account, please grant these rights
 to that service account.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L146)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L146)
 
 ### .spec.dbservers.shutdownDelay: integer
 
 ShutdownDelay define how long operator should delay finalizer removal after shutdown
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L211)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L211)
 
 ### .spec.dbservers.shutdownMethod: string
 
 ShutdownMethod describe procedure of member shutdown taken by Operator
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L209)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L209)
 
 ### .spec.dbservers.sidecarCoreNames: array
 
 SidecarCoreNames is a list of sidecar containers which must run in the pod.
 Some names (e.g.: "server", "worker") are reserved, and they don't have any impact.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L187)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L187)
 
 ### .spec.dbservers.sidecars: []core.Container
 
@@ -2196,19 +2196,19 @@ Sidecars specifies a list of additional containers to be started
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L191)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L191)
 
 ### .spec.dbservers.storageClassName: string
 
 StorageClassName specifies the classname for storage of the servers.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L91)
 
 ### .spec.dbservers.terminationGracePeriodSeconds: integer
 
 TerminationGracePeriodSeconds override default TerminationGracePeriodSeconds for pods - via silent rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L224)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L224)
 
 ### .spec.dbservers.tolerations: []core.Toleration
 
@@ -2222,13 +2222,13 @@ For more information on tolerations, consult the https://kubernetes.io/docs/conc
 Links:
 * [Documentation of core.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L122)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L122)
 
 ### .spec.dbservers.volumeAllowShrink: boolean
 
 Deprecated: VolumeAllowShrink allows shrink the volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L172)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L172)
 
 ### .spec.dbservers.volumeClaimTemplate: core.PersistentVolumeClaim
 
@@ -2242,7 +2242,7 @@ and `iops` is not forwarded to the pods resource requirements.
 Links:
 * [Documentation of core.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaim-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L165)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L165)
 
 ### .spec.dbservers.volumeMounts: []ServerGroupSpecVolumeMount
 
@@ -2251,7 +2251,7 @@ VolumeMounts define list of volume mounts mounted into server container
 Links:
 * [Documentation of ServerGroupSpecVolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L201)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L201)
 
 ### .spec.dbservers.volumes\[int\].configMap: core.ConfigMapVolumeSource
 
@@ -2260,7 +2260,7 @@ ConfigMap which should be mounted into pod
 Links:
 * [Documentation of core.ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#configmapvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L138)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L138)
 
 ### .spec.dbservers.volumes\[int\].emptyDir: core.EmptyDirVolumeSource
 
@@ -2269,7 +2269,7 @@ EmptyDir
 Links:
 * [Documentation of core.EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#emptydirvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L143)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L143)
 
 ### .spec.dbservers.volumes\[int\].hostPath: core.HostPathVolumeSource
 
@@ -2278,13 +2278,13 @@ HostPath
 Links:
 * [Documentation of core.HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#hostpathvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L148)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L148)
 
 ### .spec.dbservers.volumes\[int\].name: string
 
 Name of volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L128)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L128)
 
 ### .spec.dbservers.volumes\[int\].persistentVolumeClaim: core.PersistentVolumeClaimVolumeSource
 
@@ -2293,7 +2293,7 @@ PersistentVolumeClaim
 Links:
 * [Documentation of core.PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L153)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L153)
 
 ### .spec.dbservers.volumes\[int\].secret: core.SecretVolumeSource
 
@@ -2302,16 +2302,16 @@ Secret which should be mounted into pod
 Links:
 * [Documentation of core.SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L133)
 
 ### .spec.disableIPv6: boolean
 
 DisableIPv6 setting prevents the use of IPv6 addresses by ArangoDB servers.
 This setting cannot be changed after the deployment has been created.
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L109)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L109)
 
 ### .spec.downtimeAllowed: boolean
 
@@ -2323,9 +2323,9 @@ Operations that may result in downtime are:
 - Rotating TLS CA certificate
 Note: It is still possible that there is some downtime when the Kubernetes cluster is down, or in a bad state, irrespective of the value of this setting.
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L104)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L104)
 
 ### .spec.environment: string
 
@@ -2335,20 +2335,20 @@ Possible Values:
 * Development (default) - This value optimizes the deployment for development use. It is possible to run a deployment on a small number of nodes (e.g. minikube).
 * Production - This value optimizes the deployment for production use. It puts required affinity constraints on all pods to avoid Agents & DB-Servers from running on the same machine.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L65)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L65)
 
 ### .spec.externalAccess.advertisedEndpoint: string
 
 AdvertisedEndpoint is passed to the coordinators/single servers for advertising a specific endpoint
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L58)
 
 ### .spec.externalAccess.loadBalancerIP: string
 
 LoadBalancerIP define optional IP used to configure a load-balancer on, in case of Auto or LoadBalancer type.
 If you do not specify this setting, an IP will be chosen automatically by the load-balancer provisioner.
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L48)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L48)
 
 ### .spec.externalAccess.loadBalancerSourceRanges: array
 
@@ -2360,14 +2360,14 @@ cloud-provider does not support the feature.
 Links:
 * [Cloud Provider Firewall](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/)
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L55)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L55)
 
 ### .spec.externalAccess.managedServiceNames: array
 
 ManagedServiceNames keeps names of services which are not managed by KubeArangoDB.
 It is only relevant when type of service is `managed`.
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L62)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L62)
 
 ### .spec.externalAccess.nodePort: integer
 
@@ -2375,7 +2375,7 @@ NodePort define optional port used in case of Auto or NodePort type.
 This setting is used when `spec.externalAccess.type` is set to `NodePort` or `Auto`.
 If you do not specify this setting, a random port will be chosen automatically.
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L44)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L44)
 
 ### .spec.externalAccess.type: string
 
@@ -2387,11 +2387,11 @@ Possible Values:
 * LoadBalancer - Create a Service of type LoadBalancer for the ArangoDB deployment.
 * NodePort - Create a Service of type NodePort for the ArangoDB deployment.
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L39)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L39)
 
 ### .spec.features.foxx.queues: boolean
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_features.go#L24)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_features.go#L24)
 
 ### .spec.id.affinity: core.PodAffinity
 
@@ -2400,7 +2400,7 @@ Affinity specified additional affinity settings in ArangoDB Pod definitions
 Links:
 * [Documentation of core.PodAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L44)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L44)
 
 ### .spec.id.antiAffinity: core.PodAntiAffinity
 
@@ -2409,13 +2409,13 @@ AntiAffinity specified additional antiAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of core.Pod.AntiAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podantiaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L40)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L40)
 
 ### .spec.id.entrypoint: string
 
 Entrypoint overrides container executable
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L28)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L28)
 
 ### .spec.id.nodeAffinity: core.NodeAffinity
 
@@ -2424,19 +2424,19 @@ NodeAffinity specified additional nodeAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of code.NodeAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#nodeaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L48)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L48)
 
 ### .spec.id.nodeSelector: object
 
 NodeSelector specifies a set of selectors for nodes
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L34)
 
 ### .spec.id.priorityClassName: string
 
 PriorityClassName specifies a priority class name
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L36)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L36)
 
 ### .spec.id.resources: core.ResourceRequirements
 
@@ -2445,63 +2445,63 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L56)
 
 ### .spec.id.securityContext.addCapabilities: []core.Capability
 
 AddCapabilities add new capabilities to containers
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
 
 ### .spec.id.securityContext.allowPrivilegeEscalation: boolean
 
 AllowPrivilegeEscalation Controls whether a process can gain more privileges than its parent process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
 
 ### .spec.id.securityContext.dropAllCapabilities: boolean
 
 DropAllCapabilities specifies if capabilities should be dropped for this pod containers
 Deprecated: This field is added for backward compatibility. Will be removed in 1.1.0.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
 
 ### .spec.id.securityContext.fsGroup: integer
 
 FSGroup is a special supplemental group that applies to all containers in a pod.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
 
 ### .spec.id.securityContext.privileged: boolean
 
 Privileged If true, runs container in privileged mode. Processes in privileged containers are
 essentially equivalent to root on the host.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
 
 ### .spec.id.securityContext.readOnlyRootFilesystem: boolean
 
 ReadOnlyRootFilesystem if true, mounts the container's root filesystem as read-only.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
 
 ### .spec.id.securityContext.runAsGroup: integer
 
 RunAsGroup is the GID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
 
 ### .spec.id.securityContext.runAsNonRoot: boolean
 
 RunAsNonRoot if true, indicates that the container must run as a non-root user.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
 
 ### .spec.id.securityContext.runAsUser: integer
 
 RunAsUser is the UID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
 
 ### .spec.id.securityContext.seccompProfile: core.SeccompProfile
 
@@ -2510,7 +2510,7 @@ SeccompProfile defines a pod/container's seccomp profile settings. Only one prof
 Links:
 * [Documentation of core.SeccompProfile](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#seccompprofile-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
 
 ### .spec.id.securityContext.seLinuxOptions: core.SELinuxOptions
 
@@ -2519,14 +2519,14 @@ SELinuxOptions are the labels to be applied to the container
 Links:
 * [Documentation of core.SELinuxOptions](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#selinuxoptions-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
 
 ### .spec.id.securityContext.supplementalGroups: array
 
 SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID,
 the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
 
 ### .spec.id.securityContext.sysctls: map[string]intstr.IntOrString
 
@@ -2545,13 +2545,13 @@ sysctls:
   "kernel.msgmax": "65536"
 ```
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
 
 ### .spec.id.serviceAccountName: string
 
 ServiceAccountName specifies the name of the service account used for Pods in this group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L50)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L50)
 
 ### .spec.id.tolerations: []core.Toleration
 
@@ -2560,7 +2560,7 @@ Tolerations specifies the tolerations added to Pods in this group.
 Links:
 * [Documentation of core.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_id_group_spec.go#L32)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_id_group_spec.go#L32)
 
 ### .spec.image: string
 
@@ -2569,7 +2569,7 @@ In a development environment this setting defaults to arangodb/arangodb:latest.
 For production environments this is a required setting without a default value.
 It is highly recommend to use explicit version (not latest) for production environments.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L78)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L78)
 
 ### .spec.imageDiscoveryMode: string
 
@@ -2579,7 +2579,7 @@ Possible Values:
 * kubelet (default) - Use sha256 of the discovered image in the pods
 * direct - Use image provided in the spec.image directly in the pods
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L94)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L94)
 
 ### .spec.imagePullPolicy: core.PullPolicy
 
@@ -2593,25 +2593,25 @@ Possible Values:
 * Never - Means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
 * IfNotPresent - Means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L86)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L86)
 
 ### .spec.imagePullSecrets: array
 
 ImagePullSecrets specifies the list of image pull secrets for the docker image to use for all ArangoDB servers.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L89)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L89)
 
 ### .spec.labels: object
 
 Labels specifies the labels added to Pods in this group.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L138)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L138)
 
 ### .spec.labelsIgnoreList: array
 
 LabelsIgnoreList list regexp or plain definitions which labels should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L141)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L141)
 
 ### .spec.labelsMode: string
 
@@ -2622,7 +2622,7 @@ Possible Values:
 * append - Add new annotations/labels without affecting old ones
 * replace - Replace existing annotations/labels
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L147)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L147)
 
 ### .spec.license.secretName: string
 
@@ -2630,7 +2630,7 @@ SecretName setting specifies the name of a kubernetes `Secret` that contains
 the license key token used for enterprise images. This value is not used for
 the Community Edition.
 
-[Code Reference](/pkg/apis/deployment/v1/license_spec.go#L33)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/license_spec.go#L33)
 
 ### .spec.lifecycle.resources: core.ResourceRequirements
 
@@ -2639,7 +2639,7 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/lifecycle_spec.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/lifecycle_spec.go#L31)
 
 ### .spec.memberPropagationMode: string
 
@@ -2653,13 +2653,13 @@ Possible Values:
 * always (default) - Restart the member as soon as a configuration change is discovered
 * on-restart - Wait until the next restart to change the member configuration
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L220)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L220)
 
 ### .spec.metrics.authentication.jwtTokenSecretName: string
 
 JWTTokenSecretName contains the name of the JWT kubernetes secret used for authentication
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_spec.go#L34)
 
 ### .spec.metrics.enabled: boolean
 
@@ -2669,25 +2669,25 @@ every Agent, DB-Server, Coordinator and Single server.
 Links:
 * [Metrics collection](/docs/metrics.md)
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_spec.go#L81)
 
 ### .spec.metrics.image: string
 
 deprecated
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_spec.go#L83)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_spec.go#L83)
 
 ### .spec.metrics.mode: string
 
 deprecated
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_spec.go#L90)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_spec.go#L90)
 
 ### .spec.metrics.port: integer
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_spec.go#L99)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_spec.go#L99)
 
 ### .spec.metrics.resources: core.ResourceRequirements
 
@@ -2696,15 +2696,15 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_spec.go#L88)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_spec.go#L88)
 
 ### .spec.metrics.serviceMonitor.enabled: boolean
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_service_monitor_spec.go#L24)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_service_monitor_spec.go#L24)
 
 ### .spec.metrics.serviceMonitor.labels: object
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_service_monitor_spec.go#L25)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_service_monitor_spec.go#L25)
 
 ### .spec.metrics.tls: boolean
 
@@ -2712,9 +2712,9 @@ TLS defines if TLS should be enabled on Metrics exporter endpoint.
 This option will enable TLS only if TLS is enabled on ArangoDeployment,
 otherwise `true` value will not take any effect.
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_metrics_spec.go#L95)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_metrics_spec.go#L95)
 
 ### .spec.mode: string
 
@@ -2727,7 +2727,7 @@ Possible Values:
 
 This field is **immutable**: Change of the ArangoDeployment Mode is not possible after creation.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L60)
 
 ### .spec.networkAttachedVolumes: boolean
 
@@ -2737,38 +2737,38 @@ Furthermore, the pod will simply be redeployed on a different node, rather than 
 You must only set this option to true if your persistent volumes are “movable” in the sense that they can be mounted from a different k8s node, like in the case of network attached volumes.
 If your persistent volumes are tied to a specific pod, you must leave this option on false.
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L123)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L123)
 
 ### .spec.rebalancer.enabled: boolean
 
-[Code Reference](/pkg/apis/deployment/v1/rebalancer_spec.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/rebalancer_spec.go#L26)
 
 ### .spec.rebalancer.optimizers.leader: boolean
 
-[Code Reference](/pkg/apis/deployment/v1/rebalancer_spec.go#L74)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/rebalancer_spec.go#L74)
 
 ### .spec.rebalancer.parallelMoves: integer
 
-[Code Reference](/pkg/apis/deployment/v1/rebalancer_spec.go#L28)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/rebalancer_spec.go#L28)
 
 ### .spec.rebalancer.readers.count: boolean
 
 deprecated does not work in Rebalancer V2
 Count Enable Shard Count machanism
 
-[Code Reference](/pkg/apis/deployment/v1/rebalancer_spec.go#L62)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/rebalancer_spec.go#L62)
 
 ### .spec.recovery.autoRecover: boolean
 
-[Code Reference](/pkg/apis/deployment/v1/recovery_spec.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/recovery_spec.go#L26)
 
 ### .spec.restoreEncryptionSecret: string
 
 RestoreEncryptionSecret specifies optional name of secret which contains encryption key used for restore
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L160)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L160)
 
 ### .spec.restoreFrom: string
 
@@ -2781,7 +2781,7 @@ It will contain some of the following fields:
 If the restoreFrom key is removed from the spec, the restore key is deleted as well.
 A new restore attempt is made if and only if either in the status restore is not set or if spec.restoreFrom and status.requestedFrom are different.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L157)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L157)
 
 ### .spec.rocksdb.encryption.keySecretName: string
 
@@ -2792,7 +2792,7 @@ This requires the Enterprise Edition.
 The encryption key cannot be changed after the cluster has been created.
 The secret specified by this setting, must have a data field named 'key' containing an encryption key that is exactly 32 bytes long.
 
-[Code Reference](/pkg/apis/deployment/v1/rocksdb_spec.go#L37)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/rocksdb_spec.go#L37)
 
 ### .spec.single.affinity: core.PodAffinity
 
@@ -2801,7 +2801,7 @@ Affinity specified additional affinity settings in ArangoDB Pod definitions
 Links:
 * [Documentation of core.PodAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L180)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L180)
 
 ### .spec.single.allowMemberRecreation: boolean
 
@@ -2810,26 +2810,26 @@ This setting changes the member recreation logic based on group:
 - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
 - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L222)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L222)
 
 ### .spec.single.annotations: object
 
 Annotations specified the annotations added to Pods in this group.
 Annotations are merged with `spec.annotations`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L125)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L125)
 
 ### .spec.single.annotationsIgnoreList: array
 
 AnnotationsIgnoreList list regexp or plain definitions which annotations should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L127)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L127)
 
 ### .spec.single.annotationsMode: string
 
 AnnotationsMode Define annotations mode which should be use while overriding annotations
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L129)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L129)
 
 ### .spec.single.antiAffinity: core.PodAntiAffinity
 
@@ -2838,15 +2838,15 @@ AntiAffinity specified additional antiAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of core.Pod.AntiAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podantiaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L176)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L176)
 
 ### .spec.single.args: []string
 
 Args setting specifies additional command-line arguments passed to all servers of this group.
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L85)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L85)
 
 ### .spec.single.count: integer
 
@@ -2857,21 +2857,21 @@ for `spec.mode: Single` and `2` for `spec.mode: ActiveFailover`).
 For the `syncworkers` group, it is highly recommended to use the same number
 as for the `dbservers` group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L77)
 
 ### .spec.single.entrypoint: string
 
 Entrypoint overrides container executable
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L87)
 
 ### .spec.single.envs\[int\].name: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L26)
 
 ### .spec.single.envs\[int\].value: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L27)
 
 ### .spec.single.ephemeralVolumes.apps.size: resource.Quantity
 
@@ -2880,7 +2880,7 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.single.ephemeralVolumes.temp.size: resource.Quantity
 
@@ -2889,25 +2889,25 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.single.exporterPort: integer
 
 ExporterPort define Port used by exporter
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L235)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L235)
 
 ### .spec.single.extendedRotationCheck: boolean
 
 ExtendedRotationCheck extend checks for rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L205)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L205)
 
 ### .spec.single.externalPortEnabled: boolean
 
 ExternalPortEnabled if external port should be enabled. If is set to false, ports needs to be exposed via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L217)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L217)
 
 ### .spec.single.indexMethod: string
 
@@ -2917,7 +2917,7 @@ Possible Values:
 * random (default) - Pick random ID for member. Enforced on the Community Operator.
 * ordered - Use sequential number as Member ID, starting from 0. Enterprise Operator required.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L228)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L228)
 
 ### .spec.single.initContainers.containers: []core.Container
 
@@ -2926,49 +2926,49 @@ Containers contains list of containers
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
 
 ### .spec.single.initContainers.mode: string
 
 Mode keep container replace mode
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
 
 ### .spec.single.internalPort: integer
 
 InternalPort define port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L213)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L213)
 
 ### .spec.single.internalPortProtocol: string
 
 InternalPortProtocol define protocol of port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L215)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L215)
 
 ### .spec.single.labels: object
 
 Labels specified the labels added to Pods in this group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L131)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L131)
 
 ### .spec.single.labelsIgnoreList: array
 
 LabelsIgnoreList list regexp or plain definitions which labels should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L133)
 
 ### .spec.single.labelsMode: string
 
 LabelsMode Define labels mode which should be use while overriding labels
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L135)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L135)
 
 ### .spec.single.maxCount: integer
 
 MaxCount specifies a maximum for the count of servers. If set, a specification is invalid if `count > maxCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L81)
 
 ### .spec.single.memoryReservation: integer
 
@@ -2979,15 +2979,15 @@ Accepted Range <0, 50>. If the value is outside the accepted range, it is adjust
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: 0
+Default Value: `0`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L107)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L107)
 
 ### .spec.single.minCount: integer
 
 MinCount specifies a minimum for the count of servers. If set, a specification is invalid if `count < minCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L79)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L79)
 
 ### .spec.single.nodeAffinity: core.NodeAffinity
 
@@ -2996,7 +2996,7 @@ NodeAffinity specified additional nodeAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of code.NodeAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#nodeaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L184)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L184)
 
 ### .spec.single.nodeSelector: map[string]string
 
@@ -3005,31 +3005,31 @@ NodeSelector setting specifies a set of labels to be used as `nodeSelector` for 
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L150)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L150)
 
 ### .spec.single.numactl.args: array
 
 Args define list of the numactl process
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
 
 ### .spec.single.numactl.enabled: boolean
 
 Enabled define if numactl should be enabled
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
 
 ### .spec.single.numactl.path: string
 
 Path define numactl path within the container
 
-Default Value: /usr/bin/numactl
+Default Value: `/usr/bin/numactl`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
 
 ### .spec.single.overrideDetectedNumberOfCores: boolean
 
@@ -3041,9 +3041,9 @@ If is set to true and Container CPU Limits are set, it sets Container Environmen
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L113)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L113)
 
 ### .spec.single.overrideDetectedTotalMemory: boolean
 
@@ -3055,23 +3055,23 @@ If is set to true and Container Memory Limits are set, it sets Container Environ
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L101)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L101)
 
 ### .spec.single.podModes.network: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
 
 ### .spec.single.podModes.pid: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
 
 ### .spec.single.port: integer
 
 Port define Port used by member
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L233)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L233)
 
 ### .spec.single.priorityClassName: string
 
@@ -3081,15 +3081,15 @@ Will be forwarded to the pod spec.
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L156)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L156)
 
 ### .spec.single.probes.livenessProbeDisabled: boolean
 
 LivenessProbeDisabled if set to true, the operator does not generate a liveness probe for new pods belonging to this group
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L245)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L245)
 
 ### .spec.single.probes.livenessProbeSpec.failureThreshold: integer
 
@@ -3097,58 +3097,58 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.single.probes.livenessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.single.probes.livenessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.single.probes.livenessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.single.probes.livenessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.single.probes.ReadinessProbeDisabled: boolean
 
 OldReadinessProbeDisabled if true readinessProbes are disabled
 Deprecated: This field is deprecated, keept only for backward compatibility.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L252)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L252)
 
 ### .spec.single.probes.readinessProbeDisabled: boolean
 
 ReadinessProbeDisabled override flag for probe disabled in good manner (lowercase) with backward compatibility
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L254)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L254)
 
 ### .spec.single.probes.readinessProbeSpec.failureThreshold: integer
 
@@ -3156,51 +3156,51 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.single.probes.readinessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.single.probes.readinessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.single.probes.readinessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.single.probes.readinessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.single.probes.startupProbeDisabled: boolean
 
 StartupProbeDisabled if true startupProbes are disabled
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L259)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L259)
 
 ### .spec.single.probes.startupProbeSpec.failureThreshold: integer
 
@@ -3208,45 +3208,45 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.single.probes.startupProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.single.probes.startupProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.single.probes.startupProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.single.probes.startupProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.single.pvcResizeMode: string
 
@@ -3256,7 +3256,7 @@ Possible Values:
 * runtime (default) - PVC will be resized in Pod runtime (EKS, GKE)
 * rotate - Pod will be shutdown and PVC will be resized (AKS)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L170)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L170)
 
 ### .spec.single.resources: core.ResourceRequirements
 
@@ -3265,69 +3265,69 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L95)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L95)
 
 ### .spec.single.schedulerName: string
 
 SchedulerName define scheduler name used for group
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L89)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L89)
 
 ### .spec.single.securityContext.addCapabilities: []core.Capability
 
 AddCapabilities add new capabilities to containers
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
 
 ### .spec.single.securityContext.allowPrivilegeEscalation: boolean
 
 AllowPrivilegeEscalation Controls whether a process can gain more privileges than its parent process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
 
 ### .spec.single.securityContext.dropAllCapabilities: boolean
 
 DropAllCapabilities specifies if capabilities should be dropped for this pod containers
 Deprecated: This field is added for backward compatibility. Will be removed in 1.1.0.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
 
 ### .spec.single.securityContext.fsGroup: integer
 
 FSGroup is a special supplemental group that applies to all containers in a pod.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
 
 ### .spec.single.securityContext.privileged: boolean
 
 Privileged If true, runs container in privileged mode. Processes in privileged containers are
 essentially equivalent to root on the host.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
 
 ### .spec.single.securityContext.readOnlyRootFilesystem: boolean
 
 ReadOnlyRootFilesystem if true, mounts the container's root filesystem as read-only.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
 
 ### .spec.single.securityContext.runAsGroup: integer
 
 RunAsGroup is the GID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
 
 ### .spec.single.securityContext.runAsNonRoot: boolean
 
 RunAsNonRoot if true, indicates that the container must run as a non-root user.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
 
 ### .spec.single.securityContext.runAsUser: integer
 
 RunAsUser is the UID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
 
 ### .spec.single.securityContext.seccompProfile: core.SeccompProfile
 
@@ -3336,7 +3336,7 @@ SeccompProfile defines a pod/container's seccomp profile settings. Only one prof
 Links:
 * [Documentation of core.SeccompProfile](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#seccompprofile-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
 
 ### .spec.single.securityContext.seLinuxOptions: core.SELinuxOptions
 
@@ -3345,14 +3345,14 @@ SELinuxOptions are the labels to be applied to the container
 Links:
 * [Documentation of core.SELinuxOptions](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#selinuxoptions-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
 
 ### .spec.single.securityContext.supplementalGroups: array
 
 SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID,
 the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
 
 ### .spec.single.securityContext.sysctls: map[string]intstr.IntOrString
 
@@ -3371,7 +3371,7 @@ sysctls:
   "kernel.msgmax": "65536"
 ```
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
 
 ### .spec.single.serviceAccountName: string
 
@@ -3384,26 +3384,26 @@ deployment of the operator, we grant the rights to 'get' all 'pod' resources.
 If you are using a different service account, please grant these rights
 to that service account.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L146)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L146)
 
 ### .spec.single.shutdownDelay: integer
 
 ShutdownDelay define how long operator should delay finalizer removal after shutdown
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L211)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L211)
 
 ### .spec.single.shutdownMethod: string
 
 ShutdownMethod describe procedure of member shutdown taken by Operator
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L209)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L209)
 
 ### .spec.single.sidecarCoreNames: array
 
 SidecarCoreNames is a list of sidecar containers which must run in the pod.
 Some names (e.g.: "server", "worker") are reserved, and they don't have any impact.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L187)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L187)
 
 ### .spec.single.sidecars: []core.Container
 
@@ -3412,19 +3412,19 @@ Sidecars specifies a list of additional containers to be started
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L191)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L191)
 
 ### .spec.single.storageClassName: string
 
 StorageClassName specifies the classname for storage of the servers.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L91)
 
 ### .spec.single.terminationGracePeriodSeconds: integer
 
 TerminationGracePeriodSeconds override default TerminationGracePeriodSeconds for pods - via silent rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L224)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L224)
 
 ### .spec.single.tolerations: []core.Toleration
 
@@ -3438,13 +3438,13 @@ For more information on tolerations, consult the https://kubernetes.io/docs/conc
 Links:
 * [Documentation of core.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L122)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L122)
 
 ### .spec.single.volumeAllowShrink: boolean
 
 Deprecated: VolumeAllowShrink allows shrink the volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L172)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L172)
 
 ### .spec.single.volumeClaimTemplate: core.PersistentVolumeClaim
 
@@ -3458,7 +3458,7 @@ and `iops` is not forwarded to the pods resource requirements.
 Links:
 * [Documentation of core.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaim-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L165)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L165)
 
 ### .spec.single.volumeMounts: []ServerGroupSpecVolumeMount
 
@@ -3467,7 +3467,7 @@ VolumeMounts define list of volume mounts mounted into server container
 Links:
 * [Documentation of ServerGroupSpecVolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L201)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L201)
 
 ### .spec.single.volumes\[int\].configMap: core.ConfigMapVolumeSource
 
@@ -3476,7 +3476,7 @@ ConfigMap which should be mounted into pod
 Links:
 * [Documentation of core.ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#configmapvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L138)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L138)
 
 ### .spec.single.volumes\[int\].emptyDir: core.EmptyDirVolumeSource
 
@@ -3485,7 +3485,7 @@ EmptyDir
 Links:
 * [Documentation of core.EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#emptydirvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L143)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L143)
 
 ### .spec.single.volumes\[int\].hostPath: core.HostPathVolumeSource
 
@@ -3494,13 +3494,13 @@ HostPath
 Links:
 * [Documentation of core.HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#hostpathvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L148)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L148)
 
 ### .spec.single.volumes\[int\].name: string
 
 Name of volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L128)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L128)
 
 ### .spec.single.volumes\[int\].persistentVolumeClaim: core.PersistentVolumeClaimVolumeSource
 
@@ -3509,7 +3509,7 @@ PersistentVolumeClaim
 Links:
 * [Documentation of core.PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L153)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L153)
 
 ### .spec.single.volumes\[int\].secret: core.SecretVolumeSource
 
@@ -3518,7 +3518,7 @@ Secret which should be mounted into pod
 Links:
 * [Documentation of core.SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L133)
 
 ### .spec.storageEngine: string
 
@@ -3530,7 +3530,7 @@ Possible Values:
 
 This field is **immutable**: This setting cannot be changed after the cluster has been created.
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L72)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L72)
 
 ### .spec.sync.auth.clientCASecretName: string
 
@@ -3539,7 +3539,7 @@ a PEM encoded CA certificate used for client certificate verification
 in all ArangoSync master servers.
 This is a required setting when `spec.sync.enabled` is `true`.
 
-[Code Reference](/pkg/apis/deployment/v1/sync_authentication_spec.go#L41)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/sync_authentication_spec.go#L41)
 
 ### .spec.sync.auth.jwtSecretName: string
 
@@ -3549,7 +3549,7 @@ When not specified, the `spec.auth.jwtSecretName` value is used.
 If you specify a name of a `Secret` that does not exist, a random token is created
 and stored in a `Secret` with given name.
 
-[Code Reference](/pkg/apis/deployment/v1/sync_authentication_spec.go#L36)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/sync_authentication_spec.go#L36)
 
 ### .spec.sync.enabled: boolean
 
@@ -3557,9 +3557,9 @@ Enabled setting enables/disables support for data center 2 data center
 replication in the cluster. When enabled, the cluster will contain
 a number of `syncmaster` & `syncworker` servers.
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/sync_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/sync_spec.go#L34)
 
 ### .spec.sync.externalAccess.accessPackageSecretNames: []string
 
@@ -3573,20 +3573,20 @@ Completely removing the setting results in not modifying the list.
 Links:
 * [See the ArangoDeploymentReplication specification](deployment-replication-resource-reference.md)
 
-[Code Reference](/pkg/apis/deployment/v1/sync_external_access_spec.go#L49)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/sync_external_access_spec.go#L49)
 
 ### .spec.sync.externalAccess.advertisedEndpoint: string
 
 AdvertisedEndpoint is passed to the coordinators/single servers for advertising a specific endpoint
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L58)
 
 ### .spec.sync.externalAccess.loadBalancerIP: string
 
 LoadBalancerIP define optional IP used to configure a load-balancer on, in case of Auto or LoadBalancer type.
 If you do not specify this setting, an IP will be chosen automatically by the load-balancer provisioner.
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L48)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L48)
 
 ### .spec.sync.externalAccess.loadBalancerSourceRanges: array
 
@@ -3598,14 +3598,14 @@ cloud-provider does not support the feature.
 Links:
 * [Cloud Provider Firewall](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/)
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L55)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L55)
 
 ### .spec.sync.externalAccess.managedServiceNames: array
 
 ManagedServiceNames keeps names of services which are not managed by KubeArangoDB.
 It is only relevant when type of service is `managed`.
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L62)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L62)
 
 ### .spec.sync.externalAccess.masterEndpoint: []string
 
@@ -3614,7 +3614,7 @@ If not set, this setting defaults to:
 - If `spec.sync.externalAccess.loadBalancerIP` is set, it defaults to `https://<load-balancer-ip>:<8629>`.
 - Otherwise it defaults to `https://<sync-service-dns-name>:<8629>`.
 
-[Code Reference](/pkg/apis/deployment/v1/sync_external_access_spec.go#L40)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/sync_external_access_spec.go#L40)
 
 ### .spec.sync.externalAccess.nodePort: integer
 
@@ -3622,7 +3622,7 @@ NodePort define optional port used in case of Auto or NodePort type.
 This setting is used when `spec.externalAccess.type` is set to `NodePort` or `Auto`.
 If you do not specify this setting, a random port will be chosen automatically.
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L44)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L44)
 
 ### .spec.sync.externalAccess.type: string
 
@@ -3634,11 +3634,11 @@ Possible Values:
 * LoadBalancer - Create a Service of type LoadBalancer for the ArangoDB deployment.
 * NodePort - Create a Service of type NodePort for the ArangoDB deployment.
 
-[Code Reference](/pkg/apis/deployment/v1/external_access_spec.go#L39)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/external_access_spec.go#L39)
 
 ### .spec.sync.image: string
 
-[Code Reference](/pkg/apis/deployment/v1/sync_spec.go#L40)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/sync_spec.go#L40)
 
 ### .spec.sync.monitoring.tokenSecretName: string
 
@@ -3646,7 +3646,7 @@ TokenSecretName setting specifies the name of a kubernetes `Secret` that contain
 the bearer token used for accessing all monitoring endpoints of all arangod/arangosync servers.
 When not specified, no monitoring token is used.
 
-[Code Reference](/pkg/apis/deployment/v1/sync_monitoring_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/sync_monitoring_spec.go#L34)
 
 ### .spec.sync.tls.altNames: []string
 
@@ -3654,7 +3654,7 @@ AltNames setting specifies a list of alternate names that will be added to all g
 certificates. These names can be DNS names or email addresses.
 The default value is empty.
 
-[Code Reference](/pkg/apis/deployment/v1/tls_spec.go#L72)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_spec.go#L72)
 
 ### .spec.sync.tls.caSecretName: string
 
@@ -3669,15 +3669,15 @@ The specified `Secret`, must contain the following data fields:
 - `ca.crt` PEM encoded public key of the CA certificate
 - `ca.key` PEM encoded private key of the CA certificate
 
-[Code Reference](/pkg/apis/deployment/v1/tls_spec.go#L67)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_spec.go#L67)
 
 ### .spec.sync.tls.mode: string
 
-[Code Reference](/pkg/apis/deployment/v1/tls_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_spec.go#L81)
 
 ### .spec.sync.tls.sni.mapping.\<string\>: array
 
-[Code Reference](/pkg/apis/deployment/v1/tls_sni_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_sni_spec.go#L30)
 
 ### .spec.sync.tls.ttl: string
 
@@ -3687,9 +3687,9 @@ by a new one and the affected server will be restarted.
 Note: The time to live of the CA certificate (when created automatically)
 will be set to 10 years.
 
-Default Value: "2160h" (about 3 months)
+Default Value: `"2160h" (about 3 months)`
 
-[Code Reference](/pkg/apis/deployment/v1/tls_spec.go#L79)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_spec.go#L79)
 
 ### .spec.syncmasters.affinity: core.PodAffinity
 
@@ -3698,7 +3698,7 @@ Affinity specified additional affinity settings in ArangoDB Pod definitions
 Links:
 * [Documentation of core.PodAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L180)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L180)
 
 ### .spec.syncmasters.allowMemberRecreation: boolean
 
@@ -3707,26 +3707,26 @@ This setting changes the member recreation logic based on group:
 - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
 - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L222)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L222)
 
 ### .spec.syncmasters.annotations: object
 
 Annotations specified the annotations added to Pods in this group.
 Annotations are merged with `spec.annotations`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L125)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L125)
 
 ### .spec.syncmasters.annotationsIgnoreList: array
 
 AnnotationsIgnoreList list regexp or plain definitions which annotations should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L127)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L127)
 
 ### .spec.syncmasters.annotationsMode: string
 
 AnnotationsMode Define annotations mode which should be use while overriding annotations
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L129)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L129)
 
 ### .spec.syncmasters.antiAffinity: core.PodAntiAffinity
 
@@ -3735,15 +3735,15 @@ AntiAffinity specified additional antiAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of core.Pod.AntiAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podantiaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L176)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L176)
 
 ### .spec.syncmasters.args: []string
 
 Args setting specifies additional command-line arguments passed to all servers of this group.
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L85)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L85)
 
 ### .spec.syncmasters.count: integer
 
@@ -3754,21 +3754,21 @@ for `spec.mode: Single` and `2` for `spec.mode: ActiveFailover`).
 For the `syncworkers` group, it is highly recommended to use the same number
 as for the `dbservers` group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L77)
 
 ### .spec.syncmasters.entrypoint: string
 
 Entrypoint overrides container executable
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L87)
 
 ### .spec.syncmasters.envs\[int\].name: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L26)
 
 ### .spec.syncmasters.envs\[int\].value: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L27)
 
 ### .spec.syncmasters.ephemeralVolumes.apps.size: resource.Quantity
 
@@ -3777,7 +3777,7 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.syncmasters.ephemeralVolumes.temp.size: resource.Quantity
 
@@ -3786,25 +3786,25 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.syncmasters.exporterPort: integer
 
 ExporterPort define Port used by exporter
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L235)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L235)
 
 ### .spec.syncmasters.extendedRotationCheck: boolean
 
 ExtendedRotationCheck extend checks for rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L205)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L205)
 
 ### .spec.syncmasters.externalPortEnabled: boolean
 
 ExternalPortEnabled if external port should be enabled. If is set to false, ports needs to be exposed via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L217)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L217)
 
 ### .spec.syncmasters.indexMethod: string
 
@@ -3814,7 +3814,7 @@ Possible Values:
 * random (default) - Pick random ID for member. Enforced on the Community Operator.
 * ordered - Use sequential number as Member ID, starting from 0. Enterprise Operator required.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L228)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L228)
 
 ### .spec.syncmasters.initContainers.containers: []core.Container
 
@@ -3823,49 +3823,49 @@ Containers contains list of containers
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
 
 ### .spec.syncmasters.initContainers.mode: string
 
 Mode keep container replace mode
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
 
 ### .spec.syncmasters.internalPort: integer
 
 InternalPort define port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L213)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L213)
 
 ### .spec.syncmasters.internalPortProtocol: string
 
 InternalPortProtocol define protocol of port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L215)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L215)
 
 ### .spec.syncmasters.labels: object
 
 Labels specified the labels added to Pods in this group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L131)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L131)
 
 ### .spec.syncmasters.labelsIgnoreList: array
 
 LabelsIgnoreList list regexp or plain definitions which labels should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L133)
 
 ### .spec.syncmasters.labelsMode: string
 
 LabelsMode Define labels mode which should be use while overriding labels
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L135)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L135)
 
 ### .spec.syncmasters.maxCount: integer
 
 MaxCount specifies a maximum for the count of servers. If set, a specification is invalid if `count > maxCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L81)
 
 ### .spec.syncmasters.memoryReservation: integer
 
@@ -3876,15 +3876,15 @@ Accepted Range <0, 50>. If the value is outside the accepted range, it is adjust
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: 0
+Default Value: `0`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L107)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L107)
 
 ### .spec.syncmasters.minCount: integer
 
 MinCount specifies a minimum for the count of servers. If set, a specification is invalid if `count < minCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L79)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L79)
 
 ### .spec.syncmasters.nodeAffinity: core.NodeAffinity
 
@@ -3893,7 +3893,7 @@ NodeAffinity specified additional nodeAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of code.NodeAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#nodeaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L184)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L184)
 
 ### .spec.syncmasters.nodeSelector: map[string]string
 
@@ -3902,31 +3902,31 @@ NodeSelector setting specifies a set of labels to be used as `nodeSelector` for 
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L150)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L150)
 
 ### .spec.syncmasters.numactl.args: array
 
 Args define list of the numactl process
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
 
 ### .spec.syncmasters.numactl.enabled: boolean
 
 Enabled define if numactl should be enabled
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
 
 ### .spec.syncmasters.numactl.path: string
 
 Path define numactl path within the container
 
-Default Value: /usr/bin/numactl
+Default Value: `/usr/bin/numactl`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
 
 ### .spec.syncmasters.overrideDetectedNumberOfCores: boolean
 
@@ -3938,9 +3938,9 @@ If is set to true and Container CPU Limits are set, it sets Container Environmen
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L113)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L113)
 
 ### .spec.syncmasters.overrideDetectedTotalMemory: boolean
 
@@ -3952,23 +3952,23 @@ If is set to true and Container Memory Limits are set, it sets Container Environ
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L101)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L101)
 
 ### .spec.syncmasters.podModes.network: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
 
 ### .spec.syncmasters.podModes.pid: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
 
 ### .spec.syncmasters.port: integer
 
 Port define Port used by member
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L233)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L233)
 
 ### .spec.syncmasters.priorityClassName: string
 
@@ -3978,15 +3978,15 @@ Will be forwarded to the pod spec.
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L156)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L156)
 
 ### .spec.syncmasters.probes.livenessProbeDisabled: boolean
 
 LivenessProbeDisabled if set to true, the operator does not generate a liveness probe for new pods belonging to this group
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L245)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L245)
 
 ### .spec.syncmasters.probes.livenessProbeSpec.failureThreshold: integer
 
@@ -3994,58 +3994,58 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.syncmasters.probes.livenessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.syncmasters.probes.livenessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.syncmasters.probes.livenessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.syncmasters.probes.livenessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.syncmasters.probes.ReadinessProbeDisabled: boolean
 
 OldReadinessProbeDisabled if true readinessProbes are disabled
 Deprecated: This field is deprecated, keept only for backward compatibility.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L252)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L252)
 
 ### .spec.syncmasters.probes.readinessProbeDisabled: boolean
 
 ReadinessProbeDisabled override flag for probe disabled in good manner (lowercase) with backward compatibility
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L254)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L254)
 
 ### .spec.syncmasters.probes.readinessProbeSpec.failureThreshold: integer
 
@@ -4053,51 +4053,51 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.syncmasters.probes.readinessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.syncmasters.probes.readinessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.syncmasters.probes.readinessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.syncmasters.probes.readinessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.syncmasters.probes.startupProbeDisabled: boolean
 
 StartupProbeDisabled if true startupProbes are disabled
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L259)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L259)
 
 ### .spec.syncmasters.probes.startupProbeSpec.failureThreshold: integer
 
@@ -4105,45 +4105,45 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.syncmasters.probes.startupProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.syncmasters.probes.startupProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.syncmasters.probes.startupProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.syncmasters.probes.startupProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.syncmasters.pvcResizeMode: string
 
@@ -4153,7 +4153,7 @@ Possible Values:
 * runtime (default) - PVC will be resized in Pod runtime (EKS, GKE)
 * rotate - Pod will be shutdown and PVC will be resized (AKS)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L170)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L170)
 
 ### .spec.syncmasters.resources: core.ResourceRequirements
 
@@ -4162,69 +4162,69 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L95)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L95)
 
 ### .spec.syncmasters.schedulerName: string
 
 SchedulerName define scheduler name used for group
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L89)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L89)
 
 ### .spec.syncmasters.securityContext.addCapabilities: []core.Capability
 
 AddCapabilities add new capabilities to containers
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
 
 ### .spec.syncmasters.securityContext.allowPrivilegeEscalation: boolean
 
 AllowPrivilegeEscalation Controls whether a process can gain more privileges than its parent process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
 
 ### .spec.syncmasters.securityContext.dropAllCapabilities: boolean
 
 DropAllCapabilities specifies if capabilities should be dropped for this pod containers
 Deprecated: This field is added for backward compatibility. Will be removed in 1.1.0.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
 
 ### .spec.syncmasters.securityContext.fsGroup: integer
 
 FSGroup is a special supplemental group that applies to all containers in a pod.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
 
 ### .spec.syncmasters.securityContext.privileged: boolean
 
 Privileged If true, runs container in privileged mode. Processes in privileged containers are
 essentially equivalent to root on the host.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
 
 ### .spec.syncmasters.securityContext.readOnlyRootFilesystem: boolean
 
 ReadOnlyRootFilesystem if true, mounts the container's root filesystem as read-only.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
 
 ### .spec.syncmasters.securityContext.runAsGroup: integer
 
 RunAsGroup is the GID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
 
 ### .spec.syncmasters.securityContext.runAsNonRoot: boolean
 
 RunAsNonRoot if true, indicates that the container must run as a non-root user.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
 
 ### .spec.syncmasters.securityContext.runAsUser: integer
 
 RunAsUser is the UID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
 
 ### .spec.syncmasters.securityContext.seccompProfile: core.SeccompProfile
 
@@ -4233,7 +4233,7 @@ SeccompProfile defines a pod/container's seccomp profile settings. Only one prof
 Links:
 * [Documentation of core.SeccompProfile](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#seccompprofile-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
 
 ### .spec.syncmasters.securityContext.seLinuxOptions: core.SELinuxOptions
 
@@ -4242,14 +4242,14 @@ SELinuxOptions are the labels to be applied to the container
 Links:
 * [Documentation of core.SELinuxOptions](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#selinuxoptions-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
 
 ### .spec.syncmasters.securityContext.supplementalGroups: array
 
 SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID,
 the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
 
 ### .spec.syncmasters.securityContext.sysctls: map[string]intstr.IntOrString
 
@@ -4268,7 +4268,7 @@ sysctls:
   "kernel.msgmax": "65536"
 ```
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
 
 ### .spec.syncmasters.serviceAccountName: string
 
@@ -4281,26 +4281,26 @@ deployment of the operator, we grant the rights to 'get' all 'pod' resources.
 If you are using a different service account, please grant these rights
 to that service account.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L146)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L146)
 
 ### .spec.syncmasters.shutdownDelay: integer
 
 ShutdownDelay define how long operator should delay finalizer removal after shutdown
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L211)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L211)
 
 ### .spec.syncmasters.shutdownMethod: string
 
 ShutdownMethod describe procedure of member shutdown taken by Operator
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L209)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L209)
 
 ### .spec.syncmasters.sidecarCoreNames: array
 
 SidecarCoreNames is a list of sidecar containers which must run in the pod.
 Some names (e.g.: "server", "worker") are reserved, and they don't have any impact.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L187)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L187)
 
 ### .spec.syncmasters.sidecars: []core.Container
 
@@ -4309,19 +4309,19 @@ Sidecars specifies a list of additional containers to be started
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L191)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L191)
 
 ### .spec.syncmasters.storageClassName: string
 
 StorageClassName specifies the classname for storage of the servers.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L91)
 
 ### .spec.syncmasters.terminationGracePeriodSeconds: integer
 
 TerminationGracePeriodSeconds override default TerminationGracePeriodSeconds for pods - via silent rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L224)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L224)
 
 ### .spec.syncmasters.tolerations: []core.Toleration
 
@@ -4335,13 +4335,13 @@ For more information on tolerations, consult the https://kubernetes.io/docs/conc
 Links:
 * [Documentation of core.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L122)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L122)
 
 ### .spec.syncmasters.volumeAllowShrink: boolean
 
 Deprecated: VolumeAllowShrink allows shrink the volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L172)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L172)
 
 ### .spec.syncmasters.volumeClaimTemplate: core.PersistentVolumeClaim
 
@@ -4355,7 +4355,7 @@ and `iops` is not forwarded to the pods resource requirements.
 Links:
 * [Documentation of core.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaim-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L165)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L165)
 
 ### .spec.syncmasters.volumeMounts: []ServerGroupSpecVolumeMount
 
@@ -4364,7 +4364,7 @@ VolumeMounts define list of volume mounts mounted into server container
 Links:
 * [Documentation of ServerGroupSpecVolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L201)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L201)
 
 ### .spec.syncmasters.volumes\[int\].configMap: core.ConfigMapVolumeSource
 
@@ -4373,7 +4373,7 @@ ConfigMap which should be mounted into pod
 Links:
 * [Documentation of core.ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#configmapvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L138)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L138)
 
 ### .spec.syncmasters.volumes\[int\].emptyDir: core.EmptyDirVolumeSource
 
@@ -4382,7 +4382,7 @@ EmptyDir
 Links:
 * [Documentation of core.EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#emptydirvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L143)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L143)
 
 ### .spec.syncmasters.volumes\[int\].hostPath: core.HostPathVolumeSource
 
@@ -4391,13 +4391,13 @@ HostPath
 Links:
 * [Documentation of core.HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#hostpathvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L148)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L148)
 
 ### .spec.syncmasters.volumes\[int\].name: string
 
 Name of volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L128)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L128)
 
 ### .spec.syncmasters.volumes\[int\].persistentVolumeClaim: core.PersistentVolumeClaimVolumeSource
 
@@ -4406,7 +4406,7 @@ PersistentVolumeClaim
 Links:
 * [Documentation of core.PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L153)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L153)
 
 ### .spec.syncmasters.volumes\[int\].secret: core.SecretVolumeSource
 
@@ -4415,7 +4415,7 @@ Secret which should be mounted into pod
 Links:
 * [Documentation of core.SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L133)
 
 ### .spec.syncworkers.affinity: core.PodAffinity
 
@@ -4424,7 +4424,7 @@ Affinity specified additional affinity settings in ArangoDB Pod definitions
 Links:
 * [Documentation of core.PodAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L180)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L180)
 
 ### .spec.syncworkers.allowMemberRecreation: boolean
 
@@ -4433,26 +4433,26 @@ This setting changes the member recreation logic based on group:
 - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
 - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L222)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L222)
 
 ### .spec.syncworkers.annotations: object
 
 Annotations specified the annotations added to Pods in this group.
 Annotations are merged with `spec.annotations`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L125)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L125)
 
 ### .spec.syncworkers.annotationsIgnoreList: array
 
 AnnotationsIgnoreList list regexp or plain definitions which annotations should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L127)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L127)
 
 ### .spec.syncworkers.annotationsMode: string
 
 AnnotationsMode Define annotations mode which should be use while overriding annotations
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L129)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L129)
 
 ### .spec.syncworkers.antiAffinity: core.PodAntiAffinity
 
@@ -4461,15 +4461,15 @@ AntiAffinity specified additional antiAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of core.Pod.AntiAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podantiaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L176)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L176)
 
 ### .spec.syncworkers.args: []string
 
 Args setting specifies additional command-line arguments passed to all servers of this group.
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L85)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L85)
 
 ### .spec.syncworkers.count: integer
 
@@ -4480,21 +4480,21 @@ for `spec.mode: Single` and `2` for `spec.mode: ActiveFailover`).
 For the `syncworkers` group, it is highly recommended to use the same number
 as for the `dbservers` group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L77)
 
 ### .spec.syncworkers.entrypoint: string
 
 Entrypoint overrides container executable
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L87)
 
 ### .spec.syncworkers.envs\[int\].name: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L26)
 
 ### .spec.syncworkers.envs\[int\].value: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_env_var.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_env_var.go#L27)
 
 ### .spec.syncworkers.ephemeralVolumes.apps.size: resource.Quantity
 
@@ -4503,7 +4503,7 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.syncworkers.ephemeralVolumes.temp.size: resource.Quantity
 
@@ -4512,25 +4512,25 @@ Size define size of the ephemeral volume
 Links:
 * [Documentation of resource.Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#quantity-resource-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_ephemeral_volumes.go#L64)
 
 ### .spec.syncworkers.exporterPort: integer
 
 ExporterPort define Port used by exporter
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L235)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L235)
 
 ### .spec.syncworkers.extendedRotationCheck: boolean
 
 ExtendedRotationCheck extend checks for rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L205)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L205)
 
 ### .spec.syncworkers.externalPortEnabled: boolean
 
 ExternalPortEnabled if external port should be enabled. If is set to false, ports needs to be exposed via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L217)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L217)
 
 ### .spec.syncworkers.indexMethod: string
 
@@ -4540,7 +4540,7 @@ Possible Values:
 * random (default) - Pick random ID for member. Enforced on the Community Operator.
 * ordered - Use sequential number as Member ID, starting from 0. Enterprise Operator required.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L228)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L228)
 
 ### .spec.syncworkers.initContainers.containers: []core.Container
 
@@ -4549,49 +4549,49 @@ Containers contains list of containers
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L91)
 
 ### .spec.syncworkers.initContainers.mode: string
 
 Mode keep container replace mode
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_init_containers.go#L94)
 
 ### .spec.syncworkers.internalPort: integer
 
 InternalPort define port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L213)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L213)
 
 ### .spec.syncworkers.internalPortProtocol: string
 
 InternalPortProtocol define protocol of port used in internal communication, can be accessed over localhost via sidecar. Only for ArangoD members
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L215)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L215)
 
 ### .spec.syncworkers.labels: object
 
 Labels specified the labels added to Pods in this group.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L131)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L131)
 
 ### .spec.syncworkers.labelsIgnoreList: array
 
 LabelsIgnoreList list regexp or plain definitions which labels should be ignored
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L133)
 
 ### .spec.syncworkers.labelsMode: string
 
 LabelsMode Define labels mode which should be use while overriding labels
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L135)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L135)
 
 ### .spec.syncworkers.maxCount: integer
 
 MaxCount specifies a maximum for the count of servers. If set, a specification is invalid if `count > maxCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L81)
 
 ### .spec.syncworkers.memoryReservation: integer
 
@@ -4602,15 +4602,15 @@ Accepted Range <0, 50>. If the value is outside the accepted range, it is adjust
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: 0
+Default Value: `0`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L107)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L107)
 
 ### .spec.syncworkers.minCount: integer
 
 MinCount specifies a minimum for the count of servers. If set, a specification is invalid if `count < minCount`.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L79)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L79)
 
 ### .spec.syncworkers.nodeAffinity: core.NodeAffinity
 
@@ -4619,7 +4619,7 @@ NodeAffinity specified additional nodeAffinity settings in ArangoDB Pod definiti
 Links:
 * [Documentation of code.NodeAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#nodeaffinity-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L184)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L184)
 
 ### .spec.syncworkers.nodeSelector: map[string]string
 
@@ -4628,31 +4628,31 @@ NodeSelector setting specifies a set of labels to be used as `nodeSelector` for 
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L150)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L150)
 
 ### .spec.syncworkers.numactl.args: array
 
 Args define list of the numactl process
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L38)
 
 ### .spec.syncworkers.numactl.enabled: boolean
 
 Enabled define if numactl should be enabled
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L30)
 
 ### .spec.syncworkers.numactl.path: string
 
 Path define numactl path within the container
 
-Default Value: /usr/bin/numactl
+Default Value: `/usr/bin/numactl`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_numactl_spec.go#L34)
 
 ### .spec.syncworkers.overrideDetectedNumberOfCores: boolean
 
@@ -4664,9 +4664,9 @@ If is set to true and Container CPU Limits are set, it sets Container Environmen
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L113)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L113)
 
 ### .spec.syncworkers.overrideDetectedTotalMemory: boolean
 
@@ -4678,23 +4678,23 @@ If is set to true and Container Memory Limits are set, it sets Container Environ
 Links:
 * [Docs of the ArangoDB Envs](https://docs.arangodb.com/devel/components/arangodb-server/environment-variables/)
 
-Default Value: true
+Default Value: `true`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L101)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L101)
 
 ### .spec.syncworkers.podModes.network: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L31)
 
 ### .spec.syncworkers.podModes.pid: string
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec_pod_modes.go#L32)
 
 ### .spec.syncworkers.port: integer
 
 Port define Port used by member
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L233)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L233)
 
 ### .spec.syncworkers.priorityClassName: string
 
@@ -4704,15 +4704,15 @@ Will be forwarded to the pod spec.
 Links:
 * [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L156)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L156)
 
 ### .spec.syncworkers.probes.livenessProbeDisabled: boolean
 
 LivenessProbeDisabled if set to true, the operator does not generate a liveness probe for new pods belonging to this group
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L245)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L245)
 
 ### .spec.syncworkers.probes.livenessProbeSpec.failureThreshold: integer
 
@@ -4720,58 +4720,58 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.syncworkers.probes.livenessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.syncworkers.probes.livenessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.syncworkers.probes.livenessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.syncworkers.probes.livenessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.syncworkers.probes.ReadinessProbeDisabled: boolean
 
 OldReadinessProbeDisabled if true readinessProbes are disabled
 Deprecated: This field is deprecated, keept only for backward compatibility.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L252)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L252)
 
 ### .spec.syncworkers.probes.readinessProbeDisabled: boolean
 
 ReadinessProbeDisabled override flag for probe disabled in good manner (lowercase) with backward compatibility
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L254)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L254)
 
 ### .spec.syncworkers.probes.readinessProbeSpec.failureThreshold: integer
 
@@ -4779,51 +4779,51 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.syncworkers.probes.readinessProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.syncworkers.probes.readinessProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.syncworkers.probes.readinessProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.syncworkers.probes.readinessProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.syncworkers.probes.startupProbeDisabled: boolean
 
 StartupProbeDisabled if true startupProbes are disabled
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L259)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L259)
 
 ### .spec.syncworkers.probes.startupProbeSpec.failureThreshold: integer
 
@@ -4831,45 +4831,45 @@ FailureThreshold when a Pod starts and the probe fails, Kubernetes will try fail
 Giving up means restarting the container.
 Minimum value is 1.
 
-Default Value: 3
+Default Value: `3`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L295)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L295)
 
 ### .spec.syncworkers.probes.startupProbeSpec.initialDelaySeconds: integer
 
 InitialDelaySeconds specifies number of seconds after the container has started before liveness or readiness probes are initiated.
 Minimum value is 0.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L278)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L278)
 
 ### .spec.syncworkers.probes.startupProbeSpec.periodSeconds: integer
 
 PeriodSeconds How often (in seconds) to perform the probe.
 Minimum value is 1.
 
-Default Value: 10
+Default Value: `10`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L282)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L282)
 
 ### .spec.syncworkers.probes.startupProbeSpec.successThreshold: integer
 
 SuccessThreshold Minimum consecutive successes for the probe to be considered successful after having failed.
 Minimum value is 1.
 
-Default Value: 1
+Default Value: `1`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L290)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L290)
 
 ### .spec.syncworkers.probes.startupProbeSpec.timeoutSeconds: integer
 
 TimeoutSeconds specifies number of seconds after which the probe times out
 Minimum value is 1.
 
-Default Value: 2
+Default Value: `2`
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L286)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L286)
 
 ### .spec.syncworkers.pvcResizeMode: string
 
@@ -4879,7 +4879,7 @@ Possible Values:
 * runtime (default) - PVC will be resized in Pod runtime (EKS, GKE)
 * rotate - Pod will be shutdown and PVC will be resized (AKS)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L170)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L170)
 
 ### .spec.syncworkers.resources: core.ResourceRequirements
 
@@ -4888,69 +4888,69 @@ Resources holds resource requests & limits
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L95)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L95)
 
 ### .spec.syncworkers.schedulerName: string
 
 SchedulerName define scheduler name used for group
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L89)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L89)
 
 ### .spec.syncworkers.securityContext.addCapabilities: []core.Capability
 
 AddCapabilities add new capabilities to containers
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L46)
 
 ### .spec.syncworkers.securityContext.allowPrivilegeEscalation: boolean
 
 AllowPrivilegeEscalation Controls whether a process can gain more privileges than its parent process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L49)
 
 ### .spec.syncworkers.securityContext.dropAllCapabilities: boolean
 
 DropAllCapabilities specifies if capabilities should be dropped for this pod containers
 Deprecated: This field is added for backward compatibility. Will be removed in 1.1.0.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L43)
 
 ### .spec.syncworkers.securityContext.fsGroup: integer
 
 FSGroup is a special supplemental group that applies to all containers in a pod.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L66)
 
 ### .spec.syncworkers.securityContext.privileged: boolean
 
 Privileged If true, runs container in privileged mode. Processes in privileged containers are
 essentially equivalent to root on the host.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L52)
 
 ### .spec.syncworkers.securityContext.readOnlyRootFilesystem: boolean
 
 ReadOnlyRootFilesystem if true, mounts the container's root filesystem as read-only.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L54)
 
 ### .spec.syncworkers.securityContext.runAsGroup: integer
 
 RunAsGroup is the GID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L60)
 
 ### .spec.syncworkers.securityContext.runAsNonRoot: boolean
 
 RunAsNonRoot if true, indicates that the container must run as a non-root user.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L56)
 
 ### .spec.syncworkers.securityContext.runAsUser: integer
 
 RunAsUser is the UID to run the entrypoint of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L58)
 
 ### .spec.syncworkers.securityContext.seccompProfile: core.SeccompProfile
 
@@ -4959,7 +4959,7 @@ SeccompProfile defines a pod/container's seccomp profile settings. Only one prof
 Links:
 * [Documentation of core.SeccompProfile](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#seccompprofile-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L82)
 
 ### .spec.syncworkers.securityContext.seLinuxOptions: core.SELinuxOptions
 
@@ -4968,14 +4968,14 @@ SELinuxOptions are the labels to be applied to the container
 Links:
 * [Documentation of core.SELinuxOptions](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#selinuxoptions-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L87)
 
 ### .spec.syncworkers.securityContext.supplementalGroups: array
 
 SupplementalGroups is a list of groups applied to the first process run in each container, in addition to the container's primary GID,
 the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L64)
 
 ### .spec.syncworkers.securityContext.sysctls: map[string]intstr.IntOrString
 
@@ -4994,7 +4994,7 @@ sysctls:
   "kernel.msgmax": "65536"
 ```
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_security_context_spec.go#L77)
 
 ### .spec.syncworkers.serviceAccountName: string
 
@@ -5007,26 +5007,26 @@ deployment of the operator, we grant the rights to 'get' all 'pod' resources.
 If you are using a different service account, please grant these rights
 to that service account.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L146)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L146)
 
 ### .spec.syncworkers.shutdownDelay: integer
 
 ShutdownDelay define how long operator should delay finalizer removal after shutdown
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L211)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L211)
 
 ### .spec.syncworkers.shutdownMethod: string
 
 ShutdownMethod describe procedure of member shutdown taken by Operator
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L209)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L209)
 
 ### .spec.syncworkers.sidecarCoreNames: array
 
 SidecarCoreNames is a list of sidecar containers which must run in the pod.
 Some names (e.g.: "server", "worker") are reserved, and they don't have any impact.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L187)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L187)
 
 ### .spec.syncworkers.sidecars: []core.Container
 
@@ -5035,19 +5035,19 @@ Sidecars specifies a list of additional containers to be started
 Links:
 * [Documentation of core.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L191)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L191)
 
 ### .spec.syncworkers.storageClassName: string
 
 StorageClassName specifies the classname for storage of the servers.
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L91)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L91)
 
 ### .spec.syncworkers.terminationGracePeriodSeconds: integer
 
 TerminationGracePeriodSeconds override default TerminationGracePeriodSeconds for pods - via silent rotation
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L224)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L224)
 
 ### .spec.syncworkers.tolerations: []core.Toleration
 
@@ -5061,13 +5061,13 @@ For more information on tolerations, consult the https://kubernetes.io/docs/conc
 Links:
 * [Documentation of core.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L122)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L122)
 
 ### .spec.syncworkers.volumeAllowShrink: boolean
 
 Deprecated: VolumeAllowShrink allows shrink the volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L172)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L172)
 
 ### .spec.syncworkers.volumeClaimTemplate: core.PersistentVolumeClaim
 
@@ -5081,7 +5081,7 @@ and `iops` is not forwarded to the pods resource requirements.
 Links:
 * [Documentation of core.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaim-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L165)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L165)
 
 ### .spec.syncworkers.volumeMounts: []ServerGroupSpecVolumeMount
 
@@ -5090,7 +5090,7 @@ VolumeMounts define list of volume mounts mounted into server container
 Links:
 * [Documentation of ServerGroupSpecVolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_spec.go#L201)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_spec.go#L201)
 
 ### .spec.syncworkers.volumes\[int\].configMap: core.ConfigMapVolumeSource
 
@@ -5099,7 +5099,7 @@ ConfigMap which should be mounted into pod
 Links:
 * [Documentation of core.ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#configmapvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L138)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L138)
 
 ### .spec.syncworkers.volumes\[int\].emptyDir: core.EmptyDirVolumeSource
 
@@ -5108,7 +5108,7 @@ EmptyDir
 Links:
 * [Documentation of core.EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#emptydirvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L143)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L143)
 
 ### .spec.syncworkers.volumes\[int\].hostPath: core.HostPathVolumeSource
 
@@ -5117,13 +5117,13 @@ HostPath
 Links:
 * [Documentation of core.HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#hostpathvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L148)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L148)
 
 ### .spec.syncworkers.volumes\[int\].name: string
 
 Name of volume
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L128)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L128)
 
 ### .spec.syncworkers.volumes\[int\].persistentVolumeClaim: core.PersistentVolumeClaimVolumeSource
 
@@ -5132,7 +5132,7 @@ PersistentVolumeClaim
 Links:
 * [Documentation of core.PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L153)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L153)
 
 ### .spec.syncworkers.volumes\[int\].secret: core.SecretVolumeSource
 
@@ -5141,7 +5141,7 @@ Secret which should be mounted into pod
 Links:
 * [Documentation of core.SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretvolumesource-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/server_group_volume.go#L133)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/server_group_volume.go#L133)
 
 ### .spec.timeouts.actions: map[string]meta.Duration
 
@@ -5157,20 +5157,20 @@ actions:
   AddMember: 30m
 ```
 
-[Code Reference](/pkg/apis/deployment/v1/timeouts.go#L44)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/timeouts.go#L44)
 
 ### .spec.timeouts.maintenanceGracePeriod: integer
 
 MaintenanceGracePeriod action timeout
 
-[Code Reference](/pkg/apis/deployment/v1/timeouts.go#L36)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/timeouts.go#L36)
 
 ### .spec.timezone: string
 
 Timezone if specified, will set a timezone for deployment.
 Must be in format accepted by "tzdata", e.g. `America/New_York` or `Europe/London`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_spec.go#L269)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_spec.go#L269)
 
 ### .spec.tls.altNames: []string
 
@@ -5178,7 +5178,7 @@ AltNames setting specifies a list of alternate names that will be added to all g
 certificates. These names can be DNS names or email addresses.
 The default value is empty.
 
-[Code Reference](/pkg/apis/deployment/v1/tls_spec.go#L72)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_spec.go#L72)
 
 ### .spec.tls.caSecretName: string
 
@@ -5193,15 +5193,15 @@ The specified `Secret`, must contain the following data fields:
 - `ca.crt` PEM encoded public key of the CA certificate
 - `ca.key` PEM encoded private key of the CA certificate
 
-[Code Reference](/pkg/apis/deployment/v1/tls_spec.go#L67)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_spec.go#L67)
 
 ### .spec.tls.mode: string
 
-[Code Reference](/pkg/apis/deployment/v1/tls_spec.go#L81)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_spec.go#L81)
 
 ### .spec.tls.sni.mapping.\<string\>: array
 
-[Code Reference](/pkg/apis/deployment/v1/tls_sni_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_sni_spec.go#L30)
 
 ### .spec.tls.ttl: string
 
@@ -5211,36 +5211,36 @@ by a new one and the affected server will be restarted.
 Note: The time to live of the CA certificate (when created automatically)
 will be set to 10 years.
 
-Default Value: "2160h" (about 3 months)
+Default Value: `"2160h" (about 3 months)`
 
-[Code Reference](/pkg/apis/deployment/v1/tls_spec.go#L79)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/tls_spec.go#L79)
 
 ### .spec.topology.enabled: boolean
 
-[Code Reference](/pkg/apis/deployment/v1/topology_spec.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/topology_spec.go#L26)
 
 ### .spec.topology.label: string
 
-[Code Reference](/pkg/apis/deployment/v1/topology_spec.go#L28)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/topology_spec.go#L28)
 
 ### .spec.topology.zones: integer
 
-[Code Reference](/pkg/apis/deployment/v1/topology_spec.go#L27)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/topology_spec.go#L27)
 
 ### .spec.upgrade.autoUpgrade: boolean
 
 AutoUpgrade flag specifies if upgrade should be auto-injected, even if is not required (in case of stuck)
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_upgrade_spec.go#L26)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_upgrade_spec.go#L26)
 
 ### .spec.upgrade.debugLog: boolean
 
 DebugLog flag specifies if containers running upgrade process should print more debugging information.
 This applies only to init containers.
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/deployment/v1/deployment_upgrade_spec.go#L30)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/deployment_upgrade_spec.go#L30)
 

--- a/docs/api/ArangoDeploymentReplication.V1.md
+++ b/docs/api/ArangoDeploymentReplication.V1.md
@@ -7,14 +7,14 @@
 EnsureInSync if it is true then during cancellation process data consistency is required.
 Default value is true.
 
-[Code Reference](/pkg/apis/replication/v1/replication_spec.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/replication_spec.go#L38)
 
 ### .spec.cancellation.sourceReadOnly: boolean
 
 SourceReadOnly if it true then after cancellation source data center should be in read-only mode.
 Default value is false.
 
-[Code Reference](/pkg/apis/replication/v1/replication_spec.go#L41)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/replication_spec.go#L41)
 
 ### .spec.destination.auth.keyfileSecretName: string
 
@@ -24,7 +24,7 @@ If `userSecretName` has not been set,
 the client authentication certificate found in the secret with this name is also used to configure
 the synchronization and fetch the synchronization status.
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_authentication_spec.go#L37)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_authentication_spec.go#L37)
 
 ### .spec.destination.auth.userSecretName: string
 
@@ -33,14 +33,14 @@ field used for basic authentication.
 The user identified by the username must have write access in the `_system` database
 of the ArangoDB cluster at the endpoint.
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_authentication_spec.go#L42)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_authentication_spec.go#L42)
 
 ### .spec.destination.deploymentName: string
 
 DeploymentName holds the name of an ArangoDeployment resource.
 If set, this provides default values for masterEndpoint, auth & tls.
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_spec.go#L36)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_spec.go#L36)
 
 ### .spec.destination.masterEndpoint: array
 
@@ -49,16 +49,16 @@ Use this setting if the source cluster is not running inside a Kubernetes cluste
 that is reachable from the Kubernetes cluster the `ArangoDeploymentReplication` resource is deployed in.
 Specifying this setting and `deploymentName` at the same time is not allowed.
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_spec.go#L42)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_spec.go#L42)
 
 ### .spec.destination.tls.caSecretName: string
 
 CASecretName holds the name of a Secret containing a ca.crt public key for TLS validation.
 This setting is required, unless `deploymentName` has been set.
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_tls_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_tls_spec.go#L34)
 
 ### .spec.source.auth.keyfileSecretName: string
 
@@ -68,7 +68,7 @@ If `userSecretName` has not been set,
 the client authentication certificate found in the secret with this name is also used to configure
 the synchronization and fetch the synchronization status.
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_authentication_spec.go#L37)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_authentication_spec.go#L37)
 
 ### .spec.source.auth.userSecretName: string
 
@@ -77,14 +77,14 @@ field used for basic authentication.
 The user identified by the username must have write access in the `_system` database
 of the ArangoDB cluster at the endpoint.
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_authentication_spec.go#L42)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_authentication_spec.go#L42)
 
 ### .spec.source.deploymentName: string
 
 DeploymentName holds the name of an ArangoDeployment resource.
 If set, this provides default values for masterEndpoint, auth & tls.
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_spec.go#L36)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_spec.go#L36)
 
 ### .spec.source.masterEndpoint: array
 
@@ -93,14 +93,14 @@ Use this setting if the source cluster is not running inside a Kubernetes cluste
 that is reachable from the Kubernetes cluster the `ArangoDeploymentReplication` resource is deployed in.
 Specifying this setting and `deploymentName` at the same time is not allowed.
 
-Default Value: []
+Default Value: `[]`
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_spec.go#L42)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_spec.go#L42)
 
 ### .spec.source.tls.caSecretName: string
 
 CASecretName holds the name of a Secret containing a ca.crt public key for TLS validation.
 This setting is required, unless `deploymentName` has been set.
 
-[Code Reference](/pkg/apis/replication/v1/endpoint_tls_spec.go#L34)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/replication/v1/endpoint_tls_spec.go#L34)
 

--- a/docs/api/ArangoLocalStorage.V1Alpha.md
+++ b/docs/api/ArangoLocalStorage.V1Alpha.md
@@ -6,34 +6,34 @@
 
 LocalPath setting specifies one or more local directories (on the nodes) used to create persistent volumes in.
 
-[Code Reference](/pkg/apis/storage/v1alpha/local_storage_spec.go#L36)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/storage/v1alpha/local_storage_spec.go#L36)
 
 ### .spec.nodeSelector: object
 
 NodeSelector setting specifies which nodes the operator will provision persistent volumes on.
 
-[Code Reference](/pkg/apis/storage/v1alpha/local_storage_spec.go#L43)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/storage/v1alpha/local_storage_spec.go#L43)
 
 ### .spec.podCustomization.priority: integer
 
 Priority if defined, sets the priority for pods of storage provisioner
 
-[Code Reference](/pkg/apis/storage/v1alpha/local_storage_pod_customization.go#L25)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/storage/v1alpha/local_storage_pod_customization.go#L25)
 
 ### .spec.privileged: boolean
 
 Privileged if set, passes Privileged flag to SecurityContext for pods of storage provisioner
 
-[Code Reference](/pkg/apis/storage/v1alpha/local_storage_spec.go#L45)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/storage/v1alpha/local_storage_spec.go#L45)
 
 ### .spec.storageClass.isDefault: boolean
 
 IsDefault setting specifies if the created `StorageClass` will
 be marked as default storage class.
 
-Default Value: false
+Default Value: `false`
 
-[Code Reference](/pkg/apis/storage/v1alpha/storage_class_spec.go#L42)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/storage/v1alpha/storage_class_spec.go#L42)
 
 ### .spec.storageClass.name: string
 
@@ -42,9 +42,9 @@ created `PersistentVolume` will use.
 If empty, this field defaults to the name of the `ArangoLocalStorage` object.
 If a `StorageClass` with given name does not yet exist, it will be created.
 
-Default Value: ""
+Default Value: `""`
 
-[Code Reference](/pkg/apis/storage/v1alpha/storage_class_spec.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/storage/v1alpha/storage_class_spec.go#L38)
 
 ### .spec.storageClass.reclaimPolicy: core.PersistentVolumeReclaimPolicy
 
@@ -53,7 +53,7 @@ ReclaimPolicy defines what happens to a persistent volume when released from its
 Links:
 * [Documentation of core.PersistentVolumeReclaimPolicy](https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming)
 
-[Code Reference](/pkg/apis/storage/v1alpha/storage_class_spec.go#L46)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/storage/v1alpha/storage_class_spec.go#L46)
 
 ### .spec.tolerations: []core.Toleration
 
@@ -62,5 +62,5 @@ Tolerations specifies the tolerations added to pods of storage provisioner
 Links:
 * [Documentation of core.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core)
 
-[Code Reference](/pkg/apis/storage/v1alpha/local_storage_spec.go#L41)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/storage/v1alpha/local_storage_spec.go#L41)
 

--- a/docs/api/ArangoMember.V1.md
+++ b/docs/api/ArangoMember.V1.md
@@ -8,23 +8,23 @@ DeletionPriority define Deletion Priority.
 Higher value means higher priority. Default is 0.
 Example: set 1 for Coordinator which should be deleted first and scale down coordinators by one.
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_spec.go#L47)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_spec.go#L47)
 
 ### .spec.deploymentUID: string
 
 DeploymentUID define Deployment UID.
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_spec.go#L36)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_spec.go#L36)
 
 ### .spec.group: integer
 
 Group define Member Groups.
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_spec.go#L31)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_spec.go#L31)
 
 ### .spec.id: string
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_spec.go#L33)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_spec.go#L33)
 
 ### .spec.overrides.resources: core.ResourceRequirements
 
@@ -33,7 +33,7 @@ Resources holds resource requests & limits. Overrides template provided on the g
 Links:
 * [Documentation of core.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_spec_overrides.go#L38)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_spec_overrides.go#L38)
 
 ### .spec.overrides.volumeClaimTemplate: core.PersistentVolumeClaim
 
@@ -42,19 +42,19 @@ VolumeClaimTemplate specifies a template for volume claims. Overrides template p
 Links:
 * [Documentation of core.PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaim-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_spec_overrides.go#L33)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_spec_overrides.go#L33)
 
 ### .spec.template.checksum: string
 
 Checksum keep the Pod Spec Checksum (with ignored fields).
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_pod_template.go#L60)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_pod_template.go#L60)
 
 ### .spec.template.endpoint: string
 
 Deprecated: Endpoint is not saved into the template
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_pod_template.go#L63)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_pod_template.go#L63)
 
 ### .spec.template.podSpec: core.PodTemplateSpec
 
@@ -63,11 +63,11 @@ PodSpec specifies the Pod Spec used for this Member.
 Links:
 * [Documentation of core.PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podtemplatespec-v1-core)
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_pod_template.go#L54)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_pod_template.go#L54)
 
 ### .spec.template.podSpecChecksum: string
 
 PodSpecChecksum keep the Pod Spec Checksum (without ignored fields).
 
-[Code Reference](/pkg/apis/deployment/v1/arango_member_pod_template.go#L57)
+[Code Reference](https://github.com/arangodb/kube-arangodb/blob/1.2.35/pkg/apis/deployment/v1/arango_member_pod_template.go#L57)
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -10,4 +10,4 @@
 - [Enable maintenance mode](maintenance.md)
 - [Override detected total memory](override_detected_memory.md)
 - [Manually recover cluster if you still have volumes with data](recovery.md)
-- [How to rotate Pod](rotate-pod.md)
+- [Rotate Pod](rotate-pod.md)

--- a/docs/how-to/additional_configuration.md
+++ b/docs/how-to/additional_configuration.md
@@ -1,4 +1,4 @@
-# Additional configuration
+# How to pass additional params to operator
 
 It is possible to additionally fine-tune operator behavior by
 providing arguments via `operator.args` chart template value.

--- a/docs/how-to/arch_change.md
+++ b/docs/how-to/arch_change.md
@@ -1,4 +1,4 @@
-# Architecture change
+# How to change architecture / enable ARM support
 
 Currently `AMD64` is a default architecture in the operator
 To enable `ARM64` support in operator add following config in kube-arangodb chart:

--- a/docs/how-to/configuring_tz.md
+++ b/docs/how-to/configuring_tz.md
@@ -1,4 +1,4 @@
-# Configuring timezone
+# How to configure timezone
 
 To set timezone for cluster components, mount the required timezone into container
 by adjusting `spec.<group>` of ArangoDeployment resource:

--- a/docs/how-to/debugging.md
+++ b/docs/how-to/debugging.md
@@ -1,4 +1,4 @@
-# Collecting debug data
+# How to collect debug data
 
 ## Agency dump
 

--- a/docs/how-to/logging.md
+++ b/docs/how-to/logging.md
@@ -1,4 +1,4 @@
-# Logging configuration
+# How to configure logging
 
 ## Operator logging
 

--- a/docs/how-to/maintenance.md
+++ b/docs/how-to/maintenance.md
@@ -1,4 +1,4 @@
-# Maintenance mode
+# How to use maintenance mode
 
 ## ArangoDeployment maintenance
 

--- a/docs/how-to/override_detected_memory.md
+++ b/docs/how-to/override_detected_memory.md
@@ -1,4 +1,4 @@
-# Override detected total memory
+# How to override detected total memory
 
 ## overrideDetectedTotalMemory
 

--- a/docs/how-to/recovery.md
+++ b/docs/how-to/recovery.md
@@ -1,4 +1,4 @@
-# Manual Recovery
+# How to recover a destroyed deployment 
 
 ## Overview
 Let's consider a situation where we had a ArangoDeployment in Cluster mode (3 DbServers, 3 Coordinators, 3 Agents)

--- a/docs/how-to/recovery.md
+++ b/docs/how-to/recovery.md
@@ -1,7 +1,7 @@
 # How to recover a destroyed deployment 
 
 ## Overview
-Let's consider a situation where we had a ArangoDeployment in Cluster mode (3 DbServers, 3 Coordinators, 3 Agents)
+Let's consider a situation where we had an ArangoDeployment in Cluster mode (3 DbServers, 3 Coordinators, 3 Agents)
 with Local storage attached (only one K8s Node in the K8s cluster).
 
 Due to some reason the ArangoDeployment was deleted (e.g. ETCD storage has been wiped out) and we want to recover it.
@@ -75,6 +75,7 @@ EOF
 ## Create PV and PVC
 
 1. We need to create ArangoLocalStorage first:
+
     ```yaml
     cat <<EOF | kubectl apply -f -
     apiVersion: "storage.arangodb.com/v1alpha"
@@ -89,113 +90,124 @@ EOF
       - /mnt/data
     EOF
     ```
-2. Now create PV and PVC for every directory listed above
-   - Agents - here is an example for `AGNT-pntg5yc8`(`f9rs2htwc9e0bzme` directory)
-     - PV
-        ```yaml
-        cat <<EOF | kubectl apply -f -
-        apiVersion: "v1"
-        kind: PersistentVolume
-        metadata:
-          labels:
-            arango_deployment: cluster
-            role: agent
-          name: agent-pntg5yc8-f9rs2htwc9e0bzme
-        spec:
-          accessModes:
-          - ReadWriteOnce
-          capacity:
-            storage: 1Gi
-          local:
-            path: /mnt/data/f9rs2htwc9e0bzme
-          persistentVolumeReclaimPolicy: Retain
-          storageClassName: my-local-ssd
-          volumeMode: Filesystem
-          nodeAffinity:
-            required:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: In
-                  values:
-                  - minikube
-        EOF
-        ```
-     - PVC
-         ```yaml
-         cat <<EOF | kubectl apply -f -
-         apiVersion: v1
-         kind: PersistentVolumeClaim
-         metadata:
-           labels:
-             app: arangodb
-             arango_deployment: cluster
-             role: agent
-           name: agent-pntg5yc8
-         spec:
-           accessModes:
-           - ReadWriteOnce
-           resources:
-             requests:
+
+3. Now create PV and PVC for every directory listed above
+
+    - **Agents** - here is an example for `AGNT-pntg5yc8`(`f9rs2htwc9e0bzme` directory)
+
+        - PV
+
+           ```yaml
+           cat <<EOF | kubectl apply -f -
+           apiVersion: "v1"
+           kind: PersistentVolume
+           metadata:
+             labels:
+               arango_deployment: cluster
+               role: agent
+             name: agent-pntg5yc8-f9rs2htwc9e0bzme
+           spec:
+             accessModes:
+             - ReadWriteOnce
+             capacity:
                storage: 1Gi
-           storageClassName: my-local-ssd
-           volumeMode: Filesystem
-           volumeName: agent-pntg5yc8-f9rs2htwc9e0bzme
-         EOF
-         ```
-   - DbServers - here is an example for `PRMR-9xztmg4t` (`vka6ic19qcl1y3ec` directory)
-     - PV
-        ```yaml
-        cat <<EOF | kubectl apply -f -
-        apiVersion: "v1"
-        kind: PersistentVolume
-        metadata:
-          labels:
-            arango_deployment: cluster
-            role: dbserver
-          name: dbserver-9xztmg4t-vka6ic19qcl1y3ec
-        spec:
-          accessModes:
-          - ReadWriteOnce
-          capacity:
-            storage: 1Gi
-          local:
-            path: /mnt/data/vka6ic19qcl1y3ec
-          persistentVolumeReclaimPolicy: Retain
-          storageClassName: my-local-ssd
-          volumeMode: Filesystem
-          nodeAffinity:
-            required:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: In
-                  values:
-                  - minikube
-        EOF
-        ```
-     - PVC
-         ```yaml
-         cat <<EOF | kubectl apply -f -
-         apiVersion: v1
-         kind: PersistentVolumeClaim
-         metadata:
-           labels:
-             app: arangodb
-             arango_deployment: cluster
-             role: dbserver
-           name: dbserver-9xztmg4t
-         spec:
-           accessModes:
-           - ReadWriteOnce
-           resources:
-             requests:
+             local:
+               path: /mnt/data/f9rs2htwc9e0bzme
+             persistentVolumeReclaimPolicy: Retain
+             storageClassName: my-local-ssd
+             volumeMode: Filesystem
+             nodeAffinity:
+               required:
+                 nodeSelectorTerms:
+                 - matchExpressions:
+                   - key: kubernetes.io/hostname
+                     operator: In
+                     values:
+                     - minikube
+           EOF
+           ```
+
+        - PVC
+
+            ```yaml
+            cat <<EOF | kubectl apply -f -
+            apiVersion: v1
+            kind: PersistentVolumeClaim
+            metadata:
+              labels:
+                app: arangodb
+                arango_deployment: cluster
+                role: agent
+              name: agent-pntg5yc8
+            spec:
+              accessModes:
+              - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+              storageClassName: my-local-ssd
+              volumeMode: Filesystem
+              volumeName: agent-pntg5yc8-f9rs2htwc9e0bzme
+            EOF
+            ```
+
+    - **DbServers** - here is an example for `PRMR-9xztmg4t` (`vka6ic19qcl1y3ec` directory)
+
+        - PV
+
+           ```yaml
+           cat <<EOF | kubectl apply -f -
+           apiVersion: "v1"
+           kind: PersistentVolume
+           metadata:
+             labels:
+               arango_deployment: cluster
+               role: dbserver
+             name: dbserver-9xztmg4t-vka6ic19qcl1y3ec
+           spec:
+             accessModes:
+             - ReadWriteOnce
+             capacity:
                storage: 1Gi
-           storageClassName: my-local-ssd
-           volumeMode: Filesystem
-           volumeName: dbserver-9xztmg4t-vka6ic19qcl1y3ec
-         EOF
-         ```
+             local:
+               path: /mnt/data/vka6ic19qcl1y3ec
+             persistentVolumeReclaimPolicy: Retain
+             storageClassName: my-local-ssd
+             volumeMode: Filesystem
+             nodeAffinity:
+               required:
+                 nodeSelectorTerms:
+                 - matchExpressions:
+                   - key: kubernetes.io/hostname
+                     operator: In
+                     values:
+                     - minikube
+           EOF
+           ```
+
+        - PVC
+
+            ```yaml
+            cat <<EOF | kubectl apply -f -
+            apiVersion: v1
+            kind: PersistentVolumeClaim
+            metadata:
+              labels:
+                app: arangodb
+                arango_deployment: cluster
+                role: dbserver
+              name: dbserver-9xztmg4t
+            spec:
+              accessModes:
+              - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+              storageClassName: my-local-ssd
+              volumeMode: Filesystem
+              volumeName: dbserver-9xztmg4t-vka6ic19qcl1y3ec
+            EOF
+            ```
 
 ### Create ArangoDeployment with previously created PVC
 
@@ -264,7 +276,7 @@ status:
         persistentVolumeClaim:
           name: cluster-dbserver-31akmzrp
         persistentVolumeClaimName: cluster-dbserver-31akmzrp
-EOF
+  EOF
 ```
 
 That's it! Now you can use ArangoDB with restored data.

--- a/docs/how-to/set_root_user_password.md
+++ b/docs/how-to/set_root_user_password.md
@@ -1,4 +1,4 @@
-# Set root user password
+# How to set root user password
 
 1) Create a kubernetes [Secret](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/) with root password:
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	//github.com/arangodb/rebalancer v0.1.1
 	//github.com/arangodb/go-agency-helper v0.3.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/coreos/go-semver v0.3.1
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
 	github.com/gin-gonic/gin v1.9.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkE
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -190,7 +192,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -1008,8 +1009,6 @@ google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210903162649-d08c68adba83/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 h1:KpwkzHKEF7B9Zxg18WzOa7djJ+Ha5DzthMyZYQfEn2A=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1/go.mod h1:nKE/iIaLqn2bQwXBg8f1g2Ylh6r5MN5CmZvuzZCgsCU=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1039,8 +1038,6 @@ google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.53.0 h1:LAv2ds7cmFV/XTS3XG1NneeENYrXGmorPxsBbptIjNc=
-google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
 google.golang.org/grpc v1.56.3 h1:8I4C0Yq1EjstUzUJzpcRVbuYA2mODtEmpWiQoN/b2nc=
 google.golang.org/grpc v1.56.3/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=


### PR DESCRIPTION
- absolute links to source references
- better title for how-to pages
- render default values as inline snippet
- fix formatting in Recovery doc