### PR TITLE
Add `runAsGroup` security context to Operator deployments

### DIFF
--- a/chart/kube-arangodb-arm64/templates/deployment.yaml
+++ b/chart/kube-arangodb-arm64/templates/deployment.yaml
@@ -90,6 +90,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.operator.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.operator.securityContext.runAsGroup }}
       containers:
         - name: operator
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}

--- a/chart/kube-arangodb-enterprise-arm64/templates/deployment.yaml
+++ b/chart/kube-arangodb-enterprise-arm64/templates/deployment.yaml
@@ -90,6 +90,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.operator.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.operator.securityContext.runAsGroup }}
       containers:
         - name: operator
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}

--- a/chart/kube-arangodb-enterprise-arm64/values.yaml
+++ b/chart/kube-arangodb-enterprise-arm64/values.yaml
@@ -19,6 +19,7 @@ operator:
       memory: 256Mi
   securityContext:
     runAsUser: 1000
+    runAsGroup: 2000
   replicaCount: 1
   updateStrategy:
     type: Recreate

--- a/chart/kube-arangodb-enterprise/templates/deployment.yaml
+++ b/chart/kube-arangodb-enterprise/templates/deployment.yaml
@@ -90,6 +90,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.operator.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.operator.securityContext.runAsGroup }}
       containers:
         - name: operator
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}

--- a/chart/kube-arangodb/templates/deployment.yaml
+++ b/chart/kube-arangodb/templates/deployment.yaml
@@ -90,6 +90,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.operator.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.operator.securityContext.runAsGroup }}
       containers:
         - name: operator
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}


### PR DESCRIPTION
The operator currently allows configuration of the `runAsUser` property in the security context of a pod.
But `runAsGroup` is by default unset, which by kubernetes documentation https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ will result in primary group id being root

> If this field is omitted, the primary group ID of the containers will be root(0)

This adds the runAsGroup, with a default of 2000, to all respective operator deployments