### PR TITLE
[SECURITY] Bump go-jose to 4.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxI
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
Versions lower than 4.1.4 are affected by CVE-2026-34986. Bumping package to the latest version to avoid security issues.

```
usr/bin/arangodb_operator (gobinary)
====================================
Total: 9 (UNKNOWN: 3, LOW: 0, MEDIUM: 3, HIGH: 2, CRITICAL: 1)

┌───────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬─────────────────────────────────────────────────────────────┐
│            Library            │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                            Title                            │
├───────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼─────────────────────────────────────────────────────────────┤
│ github.com/go-jose/go-jose/v4 │ CVE-2026-34986 │ HIGH     │ fixed  │ v4.1.3            │ 4.1.4          │ github.com/go-jose/go-jose/v3:                              │
│                               │                │          │        │                   │                │ github.com/go-jose/go-jose/v4: Go JOSE: Denial of Service   │
│                               │                │          │        │                   │                │ via crafted JSON Web Encryption...                          │
│                               │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-34986                  │
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a JOSE/JWT crypto dependency to address a known CVE; while the change is limited to `go.mod`/`go.sum`, it could subtly affect token/signature handling via transitive usage.
> 
> **Overview**
> Bumps the indirect dependency `github.com/go-jose/go-jose/v4` from `v4.1.3` to `v4.1.4` and updates `go.sum` checksums accordingly, addressing a security vulnerability in versions prior to `4.1.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fdcbf5837c7d63510511f71545f4a53e2c8336b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->