### PR TITLE
[Feature] [Platform] Inventory Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - (Feature) (Platform) MetaV1 Integration Tests
 - (Feature) (Platform) Gateway UpToDate Condition
 - (Documentation) Update Supported Kubernetes Versions
+- (Feature) (Platform) Inventory Improvement
 
 ## [1.3.0](https://github.com/arangodb/kube-arangodb/tree/1.3.0) (2025-08-01)
 - (Feature) (Platform) Storage Debug

--- a/chart/kube-arangodb-arm64/templates/deployment-operator/role.yaml
+++ b/chart/kube-arangodb-arm64/templates/deployment-operator/role.yaml
@@ -126,6 +126,28 @@ rules:
       - "get"
       - "list"
       - "watch"
+  - apiGroups:
+      - "networking.arangodb.com"
+    resources:
+      - "arangoroutes"
+      - "arangoroutes/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "platform.arangodb.com"
+    resources:
+      - "arangoplatformstorages"
+      - "arangoplatformstorages/status"
+      - "arangoplatformcharts"
+      - "arangoplatformcharts/status"
+      - "arangoplatformservices"
+      - "arangoplatformservices/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
 {{- if .Values.rbac.extensions.monitoring }}
   - apiGroups:
       - "monitoring.coreos.com"

--- a/chart/kube-arangodb-enterprise-arm64/templates/deployment-operator/role.yaml
+++ b/chart/kube-arangodb-enterprise-arm64/templates/deployment-operator/role.yaml
@@ -126,6 +126,28 @@ rules:
       - "get"
       - "list"
       - "watch"
+  - apiGroups:
+      - "networking.arangodb.com"
+    resources:
+      - "arangoroutes"
+      - "arangoroutes/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "platform.arangodb.com"
+    resources:
+      - "arangoplatformstorages"
+      - "arangoplatformstorages/status"
+      - "arangoplatformcharts"
+      - "arangoplatformcharts/status"
+      - "arangoplatformservices"
+      - "arangoplatformservices/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
 {{- if .Values.rbac.extensions.monitoring }}
   - apiGroups:
       - "monitoring.coreos.com"

--- a/chart/kube-arangodb-enterprise/templates/deployment-operator/role.yaml
+++ b/chart/kube-arangodb-enterprise/templates/deployment-operator/role.yaml
@@ -126,6 +126,28 @@ rules:
       - "get"
       - "list"
       - "watch"
+  - apiGroups:
+      - "networking.arangodb.com"
+    resources:
+      - "arangoroutes"
+      - "arangoroutes/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "platform.arangodb.com"
+    resources:
+      - "arangoplatformstorages"
+      - "arangoplatformstorages/status"
+      - "arangoplatformcharts"
+      - "arangoplatformcharts/status"
+      - "arangoplatformservices"
+      - "arangoplatformservices/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
 {{- if .Values.rbac.extensions.monitoring }}
   - apiGroups:
       - "monitoring.coreos.com"

--- a/chart/kube-arangodb/templates/deployment-operator/role.yaml
+++ b/chart/kube-arangodb/templates/deployment-operator/role.yaml
@@ -126,6 +126,28 @@ rules:
       - "get"
       - "list"
       - "watch"
+  - apiGroups:
+      - "networking.arangodb.com"
+    resources:
+      - "arangoroutes"
+      - "arangoroutes/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - "platform.arangodb.com"
+    resources:
+      - "arangoplatformstorages"
+      - "arangoplatformstorages/status"
+      - "arangoplatformcharts"
+      - "arangoplatformcharts/status"
+      - "arangoplatformservices"
+      - "arangoplatformservices/status"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
 {{- if .Values.rbac.extensions.monitoring }}
   - apiGroups:
       - "monitoring.coreos.com"

--- a/docs/api/ArangoDeployment.V1.md
+++ b/docs/api/ArangoDeployment.V1.md
@@ -25,8 +25,8 @@ Type: `boolean` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.
 
 AllowMemberRecreation allows to recreate member.
 This setting changes the member recreation logic based on group:
-- For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-- For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+- For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+- For others this value is hardcoded to `false` and the value provided in spec is ignored.
 
 ***
 
@@ -1136,8 +1136,8 @@ Type: `boolean` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.
 
 AllowMemberRecreation allows to recreate member.
 This setting changes the member recreation logic based on group:
-- For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-- For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+- For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+- For others this value is hardcoded to `false` and the value provided in spec is ignored.
 
 ***
 
@@ -2116,8 +2116,8 @@ Type: `boolean` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.
 
 AllowMemberRecreation allows to recreate member.
 This setting changes the member recreation logic based on group:
-- For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-- For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+- For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+- For others this value is hardcoded to `false` and the value provided in spec is ignored.
 
 ***
 
@@ -3319,8 +3319,8 @@ Type: `boolean` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.
 
 AllowMemberRecreation allows to recreate member.
 This setting changes the member recreation logic based on group:
-- For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-- For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+- For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+- For others this value is hardcoded to `false` and the value provided in spec is ignored.
 
 ***
 
@@ -5064,8 +5064,8 @@ Type: `boolean` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.
 
 AllowMemberRecreation allows to recreate member.
 This setting changes the member recreation logic based on group:
-- For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-- For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+- For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+- For others this value is hardcoded to `false` and the value provided in spec is ignored.
 
 ***
 
@@ -6258,8 +6258,8 @@ Type: `boolean` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.
 
 AllowMemberRecreation allows to recreate member.
 This setting changes the member recreation logic based on group:
-- For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-- For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+- For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+- For others this value is hardcoded to `false` and the value provided in spec is ignored.
 
 ***
 
@@ -7230,8 +7230,8 @@ Type: `boolean` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.
 
 AllowMemberRecreation allows to recreate member.
 This setting changes the member recreation logic based on group:
-- For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-- For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+- For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+- For others this value is hardcoded to `false` and the value provided in spec is ignored.
 
 ***
 

--- a/docs/generated/metrics/arangodb_operator_agency_cache_health_present.md
+++ b/docs/generated/metrics/arangodb_operator_agency_cache_health_present.md
@@ -12,7 +12,7 @@ Determines if local agency cache health is present
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_agency_cache_healthy.md
+++ b/docs/generated/metrics/arangodb_operator_agency_cache_healthy.md
@@ -12,7 +12,7 @@ Determines if agency is healthy
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_agency_cache_leaders.md
+++ b/docs/generated/metrics/arangodb_operator_agency_cache_leaders.md
@@ -12,8 +12,8 @@ Determines agency leader vote count. Should be always one
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
-| agent | Agent ID |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |
+| agent | Agent ID | * |

--- a/docs/generated/metrics/arangodb_operator_agency_cache_member_commit_offset.md
+++ b/docs/generated/metrics/arangodb_operator_agency_cache_member_commit_offset.md
@@ -12,8 +12,8 @@ Determines agency member commit offset. Set to -1 if Agent is not reachable
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
-| agent | Agent ID |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |
+| agent | Agent ID | * |

--- a/docs/generated/metrics/arangodb_operator_agency_cache_member_serving.md
+++ b/docs/generated/metrics/arangodb_operator_agency_cache_member_serving.md
@@ -12,8 +12,8 @@ Determines if agency member is reachable
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
-| agent | Agent ID |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |
+| agent | Agent ID | * |

--- a/docs/generated/metrics/arangodb_operator_agency_cache_present.md
+++ b/docs/generated/metrics/arangodb_operator_agency_cache_present.md
@@ -12,7 +12,7 @@ Determines if local agency cache is present
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_agency_cache_serving.md
+++ b/docs/generated/metrics/arangodb_operator_agency_cache_serving.md
@@ -12,7 +12,7 @@ Determines if agency is serving
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_agency_errors.md
+++ b/docs/generated/metrics/arangodb_operator_agency_errors.md
@@ -12,7 +12,7 @@ Current count of agency cache fetch errors
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_agency_fetches.md
+++ b/docs/generated/metrics/arangodb_operator_agency_fetches.md
@@ -12,7 +12,7 @@ Current count of agency cache fetches
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_agency_index.md
+++ b/docs/generated/metrics/arangodb_operator_agency_index.md
@@ -12,7 +12,7 @@ Current index of the agency cache
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_deployment_conditions.md
+++ b/docs/generated/metrics/arangodb_operator_deployment_conditions.md
@@ -12,8 +12,8 @@ Representation of the ArangoDeployment condition state (true/false)
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
-| condition | Condition Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |
+| condition | Condition Name | SpecAccepted&lt;br/&gt;SpecPropagated&lt;br/&gt;UpToDate |

--- a/docs/generated/metrics/arangodb_operator_engine_assertions.md
+++ b/docs/generated/metrics/arangodb_operator_engine_assertions.md
@@ -12,9 +12,9 @@ Number of assertions invoked during Operator runtime
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| key | Assertion Key |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| key | Assertion Key | * |
 
 
 ## Alerting

--- a/docs/generated/metrics/arangodb_operator_engine_ops_alerts.md
+++ b/docs/generated/metrics/arangodb_operator_engine_ops_alerts.md
@@ -12,10 +12,10 @@ Counter for actions which requires ops attention
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |
 
 
 ## Alerting

--- a/docs/generated/metrics/arangodb_operator_engine_panics_recovered.md
+++ b/docs/generated/metrics/arangodb_operator_engine_panics_recovered.md
@@ -12,6 +12,6 @@ Number of Panics recovered inside Operator reconciliation loop. Section represen
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| section | Panic Section |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| section | Panic Section | * |

--- a/docs/generated/metrics/arangodb_operator_kubernetes_client_request_errors.md
+++ b/docs/generated/metrics/arangodb_operator_kubernetes_client_request_errors.md
@@ -12,7 +12,7 @@ Number of Kubernetes Client request errors
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| component | K8S Resource name |
-| verb | Verb (create,update,update-status,patch,delete,force-delete) |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| component | K8S Resource name | * |
+| verb | Verb (create,update,update-status,patch,delete,force-delete) | * |

--- a/docs/generated/metrics/arangodb_operator_kubernetes_client_requests.md
+++ b/docs/generated/metrics/arangodb_operator_kubernetes_client_requests.md
@@ -12,7 +12,7 @@ Number of Kubernetes Client requests
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| component | K8S Resource name |
-| verb | Verb (create,update,update-status,patch,delete,force-delete) |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| component | K8S Resource name | * |
+| verb | Verb (create,update,update-status,patch,delete,force-delete) | * |

--- a/docs/generated/metrics/arangodb_operator_members_conditions.md
+++ b/docs/generated/metrics/arangodb_operator_members_conditions.md
@@ -12,9 +12,9 @@ Representation of the ArangoMember condition state (true/false)
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
-| member | Member ID |
-| condition | Condition Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |
+| member | Member ID | * |
+| condition | Condition Name | Serving&lt;br/&gt;Scheduled&lt;br/&gt;Reachable&lt;br/&gt;Started&lt;br/&gt;Ready |

--- a/docs/generated/metrics/arangodb_operator_members_unexpected_container_exit_codes.md
+++ b/docs/generated/metrics/arangodb_operator_members_unexpected_container_exit_codes.md
@@ -12,12 +12,12 @@ Counter of unexpected restarts in pod (Containers/InitContainers/EphemeralContai
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
-| member | Member ID |
-| container | Container Name |
-| container_type | Container/InitContainer/EphemeralContainer |
-| code | ExitCode |
-| reason | Reason |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |
+| member | Member ID | * |
+| container | Container Name | * |
+| container_type | Container/InitContainer/EphemeralContainer | * |
+| code | ExitCode | * |
+| reason | Reason | * |

--- a/docs/generated/metrics/arangodb_operator_objects_processed.md
+++ b/docs/generated/metrics/arangodb_operator_objects_processed.md
@@ -12,6 +12,6 @@ Number of the processed objects
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| operator_name | Operator Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| operator_name | Operator Name | * |

--- a/docs/generated/metrics/arangodb_operator_rebalancer_enabled.md
+++ b/docs/generated/metrics/arangodb_operator_rebalancer_enabled.md
@@ -12,7 +12,7 @@ Determines if rebalancer is enabled
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_rebalancer_moves_current.md
+++ b/docs/generated/metrics/arangodb_operator_rebalancer_moves_current.md
@@ -12,7 +12,7 @@ Define how many moves are currently in progress
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_rebalancer_moves_failed.md
+++ b/docs/generated/metrics/arangodb_operator_rebalancer_moves_failed.md
@@ -12,7 +12,7 @@ Define how many moves failed
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_rebalancer_moves_generated.md
+++ b/docs/generated/metrics/arangodb_operator_rebalancer_moves_generated.md
@@ -12,7 +12,7 @@ Define how many moves were generated
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_rebalancer_moves_succeeded.md
+++ b/docs/generated/metrics/arangodb_operator_rebalancer_moves_succeeded.md
@@ -12,7 +12,7 @@ Define how many moves succeeded
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_resources_arangodeployment_accepted.md
+++ b/docs/generated/metrics/arangodb_operator_resources_arangodeployment_accepted.md
@@ -12,7 +12,7 @@ Defines if ArangoDeployment has been accepted
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_resources_arangodeployment_immutable_errors.md
+++ b/docs/generated/metrics/arangodb_operator_resources_arangodeployment_immutable_errors.md
@@ -12,7 +12,7 @@ Counter for deployment immutable errors
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_resources_arangodeployment_propagated.md
+++ b/docs/generated/metrics/arangodb_operator_resources_arangodeployment_propagated.md
@@ -12,7 +12,7 @@ Defines if ArangoDeployment Spec is propagated
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_resources_arangodeployment_status_restores.md
+++ b/docs/generated/metrics/arangodb_operator_resources_arangodeployment_status_restores.md
@@ -12,7 +12,7 @@ Counter for deployment status restored
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_resources_arangodeployment_uptodate.md
+++ b/docs/generated/metrics/arangodb_operator_resources_arangodeployment_uptodate.md
@@ -12,7 +12,7 @@ Defines if ArangoDeployment is uptodate
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_resources_arangodeployment_validation_errors.md
+++ b/docs/generated/metrics/arangodb_operator_resources_arangodeployment_validation_errors.md
@@ -12,7 +12,7 @@ Counter for deployment validation errors
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | Deployment Namespace |
-| name | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | Deployment Namespace | * |
+| name | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_operator_resources_arangodeploymentreplication_active.md
+++ b/docs/generated/metrics/arangodb_operator_resources_arangodeploymentreplication_active.md
@@ -12,7 +12,7 @@ Defines if ArangoDeploymentReplication is configured and running
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | DeploymentReplication Namespace |
-| name | DeploymentReplication Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | DeploymentReplication Namespace | * |
+| name | DeploymentReplication Name | * |

--- a/docs/generated/metrics/arangodb_operator_resources_arangodeploymentreplication_failed.md
+++ b/docs/generated/metrics/arangodb_operator_resources_arangodeploymentreplication_failed.md
@@ -12,7 +12,7 @@ Defines if ArangoDeploymentReplication is in Failed phase
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| namespace | DeploymentReplication Namespace |
-| name | DeploymentReplication Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| namespace | DeploymentReplication Namespace | * |
+| name | DeploymentReplication Name | * |

--- a/docs/generated/metrics/arangodb_resources_deployment_config_map_duration.md
+++ b/docs/generated/metrics/arangodb_resources_deployment_config_map_duration.md
@@ -12,6 +12,6 @@ Duration of inspected ConfigMaps by Deployment in seconds
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| deployment | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| deployment | Deployment Name | * |

--- a/docs/generated/metrics/arangodb_resources_deployment_config_map_inspected.md
+++ b/docs/generated/metrics/arangodb_resources_deployment_config_map_inspected.md
@@ -12,6 +12,6 @@ Number of inspected ConfigMaps by Deployment
 
 ## Labels
 
-| Label | Description |
-|:---:|:--- |
-| deployment | Deployment Name |
+| Label | Description | Values |
+|:---:|:--- |:---:|
+| deployment | Deployment Name | * |

--- a/integrations/inventory/v1/definition/inventory.pb.go
+++ b/integrations/inventory/v1/definition/inventory.pb.go
@@ -201,6 +201,10 @@ type Inventory struct {
 	Configuration *InventoryConfiguration `protobuf:"bytes,1,opt,name=configuration,proto3,oneof" json:"configuration,omitempty"`
 	// ArangoDB Deployment Configuration
 	Arangodb *ArangoDBConfiguration `protobuf:"bytes,2,opt,name=arangodb,proto3,oneof" json:"arangodb,omitempty"`
+	// ArangoDB Platform Networking
+	Networking *InventoryNetworking `protobuf:"bytes,3,opt,name=networking,proto3,oneof" json:"networking,omitempty"`
+	// ArangoDB Platform Spec
+	Platform *InventoryPlatform `protobuf:"bytes,4,opt,name=platform,proto3,oneof" json:"platform,omitempty"`
 }
 
 func (x *Inventory) Reset() {
@@ -245,6 +249,20 @@ func (x *Inventory) GetConfiguration() *InventoryConfiguration {
 func (x *Inventory) GetArangodb() *ArangoDBConfiguration {
 	if x != nil {
 		return x.Arangodb
+	}
+	return nil
+}
+
+func (x *Inventory) GetNetworking() *InventoryNetworking {
+	if x != nil {
+		return x.Networking
+	}
+	return nil
+}
+
+func (x *Inventory) GetPlatform() *InventoryPlatform {
+	if x != nil {
+		return x.Platform
 	}
 	return nil
 }
@@ -298,6 +316,280 @@ func (x *InventoryConfiguration) GetHash() string {
 	return ""
 }
 
+// Platform Configuration details
+type InventoryPlatform struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Defines Services definition
+	Services map[string]*InventoryPlatformService `protobuf:"bytes,1,rep,name=services,proto3" json:"services,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (x *InventoryPlatform) Reset() {
+	*x = InventoryPlatform{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[2]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *InventoryPlatform) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InventoryPlatform) ProtoMessage() {}
+
+func (x *InventoryPlatform) ProtoReflect() protoreflect.Message {
+	mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[2]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InventoryPlatform.ProtoReflect.Descriptor instead.
+func (*InventoryPlatform) Descriptor() ([]byte, []int) {
+	return file_integrations_inventory_v1_definition_inventory_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *InventoryPlatform) GetServices() map[string]*InventoryPlatformService {
+	if x != nil {
+		return x.Services
+	}
+	return nil
+}
+
+// Envoy Service Configuration details
+type InventoryPlatformService struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Service Version
+	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	// Defines if Service is Ready
+	Ready bool `protobuf:"varint,2,opt,name=ready,proto3" json:"ready,omitempty"`
+}
+
+func (x *InventoryPlatformService) Reset() {
+	*x = InventoryPlatformService{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *InventoryPlatformService) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InventoryPlatformService) ProtoMessage() {}
+
+func (x *InventoryPlatformService) ProtoReflect() protoreflect.Message {
+	mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InventoryPlatformService.ProtoReflect.Descriptor instead.
+func (*InventoryPlatformService) Descriptor() ([]byte, []int) {
+	return file_integrations_inventory_v1_definition_inventory_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *InventoryPlatformService) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *InventoryPlatformService) GetReady() bool {
+	if x != nil {
+		return x.Ready
+	}
+	return false
+}
+
+// Envoy Configuration details
+type InventoryNetworking struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Defines Routes definition
+	Routes map[string]*InventoryNetworkingRoute `protobuf:"bytes,1,rep,name=routes,proto3" json:"routes,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (x *InventoryNetworking) Reset() {
+	*x = InventoryNetworking{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *InventoryNetworking) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InventoryNetworking) ProtoMessage() {}
+
+func (x *InventoryNetworking) ProtoReflect() protoreflect.Message {
+	mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InventoryNetworking.ProtoReflect.Descriptor instead.
+func (*InventoryNetworking) Descriptor() ([]byte, []int) {
+	return file_integrations_inventory_v1_definition_inventory_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *InventoryNetworking) GetRoutes() map[string]*InventoryNetworkingRoute {
+	if x != nil {
+		return x.Routes
+	}
+	return nil
+}
+
+// Envoy Route Configuration details
+type InventoryNetworkingRoute struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Types that are assignable to Route:
+	//
+	//	*InventoryNetworkingRoute_Path
+	Route isInventoryNetworkingRoute_Route `protobuf_oneof:"route"`
+}
+
+func (x *InventoryNetworkingRoute) Reset() {
+	*x = InventoryNetworkingRoute{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[5]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *InventoryNetworkingRoute) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InventoryNetworkingRoute) ProtoMessage() {}
+
+func (x *InventoryNetworkingRoute) ProtoReflect() protoreflect.Message {
+	mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[5]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InventoryNetworkingRoute.ProtoReflect.Descriptor instead.
+func (*InventoryNetworkingRoute) Descriptor() ([]byte, []int) {
+	return file_integrations_inventory_v1_definition_inventory_proto_rawDescGZIP(), []int{5}
+}
+
+func (m *InventoryNetworkingRoute) GetRoute() isInventoryNetworkingRoute_Route {
+	if m != nil {
+		return m.Route
+	}
+	return nil
+}
+
+func (x *InventoryNetworkingRoute) GetPath() *InventoryNetworkingRoutePath {
+	if x, ok := x.GetRoute().(*InventoryNetworkingRoute_Path); ok {
+		return x.Path
+	}
+	return nil
+}
+
+type isInventoryNetworkingRoute_Route interface {
+	isInventoryNetworkingRoute_Route()
+}
+
+type InventoryNetworkingRoute_Path struct {
+	// Path Route
+	Path *InventoryNetworkingRoutePath `protobuf:"bytes,1,opt,name=path,proto3,oneof"`
+}
+
+func (*InventoryNetworkingRoute_Path) isInventoryNetworkingRoute_Route() {}
+
+// Envoy Route Path Configuration details
+type InventoryNetworkingRoutePath struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Path definition
+	Path string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+}
+
+func (x *InventoryNetworkingRoutePath) Reset() {
+	*x = InventoryNetworkingRoutePath{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *InventoryNetworkingRoutePath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InventoryNetworkingRoutePath) ProtoMessage() {}
+
+func (x *InventoryNetworkingRoutePath) ProtoReflect() protoreflect.Message {
+	mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InventoryNetworkingRoutePath.ProtoReflect.Descriptor instead.
+func (*InventoryNetworkingRoutePath) Descriptor() ([]byte, []int) {
+	return file_integrations_inventory_v1_definition_inventory_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *InventoryNetworkingRoutePath) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
 // ArangoDB Deployment Configuration
 type ArangoDBConfiguration struct {
 	state         protoimpl.MessageState
@@ -317,7 +609,7 @@ type ArangoDBConfiguration struct {
 func (x *ArangoDBConfiguration) Reset() {
 	*x = ArangoDBConfiguration{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[2]
+		mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[7]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -330,7 +622,7 @@ func (x *ArangoDBConfiguration) String() string {
 func (*ArangoDBConfiguration) ProtoMessage() {}
 
 func (x *ArangoDBConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[2]
+	mi := &file_integrations_inventory_v1_definition_inventory_proto_msgTypes[7]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -343,7 +635,7 @@ func (x *ArangoDBConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArangoDBConfiguration.ProtoReflect.Descriptor instead.
 func (*ArangoDBConfiguration) Descriptor() ([]byte, []int) {
-	return file_integrations_inventory_v1_definition_inventory_proto_rawDescGZIP(), []int{2}
+	return file_integrations_inventory_v1_definition_inventory_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ArangoDBConfiguration) GetMode() ArangoDBMode {
@@ -381,7 +673,7 @@ var file_integrations_inventory_v1_definition_inventory_proto_rawDesc = []byte{
 	0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x2f, 0x76, 0x31, 0x2f, 0x64, 0x65, 0x66, 0x69,
 	0x6e, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x2f, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79,
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x09, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72,
-	0x79, 0x22, 0xbb, 0x01, 0x0a, 0x09, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x12,
+	0x79, 0x22, 0xdb, 0x02, 0x0a, 0x09, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x12,
 	0x4c, 0x0a, 0x0d, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f,
 	0x72, 0x79, 0x2e, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x43, 0x6f, 0x6e, 0x66,
@@ -391,11 +683,59 @@ var file_integrations_inventory_v1_definition_inventory_proto_rawDesc = []byte{
 	0x20, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x2e, 0x41, 0x72, 0x61, 0x6e,
 	0x67, 0x6f, 0x44, 0x42, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f,
 	0x6e, 0x48, 0x01, 0x52, 0x08, 0x61, 0x72, 0x61, 0x6e, 0x67, 0x6f, 0x64, 0x62, 0x88, 0x01, 0x01,
-	0x42, 0x10, 0x0a, 0x0e, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69,
-	0x6f, 0x6e, 0x42, 0x0b, 0x0a, 0x09, 0x5f, 0x61, 0x72, 0x61, 0x6e, 0x67, 0x6f, 0x64, 0x62, 0x22,
+	0x12, 0x43, 0x0a, 0x0a, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69, 0x6e, 0x67, 0x18, 0x03,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x1e, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79,
+	0x2e, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72,
+	0x6b, 0x69, 0x6e, 0x67, 0x48, 0x02, 0x52, 0x0a, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69,
+	0x6e, 0x67, 0x88, 0x01, 0x01, 0x12, 0x3d, 0x0a, 0x08, 0x70, 0x6c, 0x61, 0x74, 0x66, 0x6f, 0x72,
+	0x6d, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74,
+	0x6f, 0x72, 0x79, 0x2e, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x50, 0x6c, 0x61,
+	0x74, 0x66, 0x6f, 0x72, 0x6d, 0x48, 0x03, 0x52, 0x08, 0x70, 0x6c, 0x61, 0x74, 0x66, 0x6f, 0x72,
+	0x6d, 0x88, 0x01, 0x01, 0x42, 0x10, 0x0a, 0x0e, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75,
+	0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x0b, 0x0a, 0x09, 0x5f, 0x61, 0x72, 0x61, 0x6e, 0x67,
+	0x6f, 0x64, 0x62, 0x42, 0x0d, 0x0a, 0x0b, 0x5f, 0x6e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69,
+	0x6e, 0x67, 0x42, 0x0b, 0x0a, 0x09, 0x5f, 0x70, 0x6c, 0x61, 0x74, 0x66, 0x6f, 0x72, 0x6d, 0x22,
 	0x2c, 0x0a, 0x16, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x43, 0x6f, 0x6e, 0x66,
 	0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x12, 0x0a, 0x04, 0x68, 0x61, 0x73,
-	0x68, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x68, 0x61, 0x73, 0x68, 0x22, 0xcd, 0x01,
+	0x68, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x68, 0x61, 0x73, 0x68, 0x22, 0xbd, 0x01,
+	0x0a, 0x11, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x50, 0x6c, 0x61, 0x74, 0x66,
+	0x6f, 0x72, 0x6d, 0x12, 0x46, 0x0a, 0x08, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x18,
+	0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72,
+	0x79, 0x2e, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x50, 0x6c, 0x61, 0x74, 0x66,
+	0x6f, 0x72, 0x6d, 0x2e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x45, 0x6e, 0x74, 0x72,
+	0x79, 0x52, 0x08, 0x73, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x1a, 0x60, 0x0a, 0x0d, 0x53,
+	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03,
+	0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x39,
+	0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x23, 0x2e,
+	0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x2e, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74,
+	0x6f, 0x72, 0x79, 0x50, 0x6c, 0x61, 0x74, 0x66, 0x6f, 0x72, 0x6d, 0x53, 0x65, 0x72, 0x76, 0x69,
+	0x63, 0x65, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0x4a, 0x0a,
+	0x18, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x50, 0x6c, 0x61, 0x74, 0x66, 0x6f,
+	0x72, 0x6d, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x76, 0x65, 0x72,
+	0x73, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x76, 0x65, 0x72, 0x73,
+	0x69, 0x6f, 0x6e, 0x12, 0x14, 0x0a, 0x05, 0x72, 0x65, 0x61, 0x64, 0x79, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x08, 0x52, 0x05, 0x72, 0x65, 0x61, 0x64, 0x79, 0x22, 0xb9, 0x01, 0x0a, 0x13, 0x49, 0x6e,
+	0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69, 0x6e,
+	0x67, 0x12, 0x42, 0x0a, 0x06, 0x72, 0x6f, 0x75, 0x74, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28,
+	0x0b, 0x32, 0x2a, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x2e, 0x49, 0x6e,
+	0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69, 0x6e,
+	0x67, 0x2e, 0x52, 0x6f, 0x75, 0x74, 0x65, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x52, 0x06, 0x72,
+	0x6f, 0x75, 0x74, 0x65, 0x73, 0x1a, 0x5e, 0x0a, 0x0b, 0x52, 0x6f, 0x75, 0x74, 0x65, 0x73, 0x45,
+	0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x39, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x23, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72,
+	0x79, 0x2e, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x4e, 0x65, 0x74, 0x77, 0x6f,
+	0x72, 0x6b, 0x69, 0x6e, 0x67, 0x52, 0x6f, 0x75, 0x74, 0x65, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75,
+	0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0x62, 0x0a, 0x18, 0x49, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f,
+	0x72, 0x79, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69, 0x6e, 0x67, 0x52, 0x6f, 0x75, 0x74,
+	0x65, 0x12, 0x3d, 0x0a, 0x04, 0x70, 0x61, 0x74, 0x68, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x27, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x2e, 0x49, 0x6e, 0x76, 0x65,
+	0x6e, 0x74, 0x6f, 0x72, 0x79, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69, 0x6e, 0x67, 0x52,
+	0x6f, 0x75, 0x74, 0x65, 0x50, 0x61, 0x74, 0x68, 0x48, 0x00, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68,
+	0x42, 0x07, 0x0a, 0x05, 0x72, 0x6f, 0x75, 0x74, 0x65, 0x22, 0x32, 0x0a, 0x1c, 0x49, 0x6e, 0x76,
+	0x65, 0x6e, 0x74, 0x6f, 0x72, 0x79, 0x4e, 0x65, 0x74, 0x77, 0x6f, 0x72, 0x6b, 0x69, 0x6e, 0x67,
+	0x52, 0x6f, 0x75, 0x74, 0x65, 0x50, 0x61, 0x74, 0x68, 0x12, 0x12, 0x0a, 0x04, 0x70, 0x61, 0x74,
+	0x68, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x70, 0x61, 0x74, 0x68, 0x22, 0xcd, 0x01,
 	0x0a, 0x15, 0x41, 0x72, 0x61, 0x6e, 0x67, 0x6f, 0x44, 0x42, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67,
 	0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x2b, 0x0a, 0x04, 0x6d, 0x6f, 0x64, 0x65, 0x18,
 	0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x17, 0x2e, 0x69, 0x6e, 0x76, 0x65, 0x6e, 0x74, 0x6f, 0x72,
@@ -440,26 +780,40 @@ func file_integrations_inventory_v1_definition_inventory_proto_rawDescGZIP() []b
 }
 
 var file_integrations_inventory_v1_definition_inventory_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_integrations_inventory_v1_definition_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_integrations_inventory_v1_definition_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_integrations_inventory_v1_definition_inventory_proto_goTypes = []interface{}{
-	(ArangoDBMode)(0),              // 0: inventory.ArangoDBMode
-	(ArangoDBEdition)(0),           // 1: inventory.ArangoDBEdition
-	(ArangoDBSharding)(0),          // 2: inventory.ArangoDBSharding
-	(*Inventory)(nil),              // 3: inventory.Inventory
-	(*InventoryConfiguration)(nil), // 4: inventory.InventoryConfiguration
-	(*ArangoDBConfiguration)(nil),  // 5: inventory.ArangoDBConfiguration
+	(ArangoDBMode)(0),                    // 0: inventory.ArangoDBMode
+	(ArangoDBEdition)(0),                 // 1: inventory.ArangoDBEdition
+	(ArangoDBSharding)(0),                // 2: inventory.ArangoDBSharding
+	(*Inventory)(nil),                    // 3: inventory.Inventory
+	(*InventoryConfiguration)(nil),       // 4: inventory.InventoryConfiguration
+	(*InventoryPlatform)(nil),            // 5: inventory.InventoryPlatform
+	(*InventoryPlatformService)(nil),     // 6: inventory.InventoryPlatformService
+	(*InventoryNetworking)(nil),          // 7: inventory.InventoryNetworking
+	(*InventoryNetworkingRoute)(nil),     // 8: inventory.InventoryNetworkingRoute
+	(*InventoryNetworkingRoutePath)(nil), // 9: inventory.InventoryNetworkingRoutePath
+	(*ArangoDBConfiguration)(nil),        // 10: inventory.ArangoDBConfiguration
+	nil,                                  // 11: inventory.InventoryPlatform.ServicesEntry
+	nil,                                  // 12: inventory.InventoryNetworking.RoutesEntry
 }
 var file_integrations_inventory_v1_definition_inventory_proto_depIdxs = []int32{
-	4, // 0: inventory.Inventory.configuration:type_name -> inventory.InventoryConfiguration
-	5, // 1: inventory.Inventory.arangodb:type_name -> inventory.ArangoDBConfiguration
-	0, // 2: inventory.ArangoDBConfiguration.mode:type_name -> inventory.ArangoDBMode
-	1, // 3: inventory.ArangoDBConfiguration.edition:type_name -> inventory.ArangoDBEdition
-	2, // 4: inventory.ArangoDBConfiguration.sharding:type_name -> inventory.ArangoDBSharding
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	4,  // 0: inventory.Inventory.configuration:type_name -> inventory.InventoryConfiguration
+	10, // 1: inventory.Inventory.arangodb:type_name -> inventory.ArangoDBConfiguration
+	7,  // 2: inventory.Inventory.networking:type_name -> inventory.InventoryNetworking
+	5,  // 3: inventory.Inventory.platform:type_name -> inventory.InventoryPlatform
+	11, // 4: inventory.InventoryPlatform.services:type_name -> inventory.InventoryPlatform.ServicesEntry
+	12, // 5: inventory.InventoryNetworking.routes:type_name -> inventory.InventoryNetworking.RoutesEntry
+	9,  // 6: inventory.InventoryNetworkingRoute.path:type_name -> inventory.InventoryNetworkingRoutePath
+	0,  // 7: inventory.ArangoDBConfiguration.mode:type_name -> inventory.ArangoDBMode
+	1,  // 8: inventory.ArangoDBConfiguration.edition:type_name -> inventory.ArangoDBEdition
+	2,  // 9: inventory.ArangoDBConfiguration.sharding:type_name -> inventory.ArangoDBSharding
+	6,  // 10: inventory.InventoryPlatform.ServicesEntry.value:type_name -> inventory.InventoryPlatformService
+	8,  // 11: inventory.InventoryNetworking.RoutesEntry.value:type_name -> inventory.InventoryNetworkingRoute
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_integrations_inventory_v1_definition_inventory_proto_init() }
@@ -493,6 +847,66 @@ func file_integrations_inventory_v1_definition_inventory_proto_init() {
 			}
 		}
 		file_integrations_inventory_v1_definition_inventory_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*InventoryPlatform); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_integrations_inventory_v1_definition_inventory_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*InventoryPlatformService); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_integrations_inventory_v1_definition_inventory_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*InventoryNetworking); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_integrations_inventory_v1_definition_inventory_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*InventoryNetworkingRoute); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_integrations_inventory_v1_definition_inventory_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*InventoryNetworkingRoutePath); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_integrations_inventory_v1_definition_inventory_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ArangoDBConfiguration); i {
 			case 0:
 				return &v.state
@@ -506,13 +920,16 @@ func file_integrations_inventory_v1_definition_inventory_proto_init() {
 		}
 	}
 	file_integrations_inventory_v1_definition_inventory_proto_msgTypes[0].OneofWrappers = []interface{}{}
+	file_integrations_inventory_v1_definition_inventory_proto_msgTypes[5].OneofWrappers = []interface{}{
+		(*InventoryNetworkingRoute_Path)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_integrations_inventory_v1_definition_inventory_proto_rawDesc,
 			NumEnums:      3,
-			NumMessages:   3,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/integrations/inventory/v1/definition/inventory.proto
+++ b/integrations/inventory/v1/definition/inventory.proto
@@ -30,12 +30,51 @@ message Inventory {
   optional InventoryConfiguration configuration = 1;
   // ArangoDB Deployment Configuration
   optional ArangoDBConfiguration arangodb = 2;
+  // ArangoDB Platform Networking
+  optional InventoryNetworking networking = 3;
+  // ArangoDB Platform Spec
+  optional InventoryPlatform platform = 4;
 }
 
 // Envoy Configuration details
 message InventoryConfiguration {
   // Configuration hash
   string hash = 1;
+}
+
+// Platform Configuration details
+message InventoryPlatform {
+  // Defines Services definition
+  map<string, InventoryPlatformService> services = 1;
+}
+
+// Envoy Service Configuration details
+message InventoryPlatformService {
+  // Service Version
+  string version = 1;
+
+  // Defines if Service is Ready
+  bool ready = 2;
+}
+
+// Envoy Configuration details
+message InventoryNetworking {
+  // Defines Routes definition
+  map<string, InventoryNetworkingRoute> routes = 1;
+}
+
+// Envoy Route Configuration details
+message InventoryNetworkingRoute {
+  oneof route {
+    // Path Route
+    InventoryNetworkingRoutePath path = 1;
+  }
+}
+
+// Envoy Route Path Configuration details
+message InventoryNetworkingRoutePath {
+  // Path definition
+  string path = 1;
 }
 
 // ArangoDB Deployment Mode

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -28,6 +28,7 @@ import (
 	"path"
 	"sort"
 
+	"github.com/arangodb/kube-arangodb/pkg/util"
 	"github.com/arangodb/kube-arangodb/pkg/util/pretty"
 	"github.com/arangodb/kube-arangodb/pkg/util/strings"
 )
@@ -114,9 +115,10 @@ type Alerting struct {
 }
 
 type Label struct {
-	Key         string  `json:"key" yaml:"key"`
-	Description string  `json:"description" yaml:"description"`
-	Type        *string `json:"type" yaml:"type"`
+	Key         string   `json:"key" yaml:"key"`
+	Description string   `json:"description" yaml:"description"`
+	Type        *string  `json:"type" yaml:"type"`
+	Values      []string `json:"values" yaml:"values"`
 }
 
 func GenerateMetricsDocumentation(root string, in MetricsDoc) error {
@@ -158,6 +160,7 @@ func generateMetricFile(root, name string, m Metric) error {
 	type tableRowLabels struct {
 		Label       string `table:"Label" table_align:"center"`
 		Description string `table:"Description" table_align:"left"`
+		Values      string `table:"Values" table_align:"center"`
 	}
 	type tableRowPriority struct {
 		Priority    string `table:"Priority" table_align:"center"`
@@ -173,6 +176,7 @@ func generateMetricFile(root, name string, m Metric) error {
 		t.Add(tableRowLabels{
 			Label:       l.Key,
 			Description: l.Description,
+			Values:      util.BoolSwitch(len(l.Values) == 0, "*", strings.Join(l.Values, "\n")),
 		})
 	}
 

--- a/internal/metrics.yaml
+++ b/internal/metrics.yaml
@@ -258,6 +258,10 @@ namespaces:
             description: "Deployment Name"
           - key: condition
             description: "Condition Name"
+            values:
+              - SpecAccepted
+              - SpecPropagated
+              - UpToDate
     members:
       unexpected_container_exit_codes:
         shortDescription: "Counter of unexpected restarts in pod (Containers/InitContainers/EphemeralContainers)"
@@ -291,6 +295,12 @@ namespaces:
             description: "Member ID"
           - key: condition
             description: "Condition Name"
+            values:
+              - Serving
+              - Scheduled
+              - Reachable
+              - Started
+              - Ready
     engine:
       panics_recovered:
         shortDescription: "Number of Panics recovered inside Operator reconciliation loop"

--- a/pkg/apis/deployment/v1/deployment_spec.go
+++ b/pkg/apis/deployment/v1/deployment_spec.go
@@ -275,20 +275,12 @@ func (s *DeploymentSpec) GetAllowMemberRecreation(group ServerGroup) bool {
 		return false
 	}
 
-	groupSpec := s.GetServerGroupSpec(group)
-
-	switch group {
-	case ServerGroupGateways:
-		return true
-	case ServerGroupDBServers, ServerGroupCoordinators, ServerGroupSyncMasters, ServerGroupSyncWorkers:
-		if v := groupSpec.AllowMemberRecreation; v == nil {
-			return true
-		} else {
-			return *v
-		}
-	default:
+	// Ensure that by default we do not replace servers
+	if !group.RecreateAllowed() {
 		return false
 	}
+
+	return util.OptionalType(s.GetServerGroupSpec(group).AllowMemberRecreation, false)
 }
 
 // GetRestoreFrom returns the restore from string or empty string if not set

--- a/pkg/apis/deployment/v1/server_group.go
+++ b/pkg/apis/deployment/v1/server_group.go
@@ -76,6 +76,16 @@ func (g ServerGroup) MarshalJSON() ([]byte, error) {
 	return json.Marshal(g.AsRole())
 }
 
+func (g ServerGroup) RecreateAllowed() bool {
+	switch g {
+	case ServerGroupGateways, ServerGroupDBServers, ServerGroupCoordinators, ServerGroupSyncMasters, ServerGroupSyncWorkers:
+		return true
+
+	default:
+		return false
+	}
+}
+
 const (
 	ServerGroupUnknown        ServerGroup = 0
 	ServerGroupSingle         ServerGroup = 1

--- a/pkg/apis/deployment/v1/server_group_spec.go
+++ b/pkg/apis/deployment/v1/server_group_spec.go
@@ -190,8 +190,8 @@ type ServerGroupSpec struct {
 	ExternalPortEnabled *bool `json:"externalPortEnabled,omitempty"`
 	// AllowMemberRecreation allows to recreate member.
 	// This setting changes the member recreation logic based on group:
-	// - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-	// - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+	// - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+	// - For others this value is hardcoded to `false` and the value provided in spec is ignored.
 	AllowMemberRecreation *bool `json:"allowMemberRecreation,omitempty"`
 	// TerminationGracePeriodSeconds override default TerminationGracePeriodSeconds for pods - via silent rotation
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`

--- a/pkg/apis/deployment/v2alpha1/deployment_spec.go
+++ b/pkg/apis/deployment/v2alpha1/deployment_spec.go
@@ -275,20 +275,12 @@ func (s *DeploymentSpec) GetAllowMemberRecreation(group ServerGroup) bool {
 		return false
 	}
 
-	groupSpec := s.GetServerGroupSpec(group)
-
-	switch group {
-	case ServerGroupGateways:
-		return true
-	case ServerGroupDBServers, ServerGroupCoordinators, ServerGroupSyncMasters, ServerGroupSyncWorkers:
-		if v := groupSpec.AllowMemberRecreation; v == nil {
-			return true
-		} else {
-			return *v
-		}
-	default:
+	// Ensure that by default we do not replace servers
+	if !group.RecreateAllowed() {
 		return false
 	}
+
+	return util.OptionalType(s.GetServerGroupSpec(group).AllowMemberRecreation, false)
 }
 
 // GetRestoreFrom returns the restore from string or empty string if not set

--- a/pkg/apis/deployment/v2alpha1/server_group.go
+++ b/pkg/apis/deployment/v2alpha1/server_group.go
@@ -76,6 +76,16 @@ func (g ServerGroup) MarshalJSON() ([]byte, error) {
 	return json.Marshal(g.AsRole())
 }
 
+func (g ServerGroup) RecreateAllowed() bool {
+	switch g {
+	case ServerGroupGateways, ServerGroupDBServers, ServerGroupCoordinators, ServerGroupSyncMasters, ServerGroupSyncWorkers:
+		return true
+
+	default:
+		return false
+	}
+}
+
 const (
 	ServerGroupUnknown        ServerGroup = 0
 	ServerGroupSingle         ServerGroup = 1

--- a/pkg/apis/deployment/v2alpha1/server_group_spec.go
+++ b/pkg/apis/deployment/v2alpha1/server_group_spec.go
@@ -190,8 +190,8 @@ type ServerGroupSpec struct {
 	ExternalPortEnabled *bool `json:"externalPortEnabled,omitempty"`
 	// AllowMemberRecreation allows to recreate member.
 	// This setting changes the member recreation logic based on group:
-	// - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-	// - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+	// - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+	// - For others this value is hardcoded to `false` and the value provided in spec is ignored.
 	AllowMemberRecreation *bool `json:"allowMemberRecreation,omitempty"`
 	// TerminationGracePeriodSeconds override default TerminationGracePeriodSeconds for pods - via silent rotation
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`

--- a/pkg/crd/crds/database-deployment.schema.generated.yaml
+++ b/pkg/crd/crds/database-deployment.schema.generated.yaml
@@ -141,8 +141,8 @@ v1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -2460,8 +2460,8 @@ v1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -4697,8 +4697,8 @@ v1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -7056,8 +7056,8 @@ v1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -10508,8 +10508,8 @@ v1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -12890,8 +12890,8 @@ v1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -15120,8 +15120,8 @@ v1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -17455,8 +17455,8 @@ v2alpha1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -19774,8 +19774,8 @@ v2alpha1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -22011,8 +22011,8 @@ v2alpha1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -24370,8 +24370,8 @@ v2alpha1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -27822,8 +27822,8 @@ v2alpha1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -30204,8 +30204,8 @@ v2alpha1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:
@@ -32434,8 +32434,8 @@ v2alpha1:
                 description: |-
                   AllowMemberRecreation allows to recreate member.
                   This setting changes the member recreation logic based on group:
-                  - For Sync Masters, Sync Workers, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `true`)
-                  - For Agents and Single this value is hardcoded to `false` and the value provided in spec is ignored.
+                  - For Sync Masters, Sync Workers, Gateways, Coordinator and DB-Servers it determines if a member can be recreated in case of failure (default `false`)
+                  - For others this value is hardcoded to `false` and the value provided in spec is ignored.
                 type: boolean
               annotations:
                 additionalProperties:

--- a/pkg/deployment/reconcile/plan_builder_member_recovery.go
+++ b/pkg/deployment/reconcile/plan_builder_member_recovery.go
@@ -61,15 +61,9 @@ func (r *Reconciler) createMemberFailedRestoreInternal(_ context.Context, _ k8su
 	for _, group := range api.AllServerGroups {
 		members := status.Members.MembersOfGroup(group)
 		failed := 0
-		marked := 0
 		for _, m := range members {
 			if m.Phase == api.MemberPhaseFailed {
 				failed++
-			}
-
-			// Find also marked to remove servers
-			if m.Conditions.IsTrue(api.ConditionTypeMarkedToRemove) {
-				marked++
 			}
 		}
 

--- a/pkg/deployment/reconcile/plan_builder_member_recovery.go
+++ b/pkg/deployment/reconcile/plan_builder_member_recovery.go
@@ -105,14 +105,9 @@ func (r *Reconciler) createMemberFailedRestoreInternal(_ context.Context, _ k8su
 					continue
 				}
 
-				// There are more or equal alive members than current count. A member should not be recreated.
-				// Ensure that other member is not marked to removed
 				if c := spec.DBServers.GetCount(); c <= len(members)-failed {
 					// There are more or equal alive members than current count. A member should not be recreated.
-					// Ensure that other member is not marked to removed
-					if !m.Conditions.IsTrue(api.ConditionTypeMarkedToRemove) && c <= len(members)-marked {
-						continue
-					}
+					continue
 				}
 
 				if agencyState.Plan.Collections.IsDBServerPresent(state.Server(m.ID)) {

--- a/pkg/deployment/reconcile/plan_builder_member_recovery.go
+++ b/pkg/deployment/reconcile/plan_builder_member_recovery.go
@@ -82,6 +82,7 @@ func (r *Reconciler) createMemberFailedRestoreInternal(_ context.Context, _ k8su
 
 			if !spec.GetAllowMemberRecreation(group) {
 				// If recreate not allowed always recover member
+				memberLog.Info("Restoring old member")
 				plan = append(plan, actions.NewAction(api.ActionTypeRecreateMember, group, m))
 				continue
 			}
@@ -120,24 +121,13 @@ func (r *Reconciler) createMemberFailedRestoreInternal(_ context.Context, _ k8su
 				// From here on, DBServer can be recreated.
 			}
 
-			switch group {
-			case api.ServerGroupAgents:
-				// For agents just recreate member do not rotate ID, do not remove PVC or service.
-				memberLog.Info("Restoring old member. For agency members recreation of PVC is not supported - to prevent DataLoss")
-				plan = append(plan, actions.NewAction(api.ActionTypeRecreateMember, group, m))
-			case api.ServerGroupSingle:
-				// Do not remove data for single.
-				memberLog.Info("Restoring old member. Rotation for single servers is not safe")
-				plan = append(plan, actions.NewAction(api.ActionTypeRecreateMember, group, m))
-			default:
-				if spec.GetAllowMemberRecreation(group) {
-					memberLog.Info("Creating member replacement plan because member has failed")
-					plan = append(plan,
-						actions.NewAction(api.ActionTypeRemoveMember, group, m),
-						actions.NewAction(api.ActionTypeAddMember, group, sharedReconcile.WithPredefinedMember("")),
-						actions.NewAction(api.ActionTypeWaitForMemberUp, group, sharedReconcile.WithPredefinedMember(api.MemberIDPreviousAction)),
-					)
-				}
+			if spec.GetAllowMemberRecreation(group) {
+				memberLog.Info("Creating member replacement plan because member has failed")
+				plan = append(plan,
+					actions.NewAction(api.ActionTypeRemoveMember, group, m),
+					actions.NewAction(api.ActionTypeAddMember, group, sharedReconcile.WithPredefinedMember("")),
+					actions.NewAction(api.ActionTypeWaitForMemberUp, group, sharedReconcile.WithPredefinedMember(api.MemberIDPreviousAction)),
+				)
 			}
 		}
 	}

--- a/pkg/deployment/reconcile/plan_builder_test.go
+++ b/pkg/deployment/reconcile/plan_builder_test.go
@@ -1107,7 +1107,7 @@ func TestCreatePlan(t *testing.T) {
 			ExpectedHighPlan: []api.Action{
 				actions.NewAction(api.ActionTypeRecreateMember, api.ServerGroupAgents, sharedReconcile.WithPredefinedMember("id")),
 			},
-			ExpectedLog: "Restoring old member. For agency members recreation of PVC is not supported - to prevent DataLoss",
+			ExpectedLog: "Restoring old member",
 		},
 		{
 			Name: "Coordinator in failed state",
@@ -1118,6 +1118,7 @@ func TestCreatePlan(t *testing.T) {
 				ad.Spec.Coordinators = api.ServerGroupSpec{
 					Count: util.NewType[int](2),
 				}
+				ad.Spec.Coordinators.AllowMemberRecreation = util.NewType(true)
 				ad.Status.Members.Coordinators[0].Phase = api.MemberPhaseFailed
 				ad.Status.Members.Coordinators[0].ID = "id"
 			},
@@ -1138,6 +1139,7 @@ func TestCreatePlan(t *testing.T) {
 				ad.Spec.DBServers = api.ServerGroupSpec{
 					Count: util.NewType[int](3),
 				}
+				ad.Spec.DBServers.AllowMemberRecreation = util.NewType(true)
 				ad.Status.Members.DBServers[0].Phase = api.MemberPhaseFailed
 				ad.Status.Members.DBServers[0].ID = "id"
 			},

--- a/pkg/deployment/resources/inspector/apsvc.go
+++ b/pkg/deployment/resources/inspector/apsvc.go
@@ -1,0 +1,126 @@
+//
+// DISCLAIMER
+//
+// Copyright 2025 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package inspector
+
+import (
+	"context"
+	"time"
+
+	platformApi "github.com/arangodb/kube-arangodb/pkg/apis/platform/v1beta1"
+	utilConstants "github.com/arangodb/kube-arangodb/pkg/util/constants"
+	"github.com/arangodb/kube-arangodb/pkg/util/errors"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoplatformservice"
+	inspectorConstants "github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/constants"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/definitions"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/generic"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/throttle"
+)
+
+func init() {
+	requireRegisterInspectorLoader(arangoPlatformServicesInspectorLoaderObj)
+}
+
+var arangoPlatformServicesInspectorLoaderObj = arangoPlatformServicesInspectorLoader{}
+
+type arangoPlatformServicesInspectorLoader struct {
+}
+
+func (p arangoPlatformServicesInspectorLoader) Component() definitions.Component {
+	return definitions.ArangoPlatformService
+}
+
+func (p arangoPlatformServicesInspectorLoader) Load(ctx context.Context, i *inspectorState) {
+	var q arangoPlatformServicesInspector
+
+	q.v1beta1 = newInspectorVersion[*platformApi.ArangoPlatformServiceList, *platformApi.ArangoPlatformService](ctx,
+		inspectorConstants.ArangoPlatformServiceGRv1Beta1(),
+		inspectorConstants.ArangoPlatformServiceGKv1Beta1(),
+		i.client.Arango().PlatformV1beta1().ArangoPlatformServices(i.namespace),
+		arangoplatformservice.List())
+
+	i.arangoPlatformServices = &q
+	q.state = i
+	q.last = time.Now()
+}
+
+func (p arangoPlatformServicesInspectorLoader) Verify(i *inspectorState) error {
+	return nil
+}
+
+func (p arangoPlatformServicesInspectorLoader) Copy(from, to *inspectorState, override bool) {
+	if to.arangoPlatformServices != nil {
+		if !override {
+			return
+		}
+	}
+
+	to.arangoPlatformServices = from.arangoPlatformServices
+	to.arangoPlatformServices.state = to
+}
+
+func (p arangoPlatformServicesInspectorLoader) Name() string {
+	return "arangoPlatformServices"
+}
+
+type arangoPlatformServicesInspector struct {
+	state *inspectorState
+
+	last time.Time
+
+	v1beta1 *inspectorVersion[*platformApi.ArangoPlatformService]
+}
+
+func (p *arangoPlatformServicesInspector) LastRefresh() time.Time {
+	return p.last
+}
+
+func (p *arangoPlatformServicesInspector) Refresh(ctx context.Context) error {
+	p.Throttle(p.state.throttles).Invalidate()
+	return p.state.refresh(ctx, arangoPlatformServicesInspectorLoaderObj)
+}
+
+func (p *arangoPlatformServicesInspector) Version() utilConstants.Version {
+	return utilConstants.VersionV1Beta1
+}
+
+func (p *arangoPlatformServicesInspector) Throttle(c throttle.Components) throttle.Throttle {
+	return c.ArangoPlatformService()
+}
+
+func (p *arangoPlatformServicesInspector) validate() error {
+	if p == nil {
+		return errors.Errorf("ArangoPlatformServiceInspector is nil")
+	}
+
+	if p.state == nil {
+		return errors.Errorf("Parent is nil")
+	}
+
+	return p.v1beta1.validate()
+}
+
+func (p *arangoPlatformServicesInspector) V1Beta1() (generic.Inspector[*platformApi.ArangoPlatformService], error) {
+	if p.v1beta1.err != nil {
+		return nil, p.v1beta1.err
+	}
+
+	return p.v1beta1, nil
+}

--- a/pkg/deployment/resources/inspector/apsvc_anonymous.go
+++ b/pkg/deployment/resources/inspector/apsvc_anonymous.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2024-2025 ArangoDB GmbH, Cologne, Germany
+// Copyright 2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,16 +28,16 @@ import (
 	inspectorConstants "github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/constants"
 )
 
-func (p *arangoPlatformStoragesInspector) Anonymous(gvk schema.GroupVersionKind) (anonymous.Interface, bool) {
-	g := inspectorConstants.ArangoPlatformStorageGKv1Beta1()
+func (p *arangoPlatformServicesInspector) Anonymous(gvk schema.GroupVersionKind) (anonymous.Interface, bool) {
+	g := inspectorConstants.ArangoPlatformServiceGKv1Beta1()
 
 	if g.Kind == gvk.Kind && g.Group == gvk.Group {
 		switch gvk.Version {
-		case inspectorConstants.ArangoPlatformStorageVersionV1Beta1, DefaultVersion:
+		case inspectorConstants.ArangoPlatformServiceVersionV1Beta1, DefaultVersion:
 			if p.v1beta1 == nil || p.v1beta1.err != nil {
 				return nil, false
 			}
-			return anonymous.NewAnonymous[*platformApi.ArangoPlatformStorage](g, p.state.arangoPlatformStorages.v1beta1, p.state.ArangoPlatformStorageModInterface().V1Beta1()), true
+			return anonymous.NewAnonymous[*platformApi.ArangoPlatformService](g, p.state.arangoPlatformServices.v1beta1, p.state.ArangoPlatformServiceModInterface().V1Beta1()), true
 		}
 	}
 

--- a/pkg/deployment/resources/inspector/apsvc_gvk.go
+++ b/pkg/deployment/resources/inspector/apsvc_gvk.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2024-2025 ArangoDB GmbH, Cologne, Germany
+// Copyright 2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,23 +23,13 @@ package inspector
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	platformApi "github.com/arangodb/kube-arangodb/pkg/apis/platform/v1beta1"
-	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/anonymous"
 	inspectorConstants "github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/constants"
 )
 
-func (p *arangoPlatformStoragesInspector) Anonymous(gvk schema.GroupVersionKind) (anonymous.Interface, bool) {
-	g := inspectorConstants.ArangoPlatformStorageGKv1Beta1()
+func (p *arangoPlatformServicesInspector) GroupKind() schema.GroupKind {
+	return inspectorConstants.ArangoPlatformServiceGK()
+}
 
-	if g.Kind == gvk.Kind && g.Group == gvk.Group {
-		switch gvk.Version {
-		case inspectorConstants.ArangoPlatformStorageVersionV1Beta1, DefaultVersion:
-			if p.v1beta1 == nil || p.v1beta1.err != nil {
-				return nil, false
-			}
-			return anonymous.NewAnonymous[*platformApi.ArangoPlatformStorage](g, p.state.arangoPlatformStorages.v1beta1, p.state.ArangoPlatformStorageModInterface().V1Beta1()), true
-		}
-	}
-
-	return nil, false
+func (p *arangoPlatformServicesInspector) GroupResource() schema.GroupResource {
+	return inspectorConstants.ArangoPlatformServiceGR()
 }

--- a/pkg/deployment/resources/inspector/apsvs_mod.go
+++ b/pkg/deployment/resources/inspector/apsvs_mod.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2024-2025 ArangoDB GmbH, Cologne, Germany
+// Copyright 2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,20 +27,20 @@ import (
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/mods"
 )
 
-func (i *inspectorState) ArangoPlatformStorageModInterface() mods.ArangoPlatformStorageMods {
-	return arangoPlatformStorageMod{
+func (i *inspectorState) ArangoPlatformServiceModInterface() mods.ArangoPlatformServiceMods {
+	return arangoPlatformServiceMod{
 		i: i,
 	}
 }
 
-type arangoPlatformStorageMod struct {
+type arangoPlatformServiceMod struct {
 	i *inspectorState
 }
 
-func (p arangoPlatformStorageMod) V1Beta1() generic.ModStatusClient[*platformApi.ArangoPlatformStorage] {
-	return wrapMod[*platformApi.ArangoPlatformStorage](definitions.ArangoPlatformStorage, p.i.GetThrottles, p.clientv1beta1)
+func (p arangoPlatformServiceMod) V1Beta1() generic.ModStatusClient[*platformApi.ArangoPlatformService] {
+	return wrapMod[*platformApi.ArangoPlatformService](definitions.ArangoPlatformService, p.i.GetThrottles, p.clientv1beta1)
 }
 
-func (p arangoPlatformStorageMod) clientv1beta1() generic.ModStatusClient[*platformApi.ArangoPlatformStorage] {
-	return p.i.Client().Arango().PlatformV1beta1().ArangoPlatformStorages(p.i.Namespace())
+func (p arangoPlatformServiceMod) clientv1beta1() generic.ModStatusClient[*platformApi.ArangoPlatformService] {
+	return p.i.Client().Arango().PlatformV1beta1().ArangoPlatformServices(p.i.Namespace())
 }

--- a/pkg/deployment/resources/inspector/inspector.go
+++ b/pkg/deployment/resources/inspector/inspector.go
@@ -571,6 +571,7 @@ func (i *inspectorState) copyCore() *inspectorState {
 		arangoRoutes:                  i.arangoRoutes,
 		arangoProfiles:                i.arangoProfiles,
 		arangoPlatformStorages:        i.arangoPlatformStorages,
+		arangoPlatformServices:        i.arangoPlatformServices,
 		arangoClusterSynchronizations: i.arangoClusterSynchronizations,
 		throttles:                     i.throttles.Copy(),
 		versionInfo:                   i.versionInfo,

--- a/pkg/deployment/resources/inspector/inspector.go
+++ b/pkg/deployment/resources/inspector/inspector.go
@@ -43,6 +43,7 @@ import (
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/anonymous"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoclustersynchronization"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangomember"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoplatformservice"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoplatformstorage"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoprofile"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoroute"
@@ -142,6 +143,7 @@ type inspectorState struct {
 	arangoTasks                   *arangoTasksInspector
 	arangoProfiles                *arangoProfilesInspector
 	arangoPlatformStorages        *arangoPlatformStoragesInspector
+	arangoPlatformServices        *arangoPlatformServicesInspector
 	arangoRoutes                  *arangoRoutesInspector
 	arangoClusterSynchronizations *arangoClusterSynchronizationsInspector
 	endpoints                     *endpointsInspector
@@ -183,6 +185,10 @@ func (i *inspectorState) RegisterInformers(k8s informers.SharedInformerFactory, 
 
 	if _, err := i.ArangoPlatformStorage().V1Beta1(); err == nil {
 		arango.Platform().V1beta1().ArangoPlatformStorages().Informer().AddEventHandler(i.eventHandler(definitions.ArangoPlatformStorage))
+	}
+
+	if _, err := i.ArangoPlatformService().V1Beta1(); err == nil {
+		arango.Platform().V1beta1().ArangoPlatformServices().Informer().AddEventHandler(i.eventHandler(definitions.ArangoPlatformService))
 	}
 
 	if _, err := i.ArangoRoute().V1Beta1(); err == nil {
@@ -251,6 +257,8 @@ func (i *inspectorState) AnonymousObjects() []anonymous.Impl {
 		i.arangoRoutes,
 		i.arangoClusterSynchronizations,
 		i.endpoints,
+		i.arangoPlatformStorages,
+		i.arangoPlatformServices,
 	}
 }
 
@@ -355,6 +363,10 @@ func (i *inspectorState) ArangoProfile() arangoprofile.Definition {
 
 func (i *inspectorState) ArangoPlatformStorage() arangoplatformstorage.Definition {
 	return i.arangoPlatformStorages
+}
+
+func (i *inspectorState) ArangoPlatformService() arangoplatformservice.Definition {
+	return i.arangoPlatformServices
 }
 
 func (i *inspectorState) Refresh(ctx context.Context) error {
@@ -517,6 +529,10 @@ func (i *inspectorState) validate() error {
 	}
 
 	if err := i.arangoPlatformStorages.validate(); err != nil {
+		return err
+	}
+
+	if err := i.arangoPlatformServices.validate(); err != nil {
 		return err
 	}
 

--- a/pkg/deployment/resources/inspector/inspector_test.go
+++ b/pkg/deployment/resources/inspector/inspector_test.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/deployment/resources/inspector/inspector_test.go
+++ b/pkg/deployment/resources/inspector/inspector_test.go
@@ -142,7 +142,7 @@ func getAllTypes() []string {
 func Test_Inspector_RefreshMatrix(t *testing.T) {
 	c := kclient.NewFakeClient()
 
-	tc := throttle.NewThrottleComponents(time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour)
+	tc := throttle.NewThrottleComponents(time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour)
 
 	i := NewInspector(tc, c, "test", "test")
 
@@ -302,7 +302,7 @@ func Test_Inspector_Load(t *testing.T) {
 func Test_Inspector_Invalidate(t *testing.T) {
 	c := kclient.NewFakeClient()
 
-	tc := throttle.NewThrottleComponents(time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour)
+	tc := throttle.NewThrottleComponents(time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour)
 
 	i := NewInspector(tc, c, "test", "test")
 

--- a/pkg/deployment/resources/inspector/pdbs_version_test.go
+++ b/pkg/deployment/resources/inspector/pdbs_version_test.go
@@ -52,7 +52,7 @@ func Test_PDB_Versions(t *testing.T) {
 				GitVersion: v,
 			})
 
-			tc := throttle.NewThrottleComponents(time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour)
+			tc := throttle.NewThrottleComponents(time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour, time.Hour)
 
 			i := NewInspector(tc, c, "test", "test")
 			require.NoError(t, i.Refresh(context.Background()))

--- a/pkg/deployment/resources/inspector/throttles.go
+++ b/pkg/deployment/resources/inspector/throttles.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ func NewDefaultThrottle() throttle.Components {
 		30*time.Second, // ArangoRoute
 		30*time.Second, // ArangoProfile
 		30*time.Second, // ArangoPlatformStorage
+		30*time.Second, // ArangoPlatformService
 		30*time.Second, // Node
 		30*time.Second, // PV
 		15*time.Second, // PVC

--- a/pkg/util/k8sutil/inspector/arangoplatformservice/definition.go
+++ b/pkg/util/k8sutil/inspector/arangoplatformservice/definition.go
@@ -1,0 +1,37 @@
+//
+// DISCLAIMER
+//
+// Copyright 2025 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package arangoplatformservice
+
+import (
+	platformApi "github.com/arangodb/kube-arangodb/pkg/apis/platform/v1beta1"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/base"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/generic"
+)
+
+type Inspector interface {
+	ArangoPlatformService() Definition
+}
+
+type Definition interface {
+	base.Inspector
+
+	V1Beta1() (generic.Inspector[*platformApi.ArangoPlatformService], error)
+}

--- a/pkg/util/k8sutil/inspector/arangoplatformservice/generic.go
+++ b/pkg/util/k8sutil/inspector/arangoplatformservice/generic.go
@@ -1,0 +1,43 @@
+//
+// DISCLAIMER
+//
+// Copyright 2025 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package arangoplatformservice
+
+import (
+	platformApi "github.com/arangodb/kube-arangodb/pkg/apis/platform/v1beta1"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/generic"
+)
+
+func List(filter ...generic.Filter[*platformApi.ArangoPlatformService]) generic.ExtractorList[*platformApi.ArangoPlatformServiceList, *platformApi.ArangoPlatformService] {
+	return func(in *platformApi.ArangoPlatformServiceList) []*platformApi.ArangoPlatformService {
+		ret := make([]*platformApi.ArangoPlatformService, 0, len(in.Items))
+
+		for _, el := range in.Items {
+			z := el.DeepCopy()
+			if !generic.FilterObject(z, filter...) {
+				continue
+			}
+
+			ret = append(ret, z)
+		}
+
+		return ret
+	}
+}

--- a/pkg/util/k8sutil/inspector/constants/arango_platform_service_constants.go
+++ b/pkg/util/k8sutil/inspector/constants/arango_platform_service_constants.go
@@ -24,19 +24,22 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/arangodb/kube-arangodb/pkg/apis/platform"
+	platformApiv1alpha1 "github.com/arangodb/kube-arangodb/pkg/apis/platform/v1alpha1"
 	platformApi "github.com/arangodb/kube-arangodb/pkg/apis/platform/v1beta1"
 )
 
 // ArangoPlatformService
 const (
-	ArangoPlatformServiceGroup           = platform.ArangoPlatformGroupName
-	ArangoPlatformServiceResource        = platform.ArangoPlatformServiceResourcePlural
-	ArangoPlatformServiceKind            = platform.ArangoPlatformServiceResourceKind
-	ArangoPlatformServiceVersionV1Alpha1 = platformApi.ArangoPlatformVersion
+	ArangoPlatformServiceGroup    = platform.ArangoPlatformGroupName
+	ArangoPlatformServiceResource = platform.ArangoPlatformServiceResourcePlural
+	ArangoPlatformServiceKind     = platform.ArangoPlatformServiceResourceKind
+	// deprecated: Use v1beta1 instead
+	ArangoPlatformServiceVersionV1Alpha1 = platformApiv1alpha1.ArangoPlatformVersion
+	ArangoPlatformServiceVersionV1Beta1  = platformApi.ArangoPlatformVersion
 )
 
 func init() {
-	register[*platformApi.ArangoPlatformService](ArangoPlatformServiceGKv1Alpha1(), ArangoPlatformServiceGRv1Alpha1())
+	register[*platformApi.ArangoPlatformService](ArangoPlatformServiceGKv1Beta1(), ArangoPlatformServiceGRv1Beta1())
 }
 
 func ArangoPlatformServiceGK() schema.GroupKind {
@@ -46,11 +49,20 @@ func ArangoPlatformServiceGK() schema.GroupKind {
 	}
 }
 
+// deprecated: Use v1beta1 instead
 func ArangoPlatformServiceGKv1Alpha1() schema.GroupVersionKind {
 	return schema.GroupVersionKind{
 		Group:   ArangoPlatformServiceGroup,
 		Kind:    ArangoPlatformServiceKind,
 		Version: ArangoPlatformServiceVersionV1Alpha1,
+	}
+}
+
+func ArangoPlatformServiceGKv1Beta1() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   ArangoPlatformServiceGroup,
+		Kind:    ArangoPlatformServiceKind,
+		Version: ArangoPlatformServiceVersionV1Beta1,
 	}
 }
 
@@ -61,10 +73,19 @@ func ArangoPlatformServiceGR() schema.GroupResource {
 	}
 }
 
+// deprecated: Use v1beta1 instead
 func ArangoPlatformServiceGRv1Alpha1() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    ArangoPlatformServiceGroup,
 		Resource: ArangoPlatformServiceResource,
 		Version:  ArangoPlatformServiceVersionV1Alpha1,
+	}
+}
+
+func ArangoPlatformServiceGRv1Beta1() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    ArangoPlatformServiceGroup,
+		Resource: ArangoPlatformServiceResource,
+		Version:  ArangoPlatformServiceVersionV1Beta1,
 	}
 }

--- a/pkg/util/k8sutil/inspector/definitions/components.go
+++ b/pkg/util/k8sutil/inspector/definitions/components.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ const (
 	ArangoRoute                  Component = "ArangoRoute"
 	ArangoProfile                Component = "ArangoProfile"
 	ArangoPlatformStorage        Component = "ArangoPlatformStorage"
+	ArangoPlatformService        Component = "ArangoPlatformService"
 	Node                         Component = "Node"
 	PersistentVolume             Component = "PersistentVolume"
 	PersistentVolumeClaim        Component = "PersistentVolumeClaim"
@@ -52,6 +53,7 @@ func AllComponents() []Component {
 		ArangoRoute,
 		ArangoProfile,
 		ArangoPlatformStorage,
+		ArangoPlatformService,
 		Node,
 		PersistentVolume,
 		PersistentVolumeClaim,

--- a/pkg/util/k8sutil/inspector/inspector.go
+++ b/pkg/util/k8sutil/inspector/inspector.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import (
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoclustersynchronization"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangodeployment"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangomember"
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoplatformservice"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoplatformstorage"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoprofile"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/inspector/arangoroute"
@@ -98,6 +99,7 @@ type Inspector interface {
 	arangoroute.Inspector
 	arangoprofile.Inspector
 	arangoplatformstorage.Inspector
+	arangoplatformservice.Inspector
 
 	mods.Mods
 

--- a/pkg/util/k8sutil/inspector/mods/mods.go
+++ b/pkg/util/k8sutil/inspector/mods/mods.go
@@ -73,7 +73,11 @@ type ArangoMemberMods interface {
 }
 
 type ArangoPlatformStorageMods interface {
-	V1Alpha1() generic.ModStatusClient[*platformApi.ArangoPlatformStorage]
+	V1Beta1() generic.ModStatusClient[*platformApi.ArangoPlatformStorage]
+}
+
+type ArangoPlatformServiceMods interface {
+	V1Beta1() generic.ModStatusClient[*platformApi.ArangoPlatformService]
 }
 
 type ArangoTaskMods interface {

--- a/pkg/util/k8sutil/inspector/throttle/throttle.go
+++ b/pkg/util/k8sutil/inspector/throttle/throttle.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,17 +32,18 @@ type Inspector interface {
 }
 
 func NewAlwaysThrottleComponents() Components {
-	return NewThrottleComponents(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	return NewThrottleComponents(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 }
 
-func NewThrottleComponents(acs, am, at, ar, ap, aps, node, pvc, pod, pv, pdb, secret, cm, service, serviceAccount, sm, endpoints time.Duration) Components {
+func NewThrottleComponents(acs, am, at, ar, ap, aps, apsvc, node, pvc, pod, pv, pdb, secret, cm, service, serviceAccount, sm, endpoints time.Duration) Components {
 	return &throttleComponents{
 		arangoClusterSynchronization: NewThrottle(acs),
 		arangoMember:                 NewThrottle(am),
 		arangoTask:                   NewThrottle(at),
 		arangoRoute:                  NewThrottle(ar),
 		arangoProfile:                NewThrottle(ap),
-		arangopPlatformStorage:       NewThrottle(aps),
+		arangoPlatformStorage:        NewThrottle(aps),
+		arangoPlatformService:        NewThrottle(apsvc),
 		node:                         NewThrottle(node),
 		persistentVolume:             NewThrottle(pv),
 		persistentVolumeClaim:        NewThrottle(pvc),
@@ -64,6 +65,7 @@ type Components interface {
 	ArangoRoute() Throttle
 	ArangoProfile() Throttle
 	ArangoPlatformStorage() Throttle
+	ArangoPlatformService() Throttle
 	Node() Throttle
 	PersistentVolume() Throttle
 	PersistentVolumeClaim() Throttle
@@ -89,7 +91,8 @@ type throttleComponents struct {
 	arangoTask                   Throttle
 	arangoRoute                  Throttle
 	arangoProfile                Throttle
-	arangopPlatformStorage       Throttle
+	arangoPlatformStorage        Throttle
+	arangoPlatformService        Throttle
 	node                         Throttle
 	persistentVolume             Throttle
 	persistentVolumeClaim        Throttle
@@ -147,7 +150,9 @@ func (t *throttleComponents) Get(c definitions.Component) Throttle {
 	case definitions.ArangoProfile:
 		return t.arangoProfile
 	case definitions.ArangoPlatformStorage:
-		return t.arangopPlatformStorage
+		return t.arangoPlatformStorage
+	case definitions.ArangoPlatformService:
+		return t.arangoPlatformService
 	case definitions.Node:
 		return t.node
 	case definitions.PersistentVolume:
@@ -182,7 +187,8 @@ func (t *throttleComponents) Copy() Components {
 		arangoTask:                   t.arangoTask.Copy(),
 		arangoRoute:                  t.arangoRoute.Copy(),
 		arangoProfile:                t.arangoProfile.Copy(),
-		arangopPlatformStorage:       t.arangopPlatformStorage.Copy(),
+		arangoPlatformStorage:        t.arangoPlatformStorage.Copy(),
+		arangoPlatformService:        t.arangoPlatformService.Copy(),
 		node:                         t.node.Copy(),
 		persistentVolume:             t.persistentVolume.Copy(),
 		persistentVolumeClaim:        t.persistentVolumeClaim.Copy(),
@@ -218,7 +224,11 @@ func (t *throttleComponents) ArangoProfile() Throttle {
 }
 
 func (t *throttleComponents) ArangoPlatformStorage() Throttle {
-	return t.arangopPlatformStorage
+	return t.arangoPlatformStorage
+}
+
+func (t *throttleComponents) ArangoPlatformService() Throttle {
+	return t.arangoPlatformService
 }
 
 func (t *throttleComponents) Node() Throttle {

--- a/pkg/util/k8sutil/object.go
+++ b/pkg/util/k8sutil/object.go
@@ -32,7 +32,6 @@ func Copy[T meta.Object](obj T) (T, bool) {
 	}
 
 	if q, ok := any(obj).(Q); ok {
-		println("OK")
 		return q.DeepCopy(), true
 	}
 

--- a/pkg/util/k8sutil/object.go
+++ b/pkg/util/k8sutil/object.go
@@ -1,0 +1,40 @@
+//
+// DISCLAIMER
+//
+// Copyright 2025 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package k8sutil
+
+import (
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/arangodb/kube-arangodb/pkg/util"
+)
+
+func Copy[T meta.Object](obj T) (T, bool) {
+	type Q interface {
+		DeepCopy() T
+	}
+
+	if q, ok := any(obj).(Q); ok {
+		println("OK")
+		return q.DeepCopy(), true
+	}
+
+	return util.Default[T](), false
+}

--- a/pkg/util/k8sutil/object_test.go
+++ b/pkg/util/k8sutil/object_test.go
@@ -1,0 +1,33 @@
+//
+// DISCLAIMER
+//
+// Copyright 2025 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package k8sutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	core "k8s.io/api/core/v1"
+)
+
+func Test_Copy(t *testing.T) {
+	_, ok := Copy(&core.Pod{})
+	require.True(t, ok)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extends the platform Inventory to include networking routes and platform services (served via gateway), adds RBAC and inspectors for these CRs, switches member recreation default to disabled with updated recovery logic, and enhances metrics docs with label values.
> 
> - **Platform Inventory & Gateway**:
>   - Extend `integrations/inventory/v1` to include `networking` routes and `platform` services; gateway inventory endpoint now serves enriched data.
>   - Add inspectors/throttles/mods for `ArangoPlatformService`; wire into informer/inspector.
>   - Update Helm RBAC to `get/list/watch` `networking.arangodb.com/arangoroutes` and `platform.arangodb.com` resources.
> - **Member Recreation Policy**:
>   - Change default `allowMemberRecreation` to `false`; add `ServerGroup.RecreateAllowed()`; update recovery plan builder and tests.
>   - Sync docs and CRD schema for the new default and groups (incl. Gateways).
> - **Metrics Docs**:
>   - Generate label `Values` in docs; support via `Label.Values` in generator and `metrics.yaml` additions.
> - **Utilities/Debug**:
>   - Add `k8sutil.Copy` and use it in debug package item iteration to avoid mutation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e95f6d259ca2a43824de8f7d1a3c951d39b55c9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->