### PR TITLE
s3 url must not inlude slashes

### DIFF
--- a/docs/backup-resource.md
+++ b/docs/backup-resource.md
@@ -192,7 +192,7 @@ spec:
   deployment:
     name: "my-deployment"
   upload:
-    repositoryURL: "S3://test/kube-test"
+    repositoryURL: "S3:test/kube-test"
     credentialsSecretName: "my-s3-rclone-credentials"
 ```
 
@@ -212,7 +212,7 @@ spec:
   deployment:
     name: "my-deployment"
   download:
-    repositoryURL: "S3://test/kube-test"
+    repositoryURL: "S3:test/kube-test"
     credentialsSecretName: "my-s3-rclone-credentials"
     id: "backup-id"
 ```


### PR DESCRIPTION
fixes the documentation after downloads / uploads failed with slashes in url.