### PR TITLE
FE-896 | disable privilege escalation for integration sidecar

### DIFF
--- a/pkg/util/k8sutil/pods.go
+++ b/pkg/util/k8sutil/pods.go
@@ -783,10 +783,11 @@ func CreateDefaultContainerTemplate(image *schedulerContainerResourcesApi.Image)
 		},
 		Security: &schedulerContainerResourcesApi.Security{
 			SecurityContext: &core.SecurityContext{
-				RunAsUser:              util.NewType[int64](shared.DefaultRunAsUser),
-				RunAsGroup:             util.NewType[int64](shared.DefaultRunAsGroup),
-				RunAsNonRoot:           util.NewType(true),
-				ReadOnlyRootFilesystem: util.NewType(true),
+				RunAsUser:                util.NewType[int64](shared.DefaultRunAsUser),
+				RunAsGroup:               util.NewType[int64](shared.DefaultRunAsGroup),
+				RunAsNonRoot:             util.NewType(true),
+				ReadOnlyRootFilesystem:   util.NewType(true),
+				AllowPrivilegeEscalation: util.NewType(false),
 				Capabilities: &core.Capabilities{
 					Drop: []core.Capability{
 						"ALL",


### PR DESCRIPTION
Fix POD.004 sanity check warnings for integration sidecar

Add missing `allowPrivilegeEscalation: false` to the default integration container security context