### PR TITLE
OAS-12737: Disable member maintenance via high-priority plan when member is not Ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) Disable member maintenance when a not-Ready DBServer leads failover-capable shards
 - (Bugfix) Do not fail on removed operator flags; deprecate, hide and ignore --operator.deployment-replication, --operator.apps, --operator.ml and --operator.analytics
 - (Feature) (RBAC) Add ArangoPermissionRoleUserBinding handler
 - (Feature) (Gateway) Use HTTP/2 for the default upstream to ArangoDB (hidden feature `gateway-default-http2`, enabled by default)

--- a/pkg/deployment/reconcile/plan_builder_high.go
+++ b/pkg/deployment/reconcile/plan_builder_high.go
@@ -76,9 +76,10 @@ func (r *Reconciler) createHighPlan(ctx context.Context, apiObject k8sutil.APIOb
 		ApplyIfEmpty(r.volumeMemberReplacement).
 		ApplyWithBackOff(BackOffCheck, time.Minute, r.emptyPlanBuilder)).
 		ApplyIfEmptyWithBackOff(TimezoneCheck, time.Minute, r.createTimezoneUpdatePlan).
-		Apply(r.createBackupInProgressConditionPlan). // Discover backups always
-		Apply(r.createMaintenanceConditionPlan).      // Discover maintenance always
-		Apply(r.cleanupConditions)                    // Cleanup Conditions
+		Apply(r.createBackupInProgressConditionPlan).       // Discover backups always
+		Apply(r.createMaintenanceConditionPlan).            // Discover maintenance always
+		Apply(r.cleanupConditions).                         // Cleanup Conditions
+		Apply(r.createHighMemberMaintenanceDisablePlan)     // Disable maintenance for unready members (high priority)
 
 	return q.Plan(), q.BackOff(), true
 }

--- a/pkg/deployment/reconcile/plan_builder_high.go
+++ b/pkg/deployment/reconcile/plan_builder_high.go
@@ -76,10 +76,10 @@ func (r *Reconciler) createHighPlan(ctx context.Context, apiObject k8sutil.APIOb
 		ApplyIfEmpty(r.volumeMemberReplacement).
 		ApplyWithBackOff(BackOffCheck, time.Minute, r.emptyPlanBuilder)).
 		ApplyIfEmptyWithBackOff(TimezoneCheck, time.Minute, r.createTimezoneUpdatePlan).
-		Apply(r.createBackupInProgressConditionPlan).       // Discover backups always
-		Apply(r.createMaintenanceConditionPlan).            // Discover maintenance always
-		Apply(r.cleanupConditions).                         // Cleanup Conditions
-		Apply(r.createHighMemberMaintenanceDisablePlan)     // Disable maintenance for unready members (high priority)
+		Apply(r.createBackupInProgressConditionPlan).
+		Apply(r.createMaintenanceConditionPlan).
+		Apply(r.cleanupConditions).
+		Apply(r.createHighMemberMaintenanceDisablePlan)
 
 	return q.Plan(), q.BackOff(), true
 }

--- a/pkg/deployment/reconcile/plan_builder_maintenance_impl.go
+++ b/pkg/deployment/reconcile/plan_builder_maintenance_impl.go
@@ -27,6 +27,7 @@ import (
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
 	"github.com/arangodb/kube-arangodb/pkg/deployment/actions"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/agency/state"
 	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil"
 )
@@ -48,9 +49,10 @@ func (r *Reconciler) createMemberMaintenanceManagementPlan(ctx context.Context, 
 	return plan
 }
 
-// createHighMemberMaintenanceDisablePlan emits DisableMemberMaintenance for any DBServer that
-// has member maintenance enabled but is no longer Ready. Runs unconditionally (via Apply, not
-// ApplyIfEmpty) so it fires even while the normal plan is busy with recovery/restart actions.
+// createHighMemberMaintenanceDisablePlan emits DisableMemberMaintenance for any DBServer that has
+// member maintenance enabled, is no longer Ready and currently leads shards that can fail over to
+// another replica. Runs unconditionally (via Apply, not ApplyIfEmpty) so it fires even while the
+// normal plan is busy with recovery/restart actions.
 func (r *Reconciler) createHighMemberMaintenanceDisablePlan(ctx context.Context, apiObject k8sutil.APIObject,
 	spec api.DeploymentSpec, status api.DeploymentStatus,
 	planCtx PlanBuilderContext) api.Plan {
@@ -59,16 +61,33 @@ func (r *Reconciler) createHighMemberMaintenanceDisablePlan(ctx context.Context,
 		return nil
 	}
 
+	agencyState, ok := planCtx.GetAgencyCache()
+	if !ok {
+		// Without the agency state we cannot tell whether the member hosts leaders, so do nothing.
+		return nil
+	}
+
+	// Only consider leaders on shards with a follower to fail over to. Single-replica (RF1) shards
+	// have nowhere to fail over, so disabling maintenance for a member that only leads RF1 shards
+	// would not restore availability - leave maintenance enabled in that case.
+	leaders := agencyState.PlanLeaderServersWithFailOver()
+
 	var plan api.Plan
 	for _, member := range status.Members.AsListInGroups(api.ServerGroupDBServers) {
 		readyCond, hasReady := member.Member.Conditions.Get(api.ConditionTypeReady)
-		if member.Member.Conditions.IsTrue(api.ConditionTypeMemberMaintenanceMode) &&
-			hasReady && readyCond.Status == core.ConditionFalse {
-			r.log.
-				Str("member", member.Member.ID).
-				Info("Scheduling DisableMemberMaintenance: member has maintenance enabled but is not Ready")
-			plan = append(plan, actions.NewAction(api.ActionTypeDisableMemberMaintenance, member.Group, member.Member, "Disable maintenance: member not Ready"))
+		if !(member.Member.Conditions.IsTrue(api.ConditionTypeMemberMaintenanceMode) &&
+			hasReady && readyCond.Status == core.ConditionFalse) {
+			continue
 		}
+
+		if !leaders.Contains(state.Server(member.Member.ID)) {
+			continue
+		}
+
+		r.log.
+			Str("member", member.Member.ID).
+			Info("Scheduling DisableMemberMaintenance: member has maintenance enabled, is not Ready and leads failover-capable shards")
+		plan = append(plan, actions.NewAction(api.ActionTypeDisableMemberMaintenance, member.Group, member.Member, "Disable maintenance: member not Ready and leads failover-capable shards"))
 	}
 	return plan
 }

--- a/pkg/deployment/reconcile/plan_builder_maintenance_impl.go
+++ b/pkg/deployment/reconcile/plan_builder_maintenance_impl.go
@@ -23,6 +23,8 @@ package reconcile
 import (
 	"context"
 
+	core "k8s.io/api/core/v1"
+
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
 	"github.com/arangodb/kube-arangodb/pkg/deployment/actions"
 	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
@@ -59,8 +61,9 @@ func (r *Reconciler) createHighMemberMaintenanceDisablePlan(ctx context.Context,
 
 	var plan api.Plan
 	for _, member := range status.Members.AsListInGroups(api.ServerGroupDBServers) {
+		readyCond, hasReady := member.Member.Conditions.Get(api.ConditionTypeReady)
 		if member.Member.Conditions.IsTrue(api.ConditionTypeMemberMaintenanceMode) &&
-			!member.Member.Conditions.IsTrue(api.ConditionTypeReady) {
+			hasReady && readyCond.Status == core.ConditionFalse {
 			r.log.
 				Str("member", member.Member.ID).
 				Info("Scheduling DisableMemberMaintenance: member has maintenance enabled but is not Ready")

--- a/pkg/deployment/reconcile/plan_builder_maintenance_impl.go
+++ b/pkg/deployment/reconcile/plan_builder_maintenance_impl.go
@@ -45,3 +45,27 @@ func (r *Reconciler) createMemberMaintenanceManagementPlan(ctx context.Context, 
 	}
 	return plan
 }
+
+// createHighMemberMaintenanceDisablePlan emits DisableMemberMaintenance for any DBServer that
+// has member maintenance enabled but is no longer Ready. Runs unconditionally (via Apply, not
+// ApplyIfEmpty) so it fires even while the normal plan is busy with recovery/restart actions.
+func (r *Reconciler) createHighMemberMaintenanceDisablePlan(ctx context.Context, apiObject k8sutil.APIObject,
+	spec api.DeploymentSpec, status api.DeploymentStatus,
+	planCtx PlanBuilderContext) api.Plan {
+
+	if !features.Version310().Enabled() {
+		return nil
+	}
+
+	var plan api.Plan
+	for _, member := range status.Members.AsListInGroups(api.ServerGroupDBServers) {
+		if member.Member.Conditions.IsTrue(api.ConditionTypeMemberMaintenanceMode) &&
+			!member.Member.Conditions.IsTrue(api.ConditionTypeReady) {
+			r.log.
+				Str("member", member.Member.ID).
+				Info("Scheduling DisableMemberMaintenance: member has maintenance enabled but is not Ready")
+			plan = append(plan, actions.NewAction(api.ActionTypeDisableMemberMaintenance, member.Group, member.Member, "Disable maintenance: member not Ready"))
+		}
+	}
+	return plan
+}

--- a/pkg/deployment/reconcile/plan_builder_maintenance_impl_test.go
+++ b/pkg/deployment/reconcile/plan_builder_maintenance_impl_test.go
@@ -1,0 +1,141 @@
+//
+// DISCLAIMER
+//
+// Copyright 2016-2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package reconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	core "k8s.io/api/core/v1"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
+)
+
+// newDBServerMember builds a MemberStatus for a DBServer with the requested conditions.
+func newDBServerMember(id string, maintenanceMode, ready bool) api.MemberStatus {
+	m := api.MemberStatus{ID: id}
+	if maintenanceMode {
+		m.Conditions = append(m.Conditions, api.Condition{
+			Type:   api.ConditionTypeMemberMaintenanceMode,
+			Status: core.ConditionTrue,
+		})
+	}
+	if ready {
+		m.Conditions = append(m.Conditions, api.Condition{
+			Type:   api.ConditionTypeReady,
+			Status: core.ConditionTrue,
+		})
+	}
+	return m
+}
+
+func Test_createHighMemberMaintenanceDisablePlan(t *testing.T) {
+	ctx := context.Background()
+	r := newTestReconciler()
+	depl := &api.ArangoDeployment{}
+	spec := api.DeploymentSpec{}
+
+	// Ensure Version310 is enabled for all sub-tests (it is by default; be explicit).
+	*features.Version310().EnabledPointer() = true
+	t.Cleanup(func() { features.Version310().Reset() })
+
+	addDBServer := func(status *api.DeploymentStatus, m api.MemberStatus) {
+		if err := status.Members.Add(m, api.ServerGroupDBServers); err != nil {
+			t.Fatalf("failed to add member: %v", err)
+		}
+	}
+
+	t.Run("maintenance=true ready=false emits DisableMemberMaintenance", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", true, false))
+
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+
+		require.Len(t, plan, 1)
+		require.Equal(t, api.ActionTypeDisableMemberMaintenance, plan[0].Type)
+		require.Equal(t, api.ServerGroupDBServers, plan[0].Group)
+		require.Equal(t, "dbserver1", plan[0].MemberID)
+	})
+
+	t.Run("maintenance=true ready=true does not emit action", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", true, true))
+
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+
+		require.Empty(t, plan)
+	})
+
+	t.Run("maintenance=false ready=false does not emit action", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", false, false))
+
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+
+		require.Empty(t, plan)
+	})
+
+	t.Run("only unready member with maintenance gets action; ready member untouched", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver-down", true, false))
+		addDBServer(&status, newDBServerMember("dbserver-ok", true, true))
+
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+
+		require.Len(t, plan, 1)
+		require.Equal(t, "dbserver-down", plan[0].MemberID)
+	})
+
+	t.Run("multiple unready members each get a disable action", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", true, false))
+		addDBServer(&status, newDBServerMember("dbserver2", true, false))
+
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+
+		require.Len(t, plan, 2)
+		ids := []string{plan[0].MemberID, plan[1].MemberID}
+		require.Contains(t, ids, "dbserver1")
+		require.Contains(t, ids, "dbserver2")
+	})
+
+	t.Run("Version310 disabled returns empty plan", func(t *testing.T) {
+		*features.Version310().EnabledPointer() = false
+		defer func() { *features.Version310().EnabledPointer() = true }()
+
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", true, false))
+
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+
+		require.Empty(t, plan)
+	})
+
+	t.Run("no members produces empty plan", func(t *testing.T) {
+		var status api.DeploymentStatus
+
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+
+		require.Empty(t, plan)
+	})
+}

--- a/pkg/deployment/reconcile/plan_builder_maintenance_impl_test.go
+++ b/pkg/deployment/reconcile/plan_builder_maintenance_impl_test.go
@@ -218,4 +218,14 @@ func Test_createHighMemberMaintenanceDisablePlan(t *testing.T) {
 
 		require.Empty(t, plan)
 	})
+
+	t.Run("agency cache unavailable returns empty plan", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", true, false))
+
+		// Even a not-Ready leader with maintenance must not be touched when the agency cache is unavailable.
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, &testContext{AgencyStateUnavailable: true})
+
+		require.Empty(t, plan)
+	})
 }

--- a/pkg/deployment/reconcile/plan_builder_maintenance_impl_test.go
+++ b/pkg/deployment/reconcile/plan_builder_maintenance_impl_test.go
@@ -40,12 +40,14 @@ func newDBServerMember(id string, maintenanceMode, ready bool) api.MemberStatus 
 			Status: core.ConditionTrue,
 		})
 	}
+	status := core.ConditionFalse
 	if ready {
-		m.Conditions = append(m.Conditions, api.Condition{
-			Type:   api.ConditionTypeReady,
-			Status: core.ConditionTrue,
-		})
+		status = core.ConditionTrue
 	}
+	m.Conditions = append(m.Conditions, api.Condition{
+		Type:   api.ConditionTypeReady,
+		Status: status,
+	})
 	return m
 }
 

--- a/pkg/deployment/reconcile/plan_builder_maintenance_impl_test.go
+++ b/pkg/deployment/reconcile/plan_builder_maintenance_impl_test.go
@@ -22,14 +22,57 @@ package reconcile
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/agency/state"
 	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
 )
+
+// agencyContext builds a PlanBuilderContext whose agency Plan contains one shard per provided server
+// list (shards[0] is the leader). Callers control the replica count per shard to model RF1 vs RF>1.
+func agencyContext(shards ...state.Servers) *testContext {
+	s := state.Shards{}
+	for i, servers := range shards {
+		s[fmt.Sprintf("s%d", i)] = servers
+	}
+
+	return &testContext{
+		AgencyState: state.State{
+			Plan: state.Plan{
+				Collections: state.PlanCollections{
+					"db": state.PlanDBCollections{
+						"col": state.PlanCollection{
+							Shards: s,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// leaderContext makes each given server the leader of its own failover-capable (RF2) shard.
+func leaderContext(leaders ...string) *testContext {
+	shards := make([]state.Servers, 0, len(leaders))
+	for _, id := range leaders {
+		shards = append(shards, state.Servers{state.Server(id), "follower"})
+	}
+	return agencyContext(shards...)
+}
+
+// rf1Context makes each given server the leader of its own single-replica (RF1) shard.
+func rf1Context(leaders ...string) *testContext {
+	shards := make([]state.Servers, 0, len(leaders))
+	for _, id := range leaders {
+		shards = append(shards, state.Servers{state.Server(id)})
+	}
+	return agencyContext(shards...)
+}
 
 // newDBServerMember builds a MemberStatus for a DBServer with the requested conditions.
 func newDBServerMember(id string, maintenanceMode, ready bool) api.MemberStatus {
@@ -67,11 +110,11 @@ func Test_createHighMemberMaintenanceDisablePlan(t *testing.T) {
 		}
 	}
 
-	t.Run("maintenance=true ready=false emits DisableMemberMaintenance", func(t *testing.T) {
+	t.Run("maintenance=true ready=false with active leaders emits DisableMemberMaintenance", func(t *testing.T) {
 		var status api.DeploymentStatus
 		addDBServer(&status, newDBServerMember("dbserver1", true, false))
 
-		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, leaderContext("dbserver1"))
 
 		require.Len(t, plan, 1)
 		require.Equal(t, api.ActionTypeDisableMemberMaintenance, plan[0].Type)
@@ -79,11 +122,46 @@ func Test_createHighMemberMaintenanceDisablePlan(t *testing.T) {
 		require.Equal(t, "dbserver1", plan[0].MemberID)
 	})
 
+	t.Run("maintenance=true ready=false without active leaders does not emit action", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", true, false))
+
+		// dbserver1 is not Ready but hosts no leaders, so there is nothing to fail over.
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, leaderContext("dbserver-other"))
+
+		require.Empty(t, plan)
+	})
+
+	t.Run("maintenance=true ready=false leading only RF1 shard does not emit action", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", true, false))
+
+		// dbserver1 leads a single-replica shard - there is nowhere to fail over.
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, rf1Context("dbserver1"))
+
+		require.Empty(t, plan)
+	})
+
+	t.Run("maintenance=true ready=false leading both RF1 and failover-capable shards emits action", func(t *testing.T) {
+		var status api.DeploymentStatus
+		addDBServer(&status, newDBServerMember("dbserver1", true, false))
+
+		// dbserver1 leads an RF1 shard AND a failover-capable one - the latter is enough to disable.
+		agency := agencyContext(
+			state.Servers{"dbserver1"},             // RF1
+			state.Servers{"dbserver1", "follower"}, // RF2, can fail over
+		)
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, agency)
+
+		require.Len(t, plan, 1)
+		require.Equal(t, "dbserver1", plan[0].MemberID)
+	})
+
 	t.Run("maintenance=true ready=true does not emit action", func(t *testing.T) {
 		var status api.DeploymentStatus
 		addDBServer(&status, newDBServerMember("dbserver1", true, true))
 
-		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, leaderContext("dbserver1"))
 
 		require.Empty(t, plan)
 	})
@@ -92,28 +170,28 @@ func Test_createHighMemberMaintenanceDisablePlan(t *testing.T) {
 		var status api.DeploymentStatus
 		addDBServer(&status, newDBServerMember("dbserver1", false, false))
 
-		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, leaderContext("dbserver1"))
 
 		require.Empty(t, plan)
 	})
 
-	t.Run("only unready member with maintenance gets action; ready member untouched", func(t *testing.T) {
+	t.Run("only unready leader member with maintenance gets action; ready member untouched", func(t *testing.T) {
 		var status api.DeploymentStatus
 		addDBServer(&status, newDBServerMember("dbserver-down", true, false))
 		addDBServer(&status, newDBServerMember("dbserver-ok", true, true))
 
-		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, leaderContext("dbserver-down", "dbserver-ok"))
 
 		require.Len(t, plan, 1)
 		require.Equal(t, "dbserver-down", plan[0].MemberID)
 	})
 
-	t.Run("multiple unready members each get a disable action", func(t *testing.T) {
+	t.Run("multiple unready leader members each get a disable action", func(t *testing.T) {
 		var status api.DeploymentStatus
 		addDBServer(&status, newDBServerMember("dbserver1", true, false))
 		addDBServer(&status, newDBServerMember("dbserver2", true, false))
 
-		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, leaderContext("dbserver1", "dbserver2"))
 
 		require.Len(t, plan, 2)
 		ids := []string{plan[0].MemberID, plan[1].MemberID}
@@ -128,7 +206,7 @@ func Test_createHighMemberMaintenanceDisablePlan(t *testing.T) {
 		var status api.DeploymentStatus
 		addDBServer(&status, newDBServerMember("dbserver1", true, false))
 
-		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, leaderContext("dbserver1"))
 
 		require.Empty(t, plan)
 	})
@@ -136,7 +214,7 @@ func Test_createHighMemberMaintenanceDisablePlan(t *testing.T) {
 	t.Run("no members produces empty plan", func(t *testing.T) {
 		var status api.DeploymentStatus
 
-		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, nil)
+		plan := r.createHighMemberMaintenanceDisablePlan(ctx, depl, spec, status, leaderContext())
 
 		require.Empty(t, plan)
 	})

--- a/pkg/deployment/reconcile/plan_builder_test.go
+++ b/pkg/deployment/reconcile/plan_builder_test.go
@@ -80,7 +80,8 @@ type testContext struct {
 	Inspector inspectorInterface.Inspector
 	state     member.StateInspector
 
-	AgencyState state.State
+	AgencyState            state.State
+	AgencyStateUnavailable bool
 }
 
 func (c *testContext) IsFeatureImageSupported(feature features.Feature) bool {
@@ -185,7 +186,7 @@ func (c *testContext) WithAgencyCache(action func(state.State)) bool {
 }
 
 func (c *testContext) GetAgencyCache() (state.State, bool) {
-	return c.AgencyState, true
+	return c.AgencyState, !c.AgencyStateUnavailable
 }
 
 func (c *testContext) SecretsModInterface() generic.ModClient[*core.Secret] {

--- a/pkg/deployment/reconcile/plan_builder_test.go
+++ b/pkg/deployment/reconcile/plan_builder_test.go
@@ -79,6 +79,8 @@ type testContext struct {
 
 	Inspector inspectorInterface.Inspector
 	state     member.StateInspector
+
+	AgencyState state.State
 }
 
 func (c *testContext) IsFeatureImageSupported(feature features.Feature) bool {
@@ -183,7 +185,7 @@ func (c *testContext) WithAgencyCache(action func(state.State)) bool {
 }
 
 func (c *testContext) GetAgencyCache() (state.State, bool) {
-	return state.State{}, true
+	return c.AgencyState, true
 }
 
 func (c *testContext) SecretsModInterface() generic.ModClient[*core.Secret] {


### PR DESCRIPTION
### Summary

- Adds a high-priority plan builder that emits `ActionTypeDisableMemberMaintenance` for a DBServer where `MemberMaintenanceMode=true` AND `Ready=false` (an explicitly-present `False` condition, not missing/Unknown) AND the member currently leads **failover-capable** shards (RF>1)
- Fixes a gap where maintenance was never cleared when a member went down mid-recovery — the existing normal-plan builder is `ApplyIfEmpty`-gated and never fires while recovery/restart actions are queued
- Builder is wired via `Apply` (not `ApplyIfEmpty`) in `createHighPlan` so it runs regardless of normal plan state
- Gated behind the `Version310` feature flag; idempotent by the existing high-plan empty check

### Scope / conditions

Maintenance is only disabled when doing so can actually help recovery — i.e. when the member leads shards that have somewhere to fail over to:

- **Leader on a failover-capable shard** (≥2 replicas) → disable maintenance so the shard can fail over
- **Leader of only single-replica (RF1) shards** → skipped: there is nowhere to fail over, so disabling maintenance would not restore availability and it stays enabled
- **Non-leader members** → skipped
- **Agency cache unavailable** (`GetAgencyCache` returns `ok=false`) → no-op (leadership cannot be determined)

Leadership is resolved via the agency `Plan` using `PlanLeaderServersWithFailOver()`.

### Changes

- `plan_builder_maintenance_impl.go` — new `createHighMemberMaintenanceDisablePlan` builder (gated on failover-capable leadership)
- `plan_builder_high.go` — wire the new builder into the high plan chain
- `plan_builder_maintenance_impl_test.go` — unit tests covering all condition combinations + feature-flag toggle
- `plan_builder_test.go` — make the agency cache configurable in `testContext` (including an "unavailable" mode)

### Test plan

- [x] `maintenance=true, ready=false`, failover-capable leader → emits `DisableMemberMaintenance`
- [x] `maintenance=true, ready=false`, no leaders → no action
- [x] `maintenance=true, ready=false`, only RF1 leader → no action
- [x] `maintenance=true, ready=false`, RF1 + failover-capable leader → emits action
- [x] `maintenance=true, ready=true` → no action
- [x] `maintenance=false, ready=false` → no action
- [x] mixed members → only the unready leader gets the action
- [x] multiple unready leaders → each gets an action
- [x] `Version310` disabled → empty plan
- [x] no members → empty plan
- [x] agency cache unavailable → empty plan
