### PR TITLE
Detect context deadline/cancellation through standard Unwrap() error chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) Detect context deadline/cancellation through standard Unwrap() error chains (e.g. net/http *url.Error, go-driver v1)
 - (Bugfix) Disable member maintenance when a not-Ready DBServer leads failover-capable shards
 - (Bugfix) Do not fail on removed operator flags; deprecate, hide and ignore --operator.deployment-replication, --operator.apps, --operator.ml and --operator.analytics
 - (Feature) (RBAC) Add ArangoPermissionRoleUserBinding handler

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -201,6 +201,11 @@ func IsConnectionReset(err error) bool {
 
 // IsContextCanceled returns true if the given error is caused by a context cancelation.
 func IsContextCanceled(err error) bool {
+	// Also follow the standard Unwrap() chain (e.g. *url.Error from net/http, go-driver v1 wrappers)
+	// which is not covered by the Cause()/libCause chains below.
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
 	err = errors.Cause(err)
 	if err == context.Canceled {
 		return true
@@ -213,6 +218,11 @@ func IsContextCanceled(err error) bool {
 
 // IsContextDeadlineExpired returns true if the given error is caused by a context deadline expiration.
 func IsContextDeadlineExpired(err error) bool {
+	// Also follow the standard Unwrap() chain (e.g. *url.Error from net/http, go-driver v1 wrappers)
+	// which is not covered by the Cause()/libCause chains below.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
 	err = errors.Cause(err)
 	if err == context.DeadlineExceeded {
 		return true
@@ -226,6 +236,9 @@ func IsContextDeadlineExpired(err error) bool {
 // IsContextCanceledOrExpired returns true if the given error is caused by a context cancelation
 // or deadline expiration.
 func IsContextCanceledOrExpired(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
 	err = errors.Cause(err)
 	if err == context.Canceled || err == context.DeadlineExceeded {
 		return true


### PR DESCRIPTION
IsContextDeadlineExpired/IsContextCanceled/IsContextCanceledOrExpired only followed the pkg/errors Cause() chain and libCause's known types (go-driver v2 ResponseError), missing deadlines wrapped via the standard Unwrap() chain such as net/http *url.Error and go-driver v1 wrappers. Add an errors.Is() check so those are detected as retriable instead of fatal.