### PR TITLE
Add README.md and subchart values.schema.json validation to the platform release chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) (Platform) Generate README.md in the platform release chart and validate chart overrides against each subchart values.schema.json
 
 ## [1.4.4](https://github.com/arangodb/kube-arangodb/tree/1.4.4) (2026-07-20)
 - (Bugfix) (Platform) Recover Helm releases stuck in a pending state (roll back pending upgrades/rollbacks, uninstall pending installs) instead of retrying the upgrade forever

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -384,22 +384,77 @@ func serviceValues(chart packageChartRenderInputChart, overrides helm.Values) []
 		return nil
 	}
 
-	keys := make([]string, 0, len(effective))
-	for k := range effective {
+	var out []packageChartRenderInputValue
+
+	flattenValues("", effective, chart.Schema, &out, 0)
+
+	return out
+}
+
+// serviceValuesMaxDepth bounds how deep nested values are expanded, so a pathological
+// chart cannot produce an unreadable table.
+const serviceValuesMaxDepth = 6
+
+// flattenValues expands nested values into dotted key paths so every leaf is documented
+// with its own default, rather than collapsing a subtree into an opaque JSON blob. An
+// intermediate object is listed only when the schema documents it, so its description is
+// not lost; its leaves follow underneath.
+func flattenValues(prefix string, values map[string]interface{}, schema map[string]interface{}, out *[]packageChartRenderInputValue, depth int) {
+	keys := make([]string, 0, len(values))
+	for k := range values {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	out := make([]packageChartRenderInputValue, 0, len(keys))
 	for _, k := range keys {
-		out = append(out, packageChartRenderInputValue{
-			Key:         k,
-			Default:     formatValueDefault(effective[k]),
-			Description: schemaPropertyDescription(chart.Schema, k),
+		path := k
+		if prefix != "" {
+			path = prefix + "." + k
+		}
+
+		child := schemaProperty(schema, k)
+		description := schemaDescription(child)
+
+		// Only descend into non-empty objects; everything else (scalar, list, empty
+		// object) is a leaf and gets its own row.
+		if nested, ok := values[k].(map[string]interface{}); ok && len(nested) > 0 && depth < serviceValuesMaxDepth {
+			if description != "" {
+				*out = append(*out, packageChartRenderInputValue{
+					Key:         path,
+					Description: description,
+				})
+			}
+
+			flattenValues(path, nested, child, out, depth+1)
+
+			continue
+		}
+
+		*out = append(*out, packageChartRenderInputValue{
+			Key:         path,
+			Default:     formatValueDefault(values[k]),
+			Description: description,
 		})
 	}
+}
 
-	return out
+// schemaProperty returns the subschema documenting a property of the given schema node.
+func schemaProperty(schema map[string]interface{}, key string) map[string]interface{} {
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	prop, _ := props[key].(map[string]interface{})
+
+	return prop
+}
+
+// schemaDescription returns the description a schema node documents, if any.
+func schemaDescription(schema map[string]interface{}) string {
+	description, _ := schema["description"].(string)
+
+	return escapeTableCell(description)
 }
 
 // formatValueDefault renders a value compactly for a Markdown table cell. Nested objects
@@ -430,24 +485,6 @@ func formatValueDefault(v interface{}) string {
 func escapeTableCell(s string) string {
 	s = goStrings.ReplaceAll(s, "|", "\\|")
 	return goStrings.ReplaceAll(s, "\n", " ")
-}
-
-// schemaPropertyDescription returns the description a chart's values.schema.json documents
-// for a top-level property, or "" when the chart ships no schema or no description.
-func schemaPropertyDescription(schema map[string]interface{}, key string) string {
-	props, ok := schema["properties"].(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	prop, ok := props[key].(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	description, _ := prop["description"].(string)
-
-	return escapeTableCell(description)
 }
 
 // sanitizeOverrideSchema adapts a chart's own values.schema.json so it can be inlined as

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -29,7 +29,8 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
+	"strings"
 
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
@@ -57,6 +58,9 @@ var (
 	//go:embed templates/notes.txt
 	packageChartTemplateNotes util.Template[packageChartRenderInput]
 
+	//go:embed templates/readme.md
+	packageChartTemplateReadme util.Template[packageChartRenderInput]
+
 	//go:embed templates/resource.chart.yaml
 	packageChartTemplateResourceChart util.Template[packageChartRenderInputChart]
 
@@ -76,6 +80,7 @@ type packageChartRenderInputChart struct {
 	Version   string
 	ChartData []byte
 	Values    map[string]interface{}
+	Schema    map[string]interface{}
 }
 
 type packageChartRenderInputService struct {
@@ -178,6 +183,8 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 
 	builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateValues, input), "%s/values.yaml", input.Name)
 
+	builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateReadme, input), "%s/README.md", input.Name)
+
 	builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateCheck, input), "%s/templates/check.yaml", input.Name)
 
 	builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateNotes, input), "%s/templates/NOTES.txt", input.Name)
@@ -237,16 +244,24 @@ func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint s
 		}
 	}
 
+	schema, err := extractChartSchema(chart)
+	if err != nil {
+		logger.Err(err).Str("chart", name).Warn("Unable to extract chart values schema")
+	}
+
 	return &packageChartRenderInputChart{
 		Name:      name,
 		Version:   packageSpec.Version,
 		ChartData: chart,
 		Values:    defaults,
+		Schema:    schema,
 	}, nil
 }
 
-// extractChartValues reads values.yaml from a gzipped tar chart archive.
-func extractChartValues(chartData []byte) (map[string]interface{}, error) {
+// extractChartFile reads a chart's own top-level file (`<chart>/<name>`) from a gzipped
+// tar chart archive. Files belonging to bundled subcharts (`<chart>/charts/<sub>/<name>`)
+// are ignored. Returns nil data when the file is not present.
+func extractChartFile(chartData []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewReader(chartData))
 	if err != nil {
 		return nil, err
@@ -263,35 +278,148 @@ func extractChartValues(chartData []byte) (map[string]interface{}, error) {
 			return nil, err
 		}
 
-		if filepath.Base(hdr.Name) == "values.yaml" {
-			// Only match top-level values.yaml (e.g. chartname/values.yaml)
-			parts := filepath.SplitList(hdr.Name)
-			if len(parts) <= 2 || filepath.Dir(hdr.Name) == filepath.Dir(filepath.Dir(hdr.Name)) {
-				data, err := io.ReadAll(tr)
-				if err != nil {
-					return nil, err
-				}
-				var values map[string]interface{}
-				if err := yaml.Unmarshal(data, &values); err != nil {
-					return nil, err
-				}
-				return values, nil
+		// Tar entries always use forward slashes, so split on "/" explicitly. Note that
+		// filepath.SplitList must not be used here: it splits on the OS path-list
+		// separator (":" on Linux), so it never matches and would let nested subchart
+		// files through.
+		parts := strings.Split(path.Clean(hdr.Name), "/")
+		if len(parts) == 2 && parts[1] == name {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, err
 			}
+			return data, nil
 		}
 	}
 
-	return map[string]interface{}{}, nil
+	return nil, nil
+}
+
+// extractChartValues reads values.yaml from a gzipped tar chart archive.
+func extractChartValues(chartData []byte) (map[string]interface{}, error) {
+	data, err := extractChartFile(chartData, "values.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	if data == nil {
+		return map[string]interface{}{}, nil
+	}
+
+	var values map[string]interface{}
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		return nil, err
+	}
+
+	if values == nil {
+		return map[string]interface{}{}, nil
+	}
+
+	return values, nil
+}
+
+// extractChartSchema reads values.schema.json from a gzipped tar chart archive.
+// Returns nil when the chart does not ship a schema.
+func extractChartSchema(chartData []byte) (map[string]interface{}, error) {
+	data, err := extractChartFile(chartData, "values.schema.json")
+	if err != nil {
+		return nil, err
+	}
+
+	if data == nil {
+		return nil, nil
+	}
+
+	var schema map[string]interface{}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}
+
+// sanitizeOverrideSchema adapts a chart's own values.schema.json so it can be inlined as
+// the schema of an override block. Two adjustments are needed:
+//   - `required` is dropped: an override block is a partial document merged on top of the
+//     chart defaults, so a value being mandatory for the chart does not mean the user must
+//     restate it here.
+//   - `$schema`/`$id` are dropped: the schema becomes a subschema rather than a document
+//     root, and keeping them would re-declare the dialect / shift the base URI.
+//
+// Recursion only descends into positions that actually hold schemas, so a chart value
+// legitimately named "required" (a key under `properties`) is preserved.
+func sanitizeOverrideSchema(in map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+
+	for k, v := range in {
+		switch k {
+		case "required", "$schema", "$id":
+			continue
+		case "properties", "patternProperties", "$defs", "definitions":
+			// Maps keyed by property name - keys are data, values are schemas.
+			if m, ok := v.(map[string]interface{}); ok {
+				sub := make(map[string]interface{}, len(m))
+				for name, s := range m {
+					if sm, ok := s.(map[string]interface{}); ok {
+						sub[name] = sanitizeOverrideSchema(sm)
+					} else {
+						sub[name] = s
+					}
+				}
+				out[k] = sub
+				continue
+			}
+			out[k] = v
+		case "allOf", "anyOf", "oneOf", "prefixItems":
+			// Lists of schemas.
+			if l, ok := v.([]interface{}); ok {
+				sub := make([]interface{}, len(l))
+				for i, s := range l {
+					if sm, ok := s.(map[string]interface{}); ok {
+						sub[i] = sanitizeOverrideSchema(sm)
+					} else {
+						sub[i] = s
+					}
+				}
+				out[k] = sub
+				continue
+			}
+			out[k] = v
+		case "additionalProperties", "items", "not", "if", "then", "else", "contains", "propertyNames":
+			// Single nested schema.
+			if sm, ok := v.(map[string]interface{}); ok {
+				out[k] = sanitizeOverrideSchema(sm)
+				continue
+			}
+			out[k] = v
+		default:
+			out[k] = v
+		}
+	}
+
+	return out
 }
 
 // generateValuesSchema builds a JSON Schema for values.yaml.
-// Charts and services entries use permissive schemas (additionalProperties: true)
-// so users can override any value. The deployment field is required.
+// A chart entry is validated against the chart's own values.schema.json when it ships one
+// (relaxed for partial overrides, see sanitizeOverrideSchema); charts without a schema fall
+// back to a permissive entry (additionalProperties: true). Service entries stay permissive.
+// The deployment field is required.
 func generateValuesSchema(input packageChartRenderInput) []byte {
 	chartProps := map[string]interface{}{}
 	for _, c := range input.Charts {
+		description := "Overrides for chart " + c.Name + " (version " + c.Version + ")"
+
+		if len(c.Schema) > 0 {
+			s := sanitizeOverrideSchema(c.Schema)
+			s["description"] = description
+			chartProps[c.Name] = s
+			continue
+		}
+
 		chartProps[c.Name] = map[string]interface{}{
 			"type":                 "object",
-			"description":          "Overrides for chart " + c.Name + " (version " + c.Version + ")",
+			"description":          description,
 			"additionalProperties": true,
 		}
 	}

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -244,9 +244,12 @@ func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint s
 		}
 	}
 
+	// A chart that ships a values.schema.json we cannot parse is a chart bug: silently
+	// degrading would drop override validation without any signal, so fail the packaging.
+	// A chart shipping no schema at all is fine and stays permissive.
 	schema, err := extractChartSchema(chart)
 	if err != nil {
-		logger.Err(err).Str("chart", name).Warn("Unable to extract chart values schema")
+		return nil, errors.Wrapf(err, "invalid values.schema.json in chart %s", name)
 	}
 
 	return &packageChartRenderInputChart{

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -82,15 +82,15 @@ type packageChartRenderInputChart struct {
 	ChartData []byte
 	Values    map[string]interface{}
 	Schema    map[string]interface{}
+
+	// DocumentedValues flattens Values into individual override paths, described using
+	// Schema where it provides descriptions.
+	DocumentedValues []packageChartRenderInputValue
 }
 
 type packageChartRenderInputService struct {
 	Name     string
 	ChartRef string
-
-	// Values documents the top-level values of the referenced chart, as effective for
-	// this service (chart defaults with the release overrides applied).
-	Values []packageChartRenderInputValue
 }
 
 // packageChartRenderInputValue is a single documented top-level value of a service.
@@ -181,10 +181,6 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 		o := packageChartRelease(k, v)
 
 		if o != nil {
-			// Charts are resolved above, so the referenced chart's defaults and schema are
-			// available to document what this service exposes.
-			o.Values = serviceValues(input.Charts[o.ChartRef], v.Overrides)
-
 			input.Services[k] = *o
 		}
 	}
@@ -213,10 +209,7 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 
 	// Generate per-service templates
 	for _, s := range input.Services {
-		builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateResourceService, packageChartRenderInputServiceTemplate{
-			Name:     s.Name,
-			ChartRef: s.ChartRef,
-		}), "%s/templates/services/%s.yaml", input.Name, s.Name)
+		builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateResourceService, packageChartRenderInputServiceTemplate(s)), "%s/templates/services/%s.yaml", input.Name, s.Name)
 	}
 
 	builder = builder.File(util.GZipBuilderProcessBytes(licenseData.Full()), "%s/LICENSE", input.Name)
@@ -272,11 +265,12 @@ func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint s
 	}
 
 	return &packageChartRenderInputChart{
-		Name:      name,
-		Version:   packageSpec.Version,
-		ChartData: chart,
-		Values:    defaults,
-		Schema:    schema,
+		Name:             name,
+		Version:          packageSpec.Version,
+		ChartData:        chart,
+		Values:           defaults,
+		Schema:           schema,
+		DocumentedValues: documentedValues(defaults, schema),
 	}, nil
 }
 
@@ -360,40 +354,25 @@ func extractChartSchema(chartData []byte) (map[string]interface{}, error) {
 	return schema, nil
 }
 
-// serviceValues documents the top-level values a service exposes: the referenced chart's
-// defaults with the release overrides applied, described using the chart's own
-// values.schema.json when it provides descriptions. Returns nil when the referenced chart
-// could not be resolved or exposes no values.
-func serviceValues(chart packageChartRenderInputChart, overrides helm.Values) []packageChartRenderInputValue {
-	effective := make(map[string]interface{}, len(chart.Values))
-	for k, v := range chart.Values {
-		effective[k] = v
-	}
-
-	// Release overrides win over the chart defaults for this service.
-	if len(overrides) > 0 {
-		var o map[string]interface{}
-		if err := json.Unmarshal(overrides, &o); err == nil {
-			for k, v := range o {
-				effective[k] = v
-			}
-		}
-	}
-
-	if len(effective) == 0 {
+// documentedValues flattens a chart's effective values (its packaged defaults with the
+// platform.yaml overrides already applied) into individual override paths, described using
+// the chart's own values.schema.json where it provides descriptions. Values belong to the
+// chart rather than to a service, since a chart may back several services - or none.
+func documentedValues(values, schema map[string]interface{}) []packageChartRenderInputValue {
+	if len(values) == 0 {
 		return nil
 	}
 
 	var out []packageChartRenderInputValue
 
-	flattenValues("", effective, chart.Schema, &out, 0)
+	flattenValues("", values, schema, &out, 0)
 
 	return out
 }
 
-// serviceValuesMaxDepth bounds how deep nested values are expanded, so a pathological
+// documentedValuesMaxDepth bounds how deep nested values are expanded, so a pathological
 // chart cannot produce an unreadable table.
-const serviceValuesMaxDepth = 6
+const documentedValuesMaxDepth = 6
 
 // flattenValues expands nested values into dotted key paths so every leaf is documented
 // with its own default, rather than collapsing a subtree into an opaque JSON blob. An
@@ -417,7 +396,7 @@ func flattenValues(prefix string, values map[string]interface{}, schema map[stri
 
 		// Only descend into non-empty objects; everything else (scalar, list, empty
 		// object) is a leaf and gets its own row.
-		if nested, ok := values[k].(map[string]interface{}); ok && len(nested) > 0 && depth < serviceValuesMaxDepth {
+		if nested, ok := values[k].(map[string]interface{}); ok && len(nested) > 0 && depth < documentedValuesMaxDepth {
 			if description != "" {
 				*out = append(*out, packageChartRenderInputValue{
 					Key:         path,

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -460,6 +460,13 @@ func formatValueDefault(v interface{}) string {
 	return escapeTableCell(s)
 }
 
+// escapeJSONPointer escapes a single JSON Pointer reference token (RFC 6901).
+func escapeJSONPointer(in string) string {
+	in = goStrings.ReplaceAll(in, "~", "~0")
+
+	return goStrings.ReplaceAll(in, "/", "~1")
+}
+
 // escapeTableCell keeps a value from breaking out of a Markdown table row.
 func escapeTableCell(s string) string {
 	s = goStrings.ReplaceAll(s, "|", "\\|")
@@ -476,20 +483,31 @@ func escapeTableCell(s string) string {
 //
 // Recursion only descends into positions that actually hold schemas, so a chart value
 // legitimately named "required" (a key under `properties`) is preserved.
-func sanitizeOverrideSchema(in map[string]interface{}) map[string]interface{} {
+//
+// refBase is the JSON Pointer at which the schema is being inlined. Local `$ref`s are
+// rewritten onto it, because once inlined `#/` no longer means the chart's own schema but
+// the generated release schema - a chart referencing `#/definitions/image` would otherwise
+// produce a release chart that fails validation against its own defaults.
+func sanitizeOverrideSchema(in map[string]interface{}, refBase string) map[string]interface{} {
 	out := make(map[string]interface{}, len(in))
 
 	for k, v := range in {
 		switch k {
 		case "required", "$schema", "$id":
 			continue
+		case "$ref":
+			if ref, ok := v.(string); ok && goStrings.HasPrefix(ref, "#") {
+				out[k] = refBase + goStrings.TrimPrefix(ref, "#")
+				continue
+			}
+			out[k] = v
 		case "properties", "patternProperties", "$defs", "definitions":
 			// Maps keyed by property name - keys are data, values are schemas.
 			if m, ok := v.(map[string]interface{}); ok {
 				sub := make(map[string]interface{}, len(m))
 				for name, s := range m {
 					if sm, ok := s.(map[string]interface{}); ok {
-						sub[name] = sanitizeOverrideSchema(sm)
+						sub[name] = sanitizeOverrideSchema(sm, refBase)
 					} else {
 						sub[name] = s
 					}
@@ -504,7 +522,7 @@ func sanitizeOverrideSchema(in map[string]interface{}) map[string]interface{} {
 				sub := make([]interface{}, len(l))
 				for i, s := range l {
 					if sm, ok := s.(map[string]interface{}); ok {
-						sub[i] = sanitizeOverrideSchema(sm)
+						sub[i] = sanitizeOverrideSchema(sm, refBase)
 					} else {
 						sub[i] = s
 					}
@@ -516,7 +534,7 @@ func sanitizeOverrideSchema(in map[string]interface{}) map[string]interface{} {
 		case "additionalProperties", "items", "not", "if", "then", "else", "contains", "propertyNames":
 			// Single nested schema.
 			if sm, ok := v.(map[string]interface{}); ok {
-				out[k] = sanitizeOverrideSchema(sm)
+				out[k] = sanitizeOverrideSchema(sm, refBase)
 				continue
 			}
 			out[k] = v
@@ -539,7 +557,7 @@ func generateValuesSchema(input packageChartRenderInput) []byte {
 		description := "Overrides for chart " + c.Name + " (version " + c.Version + ")"
 
 		if len(c.Schema) > 0 {
-			s := sanitizeOverrideSchema(c.Schema)
+			s := sanitizeOverrideSchema(c.Schema, "#/properties/charts/properties/"+escapeJSONPointer(c.Name))
 			s["description"] = description
 			chartProps[c.Name] = s
 			continue

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"sort"
 	goStrings "strings"
 
 	"github.com/regclient/regclient"
@@ -86,6 +87,17 @@ type packageChartRenderInputChart struct {
 type packageChartRenderInputService struct {
 	Name     string
 	ChartRef string
+
+	// Values documents the top-level values of the referenced chart, as effective for
+	// this service (chart defaults with the release overrides applied).
+	Values []packageChartRenderInputValue
+}
+
+// packageChartRenderInputValue is a single documented top-level value of a service.
+type packageChartRenderInputValue struct {
+	Key         string
+	Default     string
+	Description string
 }
 
 type packageChartRenderInputServiceTemplate struct {
@@ -169,6 +181,10 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 		o := packageChartRelease(k, v)
 
 		if o != nil {
+			// Charts are resolved above, so the referenced chart's defaults and schema are
+			// available to document what this service exposes.
+			o.Values = serviceValues(input.Charts[o.ChartRef], v.Overrides)
+
 			input.Services[k] = *o
 		}
 	}
@@ -197,7 +213,10 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 
 	// Generate per-service templates
 	for _, s := range input.Services {
-		builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateResourceService, packageChartRenderInputServiceTemplate(s)), "%s/templates/services/%s.yaml", input.Name, s.Name)
+		builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateResourceService, packageChartRenderInputServiceTemplate{
+			Name:     s.Name,
+			ChartRef: s.ChartRef,
+		}), "%s/templates/services/%s.yaml", input.Name, s.Name)
 	}
 
 	builder = builder.File(util.GZipBuilderProcessBytes(licenseData.Full()), "%s/LICENSE", input.Name)
@@ -339,6 +358,96 @@ func extractChartSchema(chartData []byte) (map[string]interface{}, error) {
 	}
 
 	return schema, nil
+}
+
+// serviceValues documents the top-level values a service exposes: the referenced chart's
+// defaults with the release overrides applied, described using the chart's own
+// values.schema.json when it provides descriptions. Returns nil when the referenced chart
+// could not be resolved or exposes no values.
+func serviceValues(chart packageChartRenderInputChart, overrides helm.Values) []packageChartRenderInputValue {
+	effective := make(map[string]interface{}, len(chart.Values))
+	for k, v := range chart.Values {
+		effective[k] = v
+	}
+
+	// Release overrides win over the chart defaults for this service.
+	if len(overrides) > 0 {
+		var o map[string]interface{}
+		if err := json.Unmarshal(overrides, &o); err == nil {
+			for k, v := range o {
+				effective[k] = v
+			}
+		}
+	}
+
+	if len(effective) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(effective))
+	for k := range effective {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]packageChartRenderInputValue, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, packageChartRenderInputValue{
+			Key:         k,
+			Default:     formatValueDefault(effective[k]),
+			Description: schemaPropertyDescription(chart.Schema, k),
+		})
+	}
+
+	return out
+}
+
+// formatValueDefault renders a value compactly for a Markdown table cell. Nested objects
+// and lists are shown as truncated JSON, since the full tree belongs in values.yaml.
+func formatValueDefault(v interface{}) string {
+	if s, ok := v.(string); ok {
+		if s == "" {
+			return `""`
+		}
+		return escapeTableCell(s)
+	}
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+
+	s := string(data)
+	const max = 48
+	if len(s) > max {
+		s = s[:max] + "..."
+	}
+
+	return escapeTableCell(s)
+}
+
+// escapeTableCell keeps a value from breaking out of a Markdown table row.
+func escapeTableCell(s string) string {
+	s = goStrings.ReplaceAll(s, "|", "\\|")
+	return goStrings.ReplaceAll(s, "\n", " ")
+}
+
+// schemaPropertyDescription returns the description a chart's values.schema.json documents
+// for a top-level property, or "" when the chart ships no schema or no description.
+func schemaPropertyDescription(schema map[string]interface{}, key string) string {
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	prop, ok := props[key].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	description, _ := prop["description"].(string)
+
+	return escapeTableCell(description)
 }
 
 // sanitizeOverrideSchema adapts a chart's own values.schema.json so it can be inlined as

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -30,7 +30,7 @@ import (
 	"io"
 	"os"
 	"path"
-	"strings"
+	goStrings "strings"
 
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
@@ -282,7 +282,7 @@ func extractChartFile(chartData []byte, name string) ([]byte, error) {
 		// filepath.SplitList must not be used here: it splits on the OS path-list
 		// separator (":" on Linux), so it never matches and would let nested subchart
 		// files through.
-		parts := strings.Split(path.Clean(hdr.Name), "/")
+		parts := goStrings.Split(path.Clean(hdr.Name), "/")
 		if len(parts) == 2 && parts[1] == name {
 			data, err := io.ReadAll(tr)
 			if err != nil {

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -25,6 +25,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	goStrings "strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -298,6 +299,18 @@ func Test_packageChartTemplateReadme(t *testing.T) {
 		// No unrendered template directives leak through
 		require.NotContains(t, readme, "{{")
 		require.NotContains(t, readme, "<no value>")
+
+		// A single, complete values.yaml example - deployment plus every chart and service.
+		// A services-only or charts-only snippet would not be a valid values file, since
+		// `deployment` is required.
+		example := readmeExample(t, readme)
+		require.Contains(t, example, "deployment: my-deployment")
+		require.Contains(t, example, "charts:")
+		require.Contains(t, example, "gral: {}")
+		require.Contains(t, example, "no-schem: {}")
+		require.Contains(t, example, "services:")
+		require.Contains(t, example, "values: {}")
+		require.Equal(t, 1, goStrings.Count(readme, "A complete `values.yaml`"), "exactly one example block")
 	})
 
 	t.Run("empty release", func(t *testing.T) {
@@ -311,5 +324,27 @@ func Test_packageChartTemplateReadme(t *testing.T) {
 		require.Contains(t, readme, "This release bundles no charts.")
 		require.Contains(t, readme, "This release bundles no services.")
 		require.NotContains(t, readme, "{{")
+
+		// With nothing bundled the example must not emit empty `charts:`/`services:` keys.
+		example := readmeExample(t, readme)
+		require.Contains(t, example, "deployment: my-deployment")
+		require.NotContains(t, example, "charts:")
+		require.NotContains(t, example, "services:")
 	})
+}
+
+// readmeExample extracts the fenced YAML of the README's complete values.yaml example.
+func readmeExample(t *testing.T, readme string) string {
+	t.Helper()
+
+	_, after, found := goStrings.Cut(readme, "A complete `values.yaml`")
+	require.True(t, found, "README must contain the complete values.yaml example")
+
+	_, after, found = goStrings.Cut(after, "```yaml\n")
+	require.True(t, found, "example must be a fenced yaml block")
+
+	example, _, found := goStrings.Cut(after, "```")
+	require.True(t, found, "example block must be closed")
+
+	return example
 }

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -202,34 +202,31 @@ func Test_generateValuesSchema_UsesChartSchema(t *testing.T) {
 	require.Equal(t, true, noSchema["additionalProperties"], "charts without a schema stay permissive")
 }
 
-// Test_serviceValues covers the per-service value documentation: chart defaults, release
-// overrides winning over them, descriptions pulled from the chart schema, and stable order.
-func Test_serviceValues(t *testing.T) {
-	chart := packageChartRenderInputChart{
-		Name:    "demo",
-		Version: "1.0.0",
-		Values: map[string]interface{}{
-			"replicas": 1,
-			"image":    "registry.example.com/demo:1.0.0",
-			"empty":    "",
-			"resources": map[string]interface{}{
-				"requests": map[string]interface{}{"cpu": "100m", "memory": "128Mi"},
-			},
+// Test_documentedValues covers the per-chart value documentation: flattening to full
+// override paths, descriptions pulled from the chart schema, and stable order.
+func Test_documentedValues(t *testing.T) {
+	chartValues := map[string]interface{}{
+		"replicas": 1,
+		"image":    "registry.example.com/demo:1.0.0",
+		"empty":    "",
+		"resources": map[string]interface{}{
+			"requests": map[string]interface{}{"cpu": "100m", "memory": "128Mi"},
 		},
-		Schema: map[string]interface{}{
-			"properties": map[string]interface{}{
-				"replicas": map[string]interface{}{"description": "Number of replicas"},
-				"image":    map[string]interface{}{"description": "Container image | with a pipe"},
-				// "empty" intentionally has no description
-				"resources": map[string]interface{}{
-					"description": "Compute resources",
-					"properties": map[string]interface{}{
-						"requests": map[string]interface{}{
-							// no description on this level - it must not be listed
-							"properties": map[string]interface{}{
-								"cpu": map[string]interface{}{"description": "CPU request"},
-								// "memory" intentionally has no description
-							},
+	}
+
+	chartSchema := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"replicas": map[string]interface{}{"description": "Number of replicas"},
+			"image":    map[string]interface{}{"description": "Container image | with a pipe"},
+			// "empty" intentionally has no description
+			"resources": map[string]interface{}{
+				"description": "Compute resources",
+				"properties": map[string]interface{}{
+					"requests": map[string]interface{}{
+						// no description on this level - it must not be listed
+						"properties": map[string]interface{}{
+							"cpu": map[string]interface{}{"description": "CPU request"},
+							// "memory" intentionally has no description
 						},
 					},
 				},
@@ -237,7 +234,7 @@ func Test_serviceValues(t *testing.T) {
 		},
 	}
 
-	values := serviceValues(chart, []byte(`{"replicas": 5}`))
+	values := documentedValues(chartValues, chartSchema)
 	require.NotEmpty(t, values)
 
 	byKey := map[string]packageChartRenderInputValue{}
@@ -257,8 +254,7 @@ func Test_serviceValues(t *testing.T) {
 		"resources.requests.memory",
 	}, keys, "values must be flattened and sorted for stable output")
 
-	// Release override wins over the chart default.
-	require.Equal(t, "5", byKey["replicas"].Default)
+	require.Equal(t, "1", byKey["replicas"].Default)
 	require.Equal(t, "Number of replicas", byKey["replicas"].Description)
 
 	// Pipes are escaped so they cannot break the Markdown table.
@@ -282,12 +278,12 @@ func Test_serviceValues(t *testing.T) {
 		require.NotContains(t, v.Default, "{", "nested values must be flattened, not JSON: %s", v.Key)
 	}
 
-	t.Run("unresolved chart yields no values", func(t *testing.T) {
-		require.Nil(t, serviceValues(packageChartRenderInputChart{}, nil))
+	t.Run("chart with no values yields nothing", func(t *testing.T) {
+		require.Nil(t, documentedValues(nil, nil))
 	})
 
 	t.Run("chart without schema still documents defaults", func(t *testing.T) {
-		v := serviceValues(packageChartRenderInputChart{Values: map[string]interface{}{"a": 1}}, nil)
+		v := documentedValues(map[string]interface{}{"a": 1}, nil)
 		require.Len(t, v, 1)
 		require.Equal(t, "1", v[0].Default)
 		require.Empty(t, v[0].Description)
@@ -301,7 +297,11 @@ func Test_packageChartTemplateReadme(t *testing.T) {
 			Name:    "arango-platform-release",
 			Version: "1.0.0",
 			Charts: map[string]packageChartRenderInputChart{
-				"gral":     {Name: "gral", Version: "1.2.3", Schema: map[string]interface{}{"type": "object"}},
+				"gral": {
+					Name: "gral", Version: "1.2.3",
+					Schema:           map[string]interface{}{"type": "object"},
+					DocumentedValues: []packageChartRenderInputValue{{Key: "replicas", Default: "2", Description: "Replica count"}},
+				},
 				"no-schem": {Name: "no-schem", Version: "4.5.6"},
 			},
 			Services: map[string]packageChartRenderInputService{
@@ -325,6 +325,10 @@ func Test_packageChartTemplateReadme(t *testing.T) {
 		require.Contains(t, readme, "not validated - chart ships no schema")
 		// Services table
 		require.Contains(t, readme, "| `gral` | `arangodb-gral` |")
+		// Values are documented per chart, using the full override path
+		require.Contains(t, readme, "| `charts.gral.replicas` | `2` | Replica count |")
+		require.Contains(t, readme, "This chart exposes no configurable values.")
+		require.NotContains(t, readme, "### Service values")
 		// No unrendered template directives leak through
 		require.NotContains(t, readme, "{{")
 		require.NotContains(t, readme, "<no value>")

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 // newTestChart builds a gzipped tar chart archive from the given entries.
@@ -430,4 +431,32 @@ func readmeExample(t *testing.T, readme string) string {
 	require.True(t, found, "example block must be closed")
 
 	return example
+}
+
+// Test_packageChartTemplateValues_EmptySections ensures a release with no charts or no
+// services still emits valid values.yaml. A bare `services:` key parses as null, which the
+// generated schema rejects as "Expected: object, given: null" - making the release chart
+// uninstallable against its own defaults.
+func Test_packageChartTemplateValues_EmptySections(t *testing.T) {
+	for name, input := range map[string]packageChartRenderInput{
+		"no services": {
+			Name: "r", Version: "1",
+			Charts: map[string]packageChartRenderInputChart{"c": {Name: "c", Version: "1"}},
+		},
+		"no charts": {Name: "r", Version: "1", Services: map[string]packageChartRenderInputService{"s": {Name: "s"}}},
+		"empty":     {Name: "r", Version: "1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, err := packageChartTemplateValues.RenderBytes(input)
+			require.NoError(t, err)
+
+			var doc map[string]interface{}
+			require.NoError(t, yaml.Unmarshal(out, &doc), "values.yaml must parse")
+
+			for _, key := range []string{"charts", "services"} {
+				require.Contains(t, doc, key)
+				require.NotNil(t, doc[key], "%s must be an object, never null: %s", key, string(out))
+			}
+		})
+	}
 }

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -138,7 +138,7 @@ func Test_sanitizeOverrideSchema(t *testing.T) {
 		},
 	}
 
-	out := sanitizeOverrideSchema(in)
+	out := sanitizeOverrideSchema(in, "#/properties/charts/properties/demo")
 
 	require.NotContains(t, out, "$schema", "dialect must not be re-declared in a subschema")
 	require.NotContains(t, out, "$id", "base URI must not shift")
@@ -160,6 +160,56 @@ func Test_sanitizeOverrideSchema(t *testing.T) {
 	// Input must not be mutated.
 	require.Contains(t, in, "$schema")
 	require.Contains(t, in, "required")
+}
+
+// Test_sanitizeOverrideSchema_RewritesLocalRefs ensures a chart schema that uses internal
+// `$ref`s stays resolvable once inlined. Without rewriting, `#/definitions/...` would point
+// at the generated release schema - which has no `definitions` - and helm would reject the
+// release chart even against its own packaged defaults.
+func Test_sanitizeOverrideSchema_RewritesLocalRefs(t *testing.T) {
+	in := map[string]interface{}{
+		"type": "object",
+		"definitions": map[string]interface{}{
+			"image": map[string]interface{}{"type": "object"},
+		},
+		"properties": map[string]interface{}{
+			"images": map[string]interface{}{
+				"additionalProperties": map[string]interface{}{"$ref": "#/definitions/image"},
+			},
+			"list": map[string]interface{}{
+				"items": map[string]interface{}{"$ref": "#/definitions/image"},
+			},
+			"self":     map[string]interface{}{"$ref": "#"},
+			"external": map[string]interface{}{"$ref": "https://example.com/other.json#/definitions/x"},
+		},
+	}
+
+	base := "#/properties/charts/properties/" + escapeJSONPointer("my-chart")
+	out := sanitizeOverrideSchema(in, base)
+
+	props := out["properties"].(map[string]interface{})
+
+	require.Equal(t, base+"/definitions/image",
+		props["images"].(map[string]interface{})["additionalProperties"].(map[string]interface{})["$ref"],
+		"refs under additionalProperties must be rebased")
+	require.Equal(t, base+"/definitions/image",
+		props["list"].(map[string]interface{})["items"].(map[string]interface{})["$ref"],
+		"refs under items must be rebased")
+	require.Equal(t, base, props["self"].(map[string]interface{})["$ref"], "a bare # must become the base")
+	require.Equal(t, "https://example.com/other.json#/definitions/x",
+		props["external"].(map[string]interface{})["$ref"], "non-local refs must be left alone")
+
+	// The definitions the refs point at must survive the inlining.
+	require.Contains(t, out, "definitions")
+	require.Contains(t, out["definitions"].(map[string]interface{}), "image")
+}
+
+// Test_escapeJSONPointer covers RFC 6901 escaping of chart names used in ref bases.
+func Test_escapeJSONPointer(t *testing.T) {
+	require.Equal(t, "plain-chart", escapeJSONPointer("plain-chart"))
+	require.Equal(t, "a~1b", escapeJSONPointer("a/b"))
+	require.Equal(t, "a~0b", escapeJSONPointer("a~b"))
+	require.Equal(t, "a~01b", escapeJSONPointer("a~1b"), "~ must be escaped before /")
 }
 
 // Test_generateValuesSchema_UsesChartSchema ensures a chart's own schema is inlined when

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -1,0 +1,238 @@
+//
+// DISCLAIMER
+//
+// Copyright 2025-2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package platform
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestChart builds a gzipped tar chart archive from the given entries.
+func newTestChart(t *testing.T, files map[string]string, order []string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	for _, name := range order {
+		body := files[name]
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0644,
+			Size: int64(len(body)),
+		}))
+		_, err := tw.Write([]byte(body))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	return buf.Bytes()
+}
+
+// Test_extractChartFile_IgnoresSubcharts ensures only the chart's own top-level file is
+// read. The nested subchart entries are written FIRST so that a matcher which does not
+// check the path depth would return the wrong (subchart) content.
+func Test_extractChartFile_IgnoresSubcharts(t *testing.T) {
+	files := map[string]string{
+		"mychart/charts/sub/values.yaml":        "owner: subchart\n",
+		"mychart/charts/sub/values.schema.json": `{"title":"subchart"}`,
+		"mychart/values.yaml":                   "owner: parent\n",
+		"mychart/values.schema.json":            `{"title":"parent"}`,
+	}
+	order := []string{
+		"mychart/charts/sub/values.yaml",
+		"mychart/charts/sub/values.schema.json",
+		"mychart/values.yaml",
+		"mychart/values.schema.json",
+	}
+
+	chart := newTestChart(t, files, order)
+
+	t.Run("values.yaml", func(t *testing.T) {
+		values, err := extractChartValues(chart)
+		require.NoError(t, err)
+		require.Equal(t, "parent", values["owner"], "must read the chart's own values.yaml, not a subchart's")
+	})
+
+	t.Run("values.schema.json", func(t *testing.T) {
+		schema, err := extractChartSchema(chart)
+		require.NoError(t, err)
+		require.NotNil(t, schema)
+		require.Equal(t, "parent", schema["title"], "must read the chart's own schema, not a subchart's")
+	})
+}
+
+// Test_extractChart_Missing covers charts that ship neither file.
+func Test_extractChart_Missing(t *testing.T) {
+	chart := newTestChart(t, map[string]string{"mychart/Chart.yaml": "name: mychart\n"}, []string{"mychart/Chart.yaml"})
+
+	values, err := extractChartValues(chart)
+	require.NoError(t, err)
+	require.Empty(t, values)
+
+	schema, err := extractChartSchema(chart)
+	require.NoError(t, err)
+	require.Nil(t, schema, "charts without a schema must fall back to nil")
+}
+
+// Test_sanitizeOverrideSchema verifies the override-schema relaxation.
+func Test_sanitizeOverrideSchema(t *testing.T) {
+	in := map[string]interface{}{
+		"$schema":              "https://json-schema.org/draft/2020-12/schema",
+		"$id":                  "https://example.com/values.schema.json",
+		"type":                 "object",
+		"required":             []interface{}{"image"},
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"image": map[string]interface{}{
+				"type":     "object",
+				"required": []interface{}{"tag"},
+				"properties": map[string]interface{}{
+					"tag": map[string]interface{}{"type": "string"},
+				},
+			},
+			// A chart value that is literally named "required" must survive.
+			"required": map[string]interface{}{"type": "boolean"},
+		},
+	}
+
+	out := sanitizeOverrideSchema(in)
+
+	require.NotContains(t, out, "$schema", "dialect must not be re-declared in a subschema")
+	require.NotContains(t, out, "$id", "base URI must not shift")
+	require.NotContains(t, out, "required", "overrides are partial documents")
+	require.Equal(t, "object", out["type"])
+	require.Equal(t, false, out["additionalProperties"], "typo detection must be preserved")
+
+	props := out["properties"].(map[string]interface{})
+
+	// Property literally named "required" is data, not a keyword.
+	require.Contains(t, props, "required")
+	require.Equal(t, "boolean", props["required"].(map[string]interface{})["type"])
+
+	// Nested `required` keyword is stripped, nested properties preserved.
+	image := props["image"].(map[string]interface{})
+	require.NotContains(t, image, "required", "nested required must be stripped for partial overrides")
+	require.Contains(t, image, "properties")
+
+	// Input must not be mutated.
+	require.Contains(t, in, "$schema")
+	require.Contains(t, in, "required")
+}
+
+// Test_generateValuesSchema_UsesChartSchema ensures a chart's own schema is inlined when
+// present, and that charts without one stay permissive.
+func Test_generateValuesSchema_UsesChartSchema(t *testing.T) {
+	input := packageChartRenderInput{
+		Name:    "arango-platform-release",
+		Version: "1.0.0",
+		Charts: map[string]packageChartRenderInputChart{
+			"with-schema": {
+				Name:    "with-schema",
+				Version: "1.2.3",
+				Schema: map[string]interface{}{
+					"$schema":              "https://json-schema.org/draft/2020-12/schema",
+					"type":                 "object",
+					"required":             []interface{}{"image"},
+					"additionalProperties": false,
+					"properties": map[string]interface{}{
+						"image": map[string]interface{}{"type": "string"},
+					},
+				},
+			},
+			"no-schema": {Name: "no-schema", Version: "4.5.6"},
+		},
+	}
+
+	var out map[string]interface{}
+	require.NoError(t, json.Unmarshal(generateValuesSchema(input), &out))
+
+	charts := out["properties"].(map[string]interface{})["charts"].(map[string]interface{})["properties"].(map[string]interface{})
+
+	withSchema := charts["with-schema"].(map[string]interface{})
+	require.Equal(t, false, withSchema["additionalProperties"], "chart schema must be enforced")
+	require.NotContains(t, withSchema, "required", "override block is partial")
+	require.NotContains(t, withSchema, "$schema")
+	require.Contains(t, withSchema, "properties")
+	require.Contains(t, withSchema["description"], "with-schema")
+
+	noSchema := charts["no-schema"].(map[string]interface{})
+	require.Equal(t, true, noSchema["additionalProperties"], "charts without a schema stay permissive")
+}
+
+// Test_packageChartTemplateReadme renders the generated chart README.
+func Test_packageChartTemplateReadme(t *testing.T) {
+	t.Run("with charts and services", func(t *testing.T) {
+		input := packageChartRenderInput{
+			Name:    "arango-platform-release",
+			Version: "1.0.0",
+			Charts: map[string]packageChartRenderInputChart{
+				"gral":     {Name: "gral", Version: "1.2.3", Schema: map[string]interface{}{"type": "object"}},
+				"no-schem": {Name: "no-schem", Version: "4.5.6"},
+			},
+			Services: map[string]packageChartRenderInputService{
+				"gral": {Name: "gral", ChartRef: "arangodb-gral"},
+			},
+		}
+
+		out, err := packageChartTemplateReadme.RenderBytes(input)
+		require.NoError(t, err)
+
+		readme := string(out)
+		t.Logf("rendered README.md:\n%s", readme)
+
+		require.Contains(t, readme, "# arango-platform-release")
+		require.Contains(t, readme, "`1.0.0`")
+		// Charts table
+		require.Contains(t, readme, "| `gral` | `1.2.3` |")
+		require.Contains(t, readme, "| `no-schem` | `4.5.6` |")
+		// Schema presence is reflected per chart
+		require.Contains(t, readme, "validated against the chart's own `values.schema.json`")
+		require.Contains(t, readme, "not validated - chart ships no schema")
+		// Services table
+		require.Contains(t, readme, "| `gral` | `arangodb-gral` |")
+		// No unrendered template directives leak through
+		require.NotContains(t, readme, "{{")
+		require.NotContains(t, readme, "<no value>")
+	})
+
+	t.Run("empty release", func(t *testing.T) {
+		out, err := packageChartTemplateReadme.RenderBytes(packageChartRenderInput{
+			Name:    "empty-release",
+			Version: "0.0.1",
+		})
+		require.NoError(t, err)
+
+		readme := string(out)
+		require.Contains(t, readme, "This release bundles no charts.")
+		require.Contains(t, readme, "This release bundles no services.")
+		require.NotContains(t, readme, "{{")
+	})
+}

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -201,6 +201,69 @@ func Test_generateValuesSchema_UsesChartSchema(t *testing.T) {
 	require.Equal(t, true, noSchema["additionalProperties"], "charts without a schema stay permissive")
 }
 
+// Test_serviceValues covers the per-service value documentation: chart defaults, release
+// overrides winning over them, descriptions pulled from the chart schema, and stable order.
+func Test_serviceValues(t *testing.T) {
+	chart := packageChartRenderInputChart{
+		Name:    "demo",
+		Version: "1.0.0",
+		Values: map[string]interface{}{
+			"replicas": 1,
+			"image":    "registry.example.com/demo:1.0.0",
+			"empty":    "",
+			"resources": map[string]interface{}{
+				"requests": map[string]interface{}{"cpu": "100m", "memory": "128Mi"},
+			},
+		},
+		Schema: map[string]interface{}{
+			"properties": map[string]interface{}{
+				"replicas": map[string]interface{}{"description": "Number of replicas"},
+				"image":    map[string]interface{}{"description": "Container image | with a pipe"},
+				// "resources" and "empty" intentionally have no description
+			},
+		},
+	}
+
+	values := serviceValues(chart, []byte(`{"replicas": 5}`))
+	require.NotEmpty(t, values)
+
+	byKey := map[string]packageChartRenderInputValue{}
+	keys := make([]string, 0, len(values))
+	for _, v := range values {
+		byKey[v.Key] = v
+		keys = append(keys, v.Key)
+	}
+
+	require.Equal(t, []string{"empty", "image", "replicas", "resources"}, keys, "values must be sorted for stable output")
+
+	// Release override wins over the chart default.
+	require.Equal(t, "5", byKey["replicas"].Default)
+	require.Equal(t, "Number of replicas", byKey["replicas"].Description)
+
+	// Pipes are escaped so they cannot break the Markdown table.
+	require.Equal(t, `Container image \| with a pipe`, byKey["image"].Description)
+
+	// Empty string is rendered visibly rather than as a blank cell.
+	require.Equal(t, `""`, byKey["empty"].Default)
+
+	// Nested objects are shown as compact JSON.
+	require.Contains(t, byKey["resources"].Default, "requests")
+
+	// Missing descriptions come back empty (template renders "-").
+	require.Empty(t, byKey["resources"].Description)
+
+	t.Run("unresolved chart yields no values", func(t *testing.T) {
+		require.Nil(t, serviceValues(packageChartRenderInputChart{}, nil))
+	})
+
+	t.Run("chart without schema still documents defaults", func(t *testing.T) {
+		v := serviceValues(packageChartRenderInputChart{Values: map[string]interface{}{"a": 1}}, nil)
+		require.Len(t, v, 1)
+		require.Equal(t, "1", v[0].Default)
+		require.Empty(t, v[0].Description)
+	})
+}
+
 // Test_packageChartTemplateReadme renders the generated chart README.
 func Test_packageChartTemplateReadme(t *testing.T) {
 	t.Run("with charts and services", func(t *testing.T) {

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -220,7 +220,19 @@ func Test_serviceValues(t *testing.T) {
 			"properties": map[string]interface{}{
 				"replicas": map[string]interface{}{"description": "Number of replicas"},
 				"image":    map[string]interface{}{"description": "Container image | with a pipe"},
-				// "resources" and "empty" intentionally have no description
+				// "empty" intentionally has no description
+				"resources": map[string]interface{}{
+					"description": "Compute resources",
+					"properties": map[string]interface{}{
+						"requests": map[string]interface{}{
+							// no description on this level - it must not be listed
+							"properties": map[string]interface{}{
+								"cpu": map[string]interface{}{"description": "CPU request"},
+								// "memory" intentionally has no description
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -235,7 +247,15 @@ func Test_serviceValues(t *testing.T) {
 		keys = append(keys, v.Key)
 	}
 
-	require.Equal(t, []string{"empty", "image", "replicas", "resources"}, keys, "values must be sorted for stable output")
+	// Nested values are expanded to full dotted paths, never collapsed into a JSON blob.
+	require.Equal(t, []string{
+		"empty",
+		"image",
+		"replicas",
+		"resources",
+		"resources.requests.cpu",
+		"resources.requests.memory",
+	}, keys, "values must be flattened and sorted for stable output")
 
 	// Release override wins over the chart default.
 	require.Equal(t, "5", byKey["replicas"].Default)
@@ -247,11 +267,20 @@ func Test_serviceValues(t *testing.T) {
 	// Empty string is rendered visibly rather than as a blank cell.
 	require.Equal(t, `""`, byKey["empty"].Default)
 
-	// Nested objects are shown as compact JSON.
-	require.Contains(t, byKey["resources"].Default, "requests")
+	// Leaves carry their own value and description from the nested schema.
+	require.Equal(t, "100m", byKey["resources.requests.cpu"].Default)
+	require.Equal(t, "CPU request", byKey["resources.requests.cpu"].Description)
+	require.Equal(t, "128Mi", byKey["resources.requests.memory"].Default)
 
-	// Missing descriptions come back empty (template renders "-").
-	require.Empty(t, byKey["resources"].Description)
+	// A documented intermediate object is listed so its description survives, but it has
+	// no default of its own - its children carry the values.
+	require.Empty(t, byKey["resources"].Default)
+	require.Equal(t, "Compute resources", byKey["resources"].Description)
+
+	// No value may render as JSON.
+	for _, v := range values {
+		require.NotContains(t, v.Default, "{", "nested values must be flattened, not JSON: %s", v.Key)
+	}
 
 	t.Run("unresolved chart yields no values", func(t *testing.T) {
 		require.Nil(t, serviceValues(packageChartRenderInputChart{}, nil))

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -102,6 +102,20 @@ func Test_extractChart_Missing(t *testing.T) {
 	require.Nil(t, schema, "charts without a schema must fall back to nil")
 }
 
+// Test_extractChartSchema_Malformed ensures an unparsable schema is surfaced as an error
+// rather than silently degrading to no validation. packageChartChart propagates it and
+// fails the packaging.
+func Test_extractChartSchema_Malformed(t *testing.T) {
+	chart := newTestChart(t,
+		map[string]string{"mychart/values.schema.json": "{not json"},
+		[]string{"mychart/values.schema.json"},
+	)
+
+	schema, err := extractChartSchema(chart)
+	require.Error(t, err, "a chart shipping an unparsable schema must not be accepted")
+	require.Nil(t, schema, "must not return a partially decoded schema")
+}
+
 // Test_sanitizeOverrideSchema verifies the override-schema relaxation.
 func Test_sanitizeOverrideSchema(t *testing.T) {
 	in := map[string]interface{}{

--- a/pkg/platform/templates/readme.md
+++ b/pkg/platform/templates/readme.md
@@ -90,7 +90,25 @@ services:
     values: {}
 {{- end }}
 ```
+
+### Service values
+
+Top-level values each service exposes, with the defaults it is packaged with. Set them under
+`services.<service>.values`. Descriptions are taken from the chart's `values.schema.json`
+where it provides them.
+{{ range $key, $value := .Services }}
+#### `{{ $value.Name }}`
+
+Chart `{{ $value.ChartRef }}`.
+{{ if $value.Values }}
+| Value | Default | Description |
+|-------|---------|-------------|
+{{- range $v := $value.Values }}
+| `{{ $v.Key }}` | `{{ $v.Default }}` | {{ if $v.Description }}{{ $v.Description }}{{ else }}-{{ end }} |
+{{- end }}
 {{ else }}
+This service exposes no values.
+{{ end }}{{ end }}{{ else }}
 This release bundles no services.
 {{ end }}
 ## Verifying the installation

--- a/pkg/platform/templates/readme.md
+++ b/pkg/platform/templates/readme.md
@@ -79,7 +79,39 @@ services:
 Charts that ship a `values.schema.json` have their override block validated against it, with
 `required` constraints relaxed because overrides are a partial document. Charts without a schema
 accept any values.
+
+### Chart values
+
+Every value each chart exposes, with the default it is packaged with. Values are listed by their
+full path, so `charts.<chart>.images.application.tag` is set as:
+
+```yaml
+charts:
+  <chart>:
+    images:
+      application:
+        tag: <value>
+```
+
+or on the command line:
+
+```bash
+--set charts.<chart>.images.application.tag=<value>
+```
+
+The same values can be set per service under `services.<service>.values` - see [Services](#services).
+Descriptions are taken from the chart's `values.schema.json` where it provides them.
+{{ range $key, $value := .Charts }}
+#### `{{ $value.Name }}`
+{{ if $value.DocumentedValues }}
+| Value | Default | Description |
+|-------|---------|-------------|
+{{- range $v := $value.DocumentedValues }}
+| `charts.{{ $value.Name }}.{{ $v.Key }}` | {{ if $v.Default }}`{{ $v.Default }}`{{ else }}-{{ end }} | {{ if $v.Description }}{{ $v.Description }}{{ else }}-{{ end }} |
+{{- end }}
 {{ else }}
+This chart exposes no configurable values.
+{{ end }}{{ end }}{{ else }}
 This release bundles no charts.
 {{ end }}
 ## Services
@@ -90,34 +122,18 @@ This release bundles no charts.
 | `{{ $value.Name }}` | `{{ $value.ChartRef }}` |
 {{- end }}
 
-### Service values
-
-Every value each service exposes, with the default it is packaged with. Nested values are listed
-by their full path, so `images.application.tag` is set as:
+Each service accepts the same values as the chart it is created from, set under
+`services.<service>.values` instead of `charts.<chart>`. See [Chart values](#chart-values) for the
+full list, for example:
 
 ```yaml
 services:
-  <service>:
-    values:
-      images:
-        application:
-          tag: <value>
-```
-
-Descriptions are taken from the chart's `values.schema.json` where it provides them.
-{{ range $key, $value := .Services }}
-#### `{{ $value.Name }}`
-
-Chart `{{ $value.ChartRef }}`.
-{{ if $value.Values }}
-| Value | Default | Description |
-|-------|---------|-------------|
-{{- range $v := $value.Values }}
-| `{{ $v.Key }}` | {{ if $v.Default }}`{{ $v.Default }}`{{ else }}-{{ end }} | {{ if $v.Description }}{{ $v.Description }}{{ else }}-{{ end }} |
+{{- range $key, $value := .Services }}
+  {{ $value.Name }}:
+    values: {}
 {{- end }}
+```
 {{ else }}
-This service exposes no values.
-{{ end }}{{ end }}{{ else }}
 This release bundles no services.
 {{ end }}
 ## Verifying the installation

--- a/pkg/platform/templates/readme.md
+++ b/pkg/platform/templates/readme.md
@@ -49,6 +49,25 @@ helm install <release-name> <chart> \
 Overrides are merged on top of the values each chart was packaged with, so only the keys you want
 to change need to be listed. Unknown chart or service names are rejected by `values.schema.json`.
 
+A complete `values.yaml` for this release, with every override block left empty:
+
+```yaml
+deployment: my-deployment
+{{- if .Charts }}
+charts:
+{{- range $key, $value := .Charts }}
+  {{ $value.Name }}: {}
+{{- end }}
+{{- end }}
+{{- if .Services }}
+services:
+{{- range $key, $value := .Services }}
+  {{ $value.Name }}:
+    values: {}
+{{- end }}
+{{- end }}
+```
+
 ## Bundled charts
 {{ if .Charts }}
 | Chart | Version | Override validation |
@@ -60,16 +79,6 @@ to change need to be listed. Unknown chart or service names are rejected by `val
 Charts that ship a `values.schema.json` have their override block validated against it, with
 `required` constraints relaxed because overrides are a partial document. Charts without a schema
 accept any values.
-
-Example:
-
-```yaml
-deployment: my-deployment
-charts:
-{{- range $key, $value := .Charts }}
-  {{ $value.Name }}: {}
-{{- end }}
-```
 {{ else }}
 This release bundles no charts.
 {{ end }}
@@ -80,16 +89,6 @@ This release bundles no charts.
 {{- range $key, $value := .Services }}
 | `{{ $value.Name }}` | `{{ $value.ChartRef }}` |
 {{- end }}
-
-Example:
-
-```yaml
-services:
-{{- range $key, $value := .Services }}
-  {{ $value.Name }}:
-    values: {}
-{{- end }}
-```
 
 ### Service values
 

--- a/pkg/platform/templates/readme.md
+++ b/pkg/platform/templates/readme.md
@@ -92,9 +92,19 @@ This release bundles no charts.
 
 ### Service values
 
-Top-level values each service exposes, with the defaults it is packaged with. Set them under
-`services.<service>.values`. Descriptions are taken from the chart's `values.schema.json`
-where it provides them.
+Every value each service exposes, with the default it is packaged with. Nested values are listed
+by their full path, so `images.application.tag` is set as:
+
+```yaml
+services:
+  <service>:
+    values:
+      images:
+        application:
+          tag: <value>
+```
+
+Descriptions are taken from the chart's `values.schema.json` where it provides them.
 {{ range $key, $value := .Services }}
 #### `{{ $value.Name }}`
 
@@ -103,7 +113,7 @@ Chart `{{ $value.ChartRef }}`.
 | Value | Default | Description |
 |-------|---------|-------------|
 {{- range $v := $value.Values }}
-| `{{ $v.Key }}` | `{{ $v.Default }}` | {{ if $v.Description }}{{ $v.Description }}{{ else }}-{{ end }} |
+| `{{ $v.Key }}` | {{ if $v.Default }}`{{ $v.Default }}`{{ else }}-{{ end }} | {{ if $v.Description }}{{ $v.Description }}{{ else }}-{{ end }} |
 {{- end }}
 {{ else }}
 This service exposes no values.

--- a/pkg/platform/templates/readme.md
+++ b/pkg/platform/templates/readme.md
@@ -1,0 +1,103 @@
+<!--
+DISCLAIMER
+
+Copyright 2025-2026 ArangoDB GmbH, Cologne, Germany
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Copyright holder is ArangoDB GmbH, Cologne, Germany
+-->
+
+# {{ .Name }}
+
+Arango Platform Release `{{ .Version }}`.
+
+This chart installs an Arango Platform release onto an existing `ArangoDeployment`. It bundles
+{{ len .Charts }} platform chart(s) and {{ len .Services }} service(s), which are created as
+`ArangoPlatformChart` and `ArangoPlatformService` resources and reconciled by the ArangoDB operator.
+
+> This file is generated when the release chart is packaged. Do not edit it by hand.
+
+## Installation
+
+The name of the target `ArangoDeployment` is required:
+
+```bash
+helm install <release-name> <chart> \
+  --namespace <namespace> \
+  --set deployment=<arango-deployment-name>
+```
+
+## Values
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `deployment` | string | yes | Name of the `ArangoDeployment` to target. Must be non-empty. |
+| `charts.<chart>` | object | no | Value overrides for a bundled chart. |
+| `services.<service>.values` | object | no | Value overrides for a service. |
+
+Overrides are merged on top of the values each chart was packaged with, so only the keys you want
+to change need to be listed. Unknown chart or service names are rejected by `values.schema.json`.
+
+## Bundled charts
+{{ if .Charts }}
+| Chart | Version | Override validation |
+|-------|---------|---------------------|
+{{- range $key, $value := .Charts }}
+| `{{ $value.Name }}` | `{{ $value.Version }}` | {{ if $value.Schema }}validated against the chart's own `values.schema.json`{{ else }}not validated - chart ships no schema{{ end }} |
+{{- end }}
+
+Charts that ship a `values.schema.json` have their override block validated against it, with
+`required` constraints relaxed because overrides are a partial document. Charts without a schema
+accept any values.
+
+Example:
+
+```yaml
+deployment: my-deployment
+charts:
+{{- range $key, $value := .Charts }}
+  {{ $value.Name }}: {}
+{{- end }}
+```
+{{ else }}
+This release bundles no charts.
+{{ end }}
+## Services
+{{ if .Services }}
+| Service | Chart |
+|---------|-------|
+{{- range $key, $value := .Services }}
+| `{{ $value.Name }}` | `{{ $value.ChartRef }}` |
+{{- end }}
+
+Example:
+
+```yaml
+services:
+{{- range $key, $value := .Services }}
+  {{ $value.Name }}:
+    values: {}
+{{- end }}
+```
+{{ else }}
+This release bundles no services.
+{{ end }}
+## Verifying the installation
+
+```bash
+kubectl get arangoplatformcharts -n <namespace>
+kubectl get arangoplatformservices -n <namespace>
+```
+
+Both resources report a `Ready` condition once the operator has reconciled them.

--- a/pkg/platform/templates/values.yaml
+++ b/pkg/platform/templates/values.yaml
@@ -22,12 +22,14 @@
 
 deployment: ""
 
-charts:
+{{ if .Charts }}charts:
 {{ range $key, $value := .Charts }}  {{ $value.Name }}:
 {{ if $value.Values }}{{ $value.Values | toYaml | indent 4 }}
 {{ else }}    {}
-{{ end }}{{ end }}
-services:
+{{ end }}{{ end }}{{ else }}charts: {}
+{{ end }}
+{{ if .Services }}services:
 {{ range $key, $value := .Services }}  {{ $value.Name }}:
     values: {}
+{{ end }}{{ else }}services: {}
 {{ end }}


### PR DESCRIPTION
## Summary

Improves the generated Arango Platform release chart (`arangodb platform package chart`): chart overrides are validated against each subchart's own schema, every chart's values are documented in a generated `README.md`, and several latent packaging bugs are fixed along the way.

## Changes

### 1. Read `values.schema.json` from bundled subcharts

The generator previously read only each subchart's `values.yaml` and then synthesized a top-level `values.schema.json` in which **every** chart override block was `additionalProperties: true` — i.e. no validation at all. Typos or invalid values inside a chart's override block passed silently.

Each chart's own `values.schema.json` (already present in the bundled `files/<chart>.tgz`) is now read and inlined as the schema for its override block. `helm template`/`install` then enforces it — verified end-to-end: a bogus key on a schema'd chart is rejected (`Additional property ... is not allowed`) while schema-less charts stay permissive.

### 2. Relax the inlined schema for partial overrides

An override block is a *partial* document merged on top of the chart defaults, so applying a chart schema verbatim would wrongly demand every `required` key and break existing overrides files. `sanitizeOverrideSchema` therefore strips:

- `required` — overrides are partial; a chart-mandatory value need not be restated
- `$schema` / `$id` — the schema is inlined as a subschema, not a document root

Recursion only descends into positions that actually hold schemas, so a chart value legitimately **named** `required` (a key under `properties`) is preserved. `additionalProperties: false` is kept, which is where the typo-catching value comes from.

### 3. Rebase local `$ref`s when inlining

A real chart (`arangodb-ml-api`) ships a schema using internal refs like `#/definitions/image`. Once inlined, `#/` no longer means the chart's own schema but the generated release schema — which has no `definitions` — so `helm template` rejected the release chart **against its own packaged defaults** (`Object has no key 'definitions'`). Local refs are now rebased onto the inline site (`#/properties/charts/properties/<chart>/...`), with RFC 6901 escaping of the chart name; external refs are left untouched.

### 4. Fix top-level file matching in the chart archive

The existing "only match top-level `values.yaml`" guard was ineffective:

```go
parts := filepath.SplitList(hdr.Name)
if len(parts) <= 2 || ...
```

`filepath.SplitList` splits on the OS **path-list** separator (`:` on Linux), not `/`, so it never matched and the condition always short-circuited true. Any `values.yaml` in the archive would match — including a bundled subchart's `charts/<sub>/values.yaml` — with tar ordering deciding the winner. Replaced with a shared `extractChartFile` helper doing a real path-depth check.

### 5. Emit empty `charts`/`services` as objects

A release with no services (or no charts) generated a `values.yaml` with a bare `services:` key, which parses as YAML `null`. The generated schema declares `services` as `type: object`, so the release chart failed validation **against its own defaults** (`Expected: object, given: null`). Empty sections now render as `{}`. (Pre-existing on `master`; only surfaced once a release without services was packaged.)

### 6. Generate `README.md`

The chart now ships a generated `README.md` at its root (static docs, rendered once at package time — not a Helm template, so `helm show readme <chart>` works). It documents:

- the required `deployment` value and the `charts.<chart>` / `services.<service>.values` override keys;
- a single, complete `values.yaml` example (`deployment` plus every chart and service) — a partial snippet would be invalid, since `deployment` is required;
- a **Bundled charts** table showing each chart's name, version, and whether its overrides are schema-validated;
- **per-chart value tables** — every value each chart exposes, with the default it is packaged with. Values belong to the chart (not the service): a chart may back several services, or none, so this documents all charts rather than only the ones with a service.

Values are expanded to full override paths (`charts.<chart>.resources.requests.cpu`) instead of opaque JSON, so each leaf is individually settable and copy-pasteable into `--set`. Descriptions come from the chart's `values.schema.json` where it provides them; a documented intermediate object is listed (with `-` as default) so its description survives, and its leaves follow underneath. Depth is capped so a pathological chart cannot produce an unreadable table.

## Behaviour for charts without a schema

Backward compatible — this only adds validation where a schema exists:

| Case | Behaviour |
|------|-----------|
| Chart ships **no** `values.schema.json` | Permissive entry (`additionalProperties: true`) — byte-identical to the previous output |
| Chart ships a **valid** schema | Overrides validated against it (relaxed and rebased as described above) |
| Chart ships an **unparsable** schema | Packaging **fails**, naming the chart |

The last case is deliberate: silently degrading would drop override validation with no signal, which is exactly the failure mode this PR set out to remove.

## Testing

New `pkg/platform/package_chart_test.go`:

- `Test_extractChartFile_IgnoresSubcharts` — writes the nested `charts/sub/` entries **first**, so it fails against the old matcher
- `Test_extractChart_Missing` / `Test_extractChartSchema_Malformed` — charts shipping neither file / an unparsable schema
- `Test_sanitizeOverrideSchema` — strips `required`/`$schema`/`$id`, preserves a property named `required`, keeps `additionalProperties: false`, does not mutate the input
- `Test_sanitizeOverrideSchema_RewritesLocalRefs` / `Test_escapeJSONPointer` — local refs rebased, external refs and definitions preserved, RFC 6901 escaping
- `Test_generateValuesSchema_UsesChartSchema` — chart schema inlined when present, permissive fallback otherwise
- `Test_documentedValues` — flattening to full paths, descriptions from the nested schema, stable order, no JSON blobs
- `Test_packageChartTemplateReadme` / `Test_packageChartTemplateValues_EmptySections` — README renders (charts/services and empty-release cases) with no unrendered directives; empty sections stay valid objects

Additionally verified end-to-end with real `helm` (3.21): `helm show readme`, and `helm template` succeeding on the generated charts while rejecting invalid overrides on the one chart that ships a schema. `go build`, `go vet -tags testing`, `golangci-lint` and the tests all pass; gofmt clean.
