### PR TITLE
[Feature] [Platform] Fix ImagePullSecrets Merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - (Bugfix) (Platform) Fix LM CLI Option
 - (Bugfix) (Platform) Fix topology for Gateways
 - (Feature) (Platform) Dump CLI switch to Services
+- (Feature) (Platform) Fix ImagePullSecrets Merge
 
 ## [1.3.2](https://github.com/arangodb/kube-arangodb/tree/1.3.2) (2025-11-20)
 - (Bugfix) (Platform) Increase memory limit for Inventory

--- a/pkg/apis/scheduler/v1beta1/pod/resources/image.go
+++ b/pkg/apis/scheduler/v1beta1/pod/resources/image.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2024-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,11 +59,19 @@ func (i *Image) With(other *Image) *Image {
 		return nil
 	}
 
-	if other == nil {
-		return i.DeepCopy()
+	if i == nil || other == nil {
+		if i != nil {
+			return i.DeepCopy()
+		}
+
+		return other.DeepCopy()
 	}
 
-	return other.DeepCopy()
+	z := i.DeepCopy()
+
+	z.ImagePullSecrets = append(z.ImagePullSecrets, other.ImagePullSecrets...)
+
+	return z
 }
 
 func (i *Image) Validate() error {

--- a/pkg/apis/scheduler/v1beta1/pod/resources/image_test.go
+++ b/pkg/apis/scheduler/v1beta1/pod/resources/image_test.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2024-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,6 +83,25 @@ func Test_Image(t *testing.T) {
 		})(func(t *testing.T, pod *core.PodTemplateSpec) {
 			require.Len(t, pod.Spec.ImagePullSecrets, 1)
 			require.Equal(t, "secret", pod.Spec.ImagePullSecrets[0].Name)
+		})
+	})
+	t.Run("With Merge", func(t *testing.T) {
+		applyImage(t, &core.PodTemplateSpec{}, &Image{
+			ImagePullSecrets: []string{
+				"secret",
+			},
+		}, &Image{
+			ImagePullSecrets: []string{
+				"secret2",
+			},
+		}, &Image{
+			ImagePullSecrets: []string{
+				"secret",
+			},
+		})(func(t *testing.T, pod *core.PodTemplateSpec) {
+			require.Len(t, pod.Spec.ImagePullSecrets, 2)
+			require.Equal(t, "secret", pod.Spec.ImagePullSecrets[0].Name)
+			require.Equal(t, "secret2", pod.Spec.ImagePullSecrets[1].Name)
 		})
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> `Image.With` now merges `imagePullSecrets` instead of replacing; adds merge test and updates changelog.
> 
> - **Scheduler (resources)**:
>   - Change `Image.With` in `pkg/apis/scheduler/v1beta1/pod/resources/image.go` to merge `Image.ImagePullSecrets` (appends and preserves existing) when combining specs; handles nils by copying the non-nil side.
> - **Tests**:
>   - Add "With Merge" case in `pkg/apis/scheduler/v1beta1/pod/resources/image_test.go` to assert merged `ImagePullSecrets` without duplicates.
> - **Changelog**:
>   - Note feature "Fix ImagePullSecrets Merge" under `CHANGELOG.md`.
> - **Meta**:
>   - Update copyright year ranges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b854b43b502fa8f96cff72c2e40ce6b4d53f0da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->