### PR TITLE
ci(security): add warn-only Trivy dependency CVE scan

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@4.1
-  trivy-scan: arangodb/trivy-scan@0.1.0
+  trivy-scan: arangodb/trivy-scan@0.1.1
 
 parameters:
   manifests-verify:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@4.1
+  trivy-scan: arangodb/trivy-scan@0.1.0
 
 parameters:
   manifests-verify:
@@ -78,9 +79,21 @@ jobs:
             fi
             make ci-check
 
+  dependency-cve-scan:
+    executor: golang-executor
+    steps:
+      - checkout
+      - trivy-scan/scan:
+          scan-type: fs
+          scan-path: "."
+          severity: "CRITICAL,HIGH"
+          fail-on-findings: false
+          store-junit-results: true
+
 workflows:
   version: 2
 
   run_tests:
     jobs:
       - check-code
+      - dependency-cve-scan


### PR DESCRIPTION
## What this PR does
- Adds one non-blocking CircleCI job, `dependency-cve-scan`, which runs a Trivy filesystem scan over the repo's dependency manifests (go.mod/go.sum and any lockfiles) for fixable CRITICAL/HIGH CVEs.
- Findings show up in the job log and in the CircleCI Tests tab (JUnit results via `store-junit-results: true`).
- The job is warn-only and cannot fail your build: it sets `fail-on-findings: false`. Flip that parameter to `true` to turn it into an enforcing gate whenever the team wants one.
- Uses the shared orb `arangodb/trivy-scan@0.1.1`, which adds a daily-rotating vulnerability DB cache (a static cache key froze the DB — CircleCI caches are immutable), a mirror.gcr.io → ECR → ghcr DB registry fallback chain, and a tag-pinned installer fallback. Orb source lives in arangoml/ai-infrastructure under `circleci_orbs/trivy-scan` (questions: mark.read).

The diff only touches `.circleci/continue_config.yml`; no application code or dependencies change.

## Status (2026-07-06)
All checks green. Ready for review.

Happy to adjust or remove this if the team prefers a different approach.

