### PR TITLE
Revert old logic for arango_operator_deployment_agency_state metric

### DIFF
--- a/pkg/deployment/old_metrics.go
+++ b/pkg/deployment/old_metrics.go
@@ -144,8 +144,8 @@ func (i *inventory) CollectMetrics(in metrics.PushMetric) {
 					}
 
 				}
+				in.Push(i.deploymentAgencyStateMetric.Gauge(1, deployment.GetNamespace(), deployment.GetName()))
 			}
-			in.Push(i.deploymentAgencyStateMetric.Gauge(1, deployment.GetNamespace(), deployment.GetName()))
 		}
 	}
 }


### PR DESCRIPTION
Reverts metrics loading logic changed in the: https://github.com/arangodb/kube-arangodb/pull/1470