### PR TITLE
Sync operator-managed predefined RBAC roles into the authorization sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-- (Feature) (RBAC) Create the operator managed predefined RBAC roles in the authorization sidecar after root user creation (super-admin bound to the root user with `*` scope; other roles created empty), recreating and repairing them via a throttled high plan builder, and allow extending a predefined role by attaching policies through the binding reference `direct` field
+- (Feature) (RBAC) Create the operator managed predefined RBAC roles in the authorization sidecar after root user creation (super-admin bound to the root user with `*` scope; other roles created empty), recreating and repairing them via a throttled high plan builder, and allow extending a predefined role by attaching policies through the binding reference `direct` field; the reserved super-admin role cannot be assigned or modified by customer bindings
 - (Feature) (Platform) Generate README.md in the platform release chart and validate chart overrides against each subchart values.schema.json
 
 ## [1.4.4](https://github.com/arangodb/kube-arangodb/tree/1.4.4) (2026-07-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-- (Feature) (RBAC) Create the operator managed predefined RBAC roles in the authorization sidecar after root user creation (super-admin bound to the root user with `*` scope; other roles created empty), recreating and repairing them via a throttled high plan builder
+- (Feature) (RBAC) Create the operator managed predefined RBAC roles in the authorization sidecar after root user creation (super-admin bound to the root user with `*` scope; other roles created empty), recreating and repairing them via a throttled high plan builder, and allow extending a predefined role by attaching policies through the binding reference `direct` field
 - (Feature) (Platform) Generate README.md in the platform release chart and validate chart overrides against each subchart values.schema.json
 
 ## [1.4.4](https://github.com/arangodb/kube-arangodb/tree/1.4.4) (2026-07-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) (RBAC) Create the operator managed predefined RBAC roles in the authorization sidecar after root user creation (super-admin bound to the root user with `*` scope; other roles created empty), recreating and repairing them via a throttled high plan builder
 - (Feature) (Platform) Generate README.md in the platform release chart and validate chart overrides against each subchart values.schema.json
 
 ## [1.4.4](https://github.com/arangodb/kube-arangodb/tree/1.4.4) (2026-07-20)

--- a/design/rbac/README.md
+++ b/design/rbac/README.md
@@ -11,6 +11,7 @@ the gateway sidecar through Envoy's ext_authz filter and gRPC interceptors.
 
 - [Architecture](architecture.md) - Request flow, Envoy ext_authz, gRPC interceptor, plugin chain
 - [Data Model](data_model.md) - Policies, Roles, Scopes, UserRoleBindings, and CRD bindings
+- [Predefined Roles](predefined_roles.md) - The operator-managed role catalog, accesses, and lifecycle
 - [Evaluation](evaluation.md) - Policy evaluation logic and configuration modes
 - [API](api.md) - Management API, Integration API (identity, canI, evaluate), proto definitions
 - [Token Integration](token_integration.md) - ArangoPermissionToken reconciliation flow

--- a/design/rbac/predefined_roles.md
+++ b/design/rbac/predefined_roles.md
@@ -46,7 +46,7 @@ operator-managed, which is why it is visible but not editable.
 
 | Role (`managed:predefined:…`) | Description | Access |
 |---|---|---|
-| `super-admin` | Reserved role providing full access to all functionality. **Cannot be assigned by the customer.** | Allow `*` on `*`. Bound automatically to the deployment `root` user with an Allow-all scope. |
+| `super-admin` | Reserved role providing full access to all functionality. **Cannot be assigned by the customer** - the operator rejects (`SpecValid: false`) any `ArangoPermissionRoleUserBinding`/`ArangoPermissionPolicyRoleBinding` that references it (`permission.IsReservedRoleName`). | Allow `*` on `*`. Bound automatically to the deployment `root` user with an Allow-all scope. |
 | `tenant-admin` | Manages users and role bindings. | Assign and scope roles; read users, roles, and resources. |
 | `coredb-reader` | Reads scoped resources and executes read-only database operations. | Read-only on scoped `Database`/`Collection`. |
 | `coredb-developer` | Reads and writes scoped resources and executes read and write database operations. | Read and write on scoped `Database`/`Collection`. |
@@ -87,8 +87,11 @@ Predefined roles are synced by the deployment reconciler:
 4. A throttled high plan builder re-runs the action periodically, so a deleted or
    drifted predefined role is recreated and repaired.
 
-See `pkg/deployment/reconcile/plan_builder_rbac.go` for the catalog and
-`plan_builder_high.go` (`createSyncRBACPermissionsPlan`) for the builder.
+The role identifiers are the exported single source of truth in
+`pkg/apis/permission` (`PredefinedRoleNames`, the `PredefinedRole*` constants, and
+`ManagedPredefinedRoleName`); the reconcile catalog, the reserved-role guard, and the
+e2e tests all reference them. See `pkg/deployment/reconcile/plan_builder_rbac.go` for
+the catalog and `plan_builder_high.go` (`createSyncRBACPermissionsPlan`) for the builder.
 
 ## Extending
 

--- a/design/rbac/predefined_roles.md
+++ b/design/rbac/predefined_roles.md
@@ -1,0 +1,116 @@
+# Predefined Roles
+
+> **Alpha Feature** - RBAC is currently in alpha (`v1alpha1`). The predefined role
+> catalog, its names, and the accesses it grants may change without notice.
+
+The operator seeds every RBAC-enabled deployment with a catalog of **predefined
+roles**. These roles are operator-managed: customers can assign and scope them,
+but cannot edit or delete them. Only the roles listed here are shipped - users
+cannot define their own predefined roles (custom roles are still possible as
+regular `ArangoPermissionRole` objects, see
+[docs/platform/rbac/predefined_roles.md](../../docs/platform/rbac/predefined_roles.md)).
+
+## Model
+
+- **Default deny.** No access is granted unless a scoped role explicitly allows
+  it. A predefined role grants nothing until it is bound to a user (via an
+  `ArangoPermissionRoleUserBinding`) with a scope.
+- **Predefined only (MVP).** Users assign and scope roles; they do not create
+  predefined roles.
+- **Deny and allow effects** with deny taking precedence.
+- **Scoping** is applied per user-role binding at resource-type level, with one,
+  many, and pattern (URN) matching (see [Data Model](data_model.md)).
+
+### Granularity of resource types
+
+| Component | Resource types |
+|---|---|
+| CoreDB | `Database`, `Collection` |
+| AI Services | `Workspace` (equivalent to `Database`) |
+
+## Naming
+
+Predefined roles are created in the authorization sidecar under the reserved
+prefix `managed:predefined:`, following the `managed:` convention used for other
+operator-owned objects (handlers use `managed:operator:`). A role and its bundled
+policy share the same name (they live in separate policy/role collections):
+
+```
+managed:predefined:<role>
+```
+
+For example, `managed:predefined:coredb-reader`. The prefix marks the object as
+operator-managed, which is why it is visible but not editable.
+
+## Catalog
+
+| Role (`managed:predefined:…`) | Description | Access |
+|---|---|---|
+| `super-admin` | Reserved role providing full access to all functionality. **Cannot be assigned by the customer.** | Allow `*` on `*`. Bound automatically to the deployment `root` user with an Allow-all scope. |
+| `tenant-admin` | Manages users and role bindings. | Assign and scope roles; read users, roles, and resources. |
+| `coredb-reader` | Reads scoped resources and executes read-only database operations. | Read-only on scoped `Database`/`Collection`. |
+| `coredb-developer` | Reads and writes scoped resources and executes read and write database operations. | Read and write on scoped `Database`/`Collection`. |
+| `coredb-admin` | Manages scoped resources' structures and lifecycle. | Create, alter, and drop scoped `Database`/`Collection`. |
+| `ai-user` | Executes AI workflows and reads resulting outputs within scoped resources. | Execute AI workflows and read outputs on scoped `Workspace`. |
+| `ai-developer` | Builds, configures, manages, and executes AI workflows and artifacts within scoped resources. | Full AI workflow and artifact management on scoped `Workspace`. |
+| `platform-operator` | Operates platform services, manages bundled services, views observability, and starts containers within scoped resources. | Operate platform/bundled services, view observability, start containers on scoped resources. |
+| `secret-admin` | Manages secrets within scoped resources. | Manage secrets on scoped resources. |
+
+### Bundled policies (MVP status)
+
+The **Access** column above describes each role's intended authorization. In the
+current MVP only `super-admin` ships a concrete bundled policy (Allow `*` on `*`).
+The remaining roles are created as **empty role containers** - they exist so they
+can be assigned, scoped, and extended, and so their names are stable across
+releases, but their bundled policies are defined in a later iteration. Until a
+bundled policy is defined (or a policy is attached to the role, see
+[Extending](#extending)), binding one of these roles grants no permissions
+(default deny).
+
+Bundled third-party services and solutions are exposed as **binary (on/off)**
+permissions; the concrete action set for each service is service-defined.
+
+## Lifecycle
+
+Predefined roles are synced by the deployment reconciler:
+
+1. After the deployment bootstrap completes (the `root` user is created) and the
+   gateway/authorization sidecar is enabled, the reconciler runs the
+   `SyncRBACPermissions` action.
+2. The action connects to the authorization sidecar and upserts every predefined
+   role directly through the management API - it does **not** create
+   intermediate `ArangoPermission*` custom resources. Each role's policy set is
+   its bundled policy (for `super-admin`) merged with any policies attached via
+   `ArangoPermissionPolicyRoleBindings` (see [Extending](#extending)).
+3. `super-admin` additionally gets its Allow-all policy and a binding of the
+   `root` user with an Allow-all scope.
+4. A throttled high plan builder re-runs the action periodically, so a deleted or
+   drifted predefined role is recreated and repaired.
+
+See `pkg/deployment/reconcile/plan_builder_rbac.go` for the catalog and
+`plan_builder_high.go` (`createSyncRBACPermissionsPlan`) for the builder.
+
+## Extending
+
+Predefined roles cannot be renamed or deleted, but they are **extensible**:
+
+- **Attach policies to a predefined role.** An `ArangoPermissionPolicyRoleBinding`
+  may reference a predefined role by its `managed:predefined:*` name (there is no
+  `ArangoPermissionRole` CRD - the `role_user_binding`/`policy_role_binding`
+  handlers accept the direct sidecar name). The reconciler discovers such bindings
+  (`collectBoundPolicies`), resolves their policies to sidecar names, and merges
+  them into the predefined role. Drift-repair targets the merged set, so bound
+  policies are preserved; unbinding removes them again.
+- **Per-user composition.** A user's effective permissions are the union of all
+  their role bindings (with `Deny` precedence), so a user can be granted an
+  additional custom `ArangoPermissionRole` on top of a predefined one.
+
+See [docs/platform/rbac/predefined_roles.md](../../docs/platform/rbac/predefined_roles.md#extending-predefined-roles).
+
+## Machine users
+
+Services that must operate independently of a human user's permissions
+authenticate as machine identities. The operator itself acts as a machine
+identity (`managed:operator:*`) when reconciling authorization state, and
+services obtain scoped bearer tokens through `ArangoPermissionToken`
+(see [Token Integration](token_integration.md)).

--- a/design/rbac/predefined_roles.md
+++ b/design/rbac/predefined_roles.md
@@ -95,9 +95,11 @@ See `pkg/deployment/reconcile/plan_builder_rbac.go` for the catalog and
 Predefined roles cannot be renamed or deleted, but they are **extensible**:
 
 - **Attach policies to a predefined role.** An `ArangoPermissionPolicyRoleBinding`
-  may reference a predefined role by its `managed:predefined:*` name (there is no
-  `ArangoPermissionRole` CRD - the `role_user_binding`/`policy_role_binding`
-  handlers accept the direct sidecar name). The reconciler discovers such bindings
+  may reference a predefined role through the reference's `direct` field, which
+  holds the exact sidecar name (e.g. `managed:predefined:coredb-reader`). There is
+  no `ArangoPermissionRole` CRD, so `direct` is used instead of `name`; the
+  `role_user_binding`/`policy_role_binding` handlers resolve it as-is
+  (`ArangoPermissionBindingRef.IsDirect`). The reconciler discovers such bindings
   (`collectBoundPolicies`), resolves their policies to sidecar names, and merges
   them into the predefined role. Drift-repair targets the merged set, so bound
   policies are preserved; unbinding removes them again.

--- a/docs/api/ArangoPermissionPolicyRoleBinding.V1Alpha1.md
+++ b/docs/api/ArangoPermissionPolicyRoleBinding.V1Alpha1.md
@@ -18,17 +18,39 @@ Name of the object
 
 ***
 
+### .spec.policy.direct
+
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L40)</sup>
+
+Direct references an existing authorization object (role or policy) by its exact name, without
+a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+"managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+must be set.
+
+***
+
 ### .spec.policy.name
 
-Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L33)</sup>
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L34)</sup>
 
 Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
 
 ***
 
+### .spec.role.direct
+
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L40)</sup>
+
+Direct references an existing authorization object (role or policy) by its exact name, without
+a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+"managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+must be set.
+
+***
+
 ### .spec.role.name
 
-Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L33)</sup>
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L34)</sup>
 
 Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
 

--- a/docs/api/ArangoPermissionRoleUserBinding.V1Alpha1.md
+++ b/docs/api/ArangoPermissionRoleUserBinding.V1Alpha1.md
@@ -90,7 +90,7 @@ Resources defines the list of resources
 
 ### .spec.userName
 
-Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/role_user_binding_spec.go#L45)</sup>
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/role_user_binding_spec.go#L46)</sup>
 
 This field is **required**
 

--- a/docs/api/ArangoPermissionRoleUserBinding.V1Alpha1.md
+++ b/docs/api/ArangoPermissionRoleUserBinding.V1Alpha1.md
@@ -18,9 +18,20 @@ Name of the object
 
 ***
 
+### .spec.role.direct
+
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L40)</sup>
+
+Direct references an existing authorization object (role or policy) by its exact name, without
+a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+"managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+must be set.
+
+***
+
 ### .spec.role.name
 
-Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L33)</sup>
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L34)</sup>
 
 Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
 

--- a/docs/api/ArangoPermissionToken.V1Alpha1.md
+++ b/docs/api/ArangoPermissionToken.V1Alpha1.md
@@ -69,9 +69,20 @@ Resources defines the list of resources
 
 ***
 
+### .spec.roles\[int\].role.direct
+
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L40)</sup>
+
+Direct references an existing authorization object (role or policy) by its exact name, without
+a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+"managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+must be set.
+
+***
+
 ### .spec.roles\[int\].role.name
 
-Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L33)</sup>
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L34)</sup>
 
 Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
 
@@ -128,9 +139,20 @@ Resources defines the list of resources
 
 ***
 
+### .spec.roles\[int\].scope.ref.direct
+
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L40)</sup>
+
+Direct references an existing authorization object (role or policy) by its exact name, without
+a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+"managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+must be set.
+
+***
+
 ### .spec.roles\[int\].scope.ref.name
 
-Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L33)</sup>
+Type: `string` <sup>[\[ref\]](https://github.com/arangodb/kube-arangodb/blob/1.4.4/pkg/apis/permission/v1alpha1/binding_ref.go#L34)</sup>
 
 Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
 

--- a/docs/generated/actions.md
+++ b/docs/generated/actions.md
@@ -87,6 +87,7 @@ nav_order: 11
 | SetMemberConditionV2 | yes | 10m0s | no | Community & Enterprise | Set member condition |
 | SetMemberCurrentImage | no | 10m0s | no | Community & Enterprise | Update Member current image |
 | ShutdownMember | no | 30m0s | no | Community & Enterprise | Sends Shutdown requests and waits for container to be stopped |
+| SyncRBACPermissions | no | 10m0s | no | Community & Enterprise | Sync the operator managed predefined RBAC roles into the authorization sidecar (super-admin ships an Allow-all policy bound to the root user; other roles are created empty) |
 | TLSKeyStatusUpdate | no | 10m0s | no | Enterprise Only | Update Status of TLS propagation process |
 | TLSPropagated | yes | 10m0s | no | Enterprise Only | Update TLS propagation condition |
 | TimezoneSecretSet | no | 30m0s | no | Community & Enterprise | Set timezone details in cluster |
@@ -186,6 +187,7 @@ spec:
       SetMemberConditionV2: 10m0s
       SetMemberCurrentImage: 10m0s
       ShutdownMember: 30m0s
+      SyncRBACPermissions: 10m0s
       TLSKeyStatusUpdate: 10m0s
       TLSPropagated: 10m0s
       TimezoneSecretSet: 30m0s

--- a/docs/platform.rbac.md
+++ b/docs/platform.rbac.md
@@ -26,6 +26,7 @@ before reaching the database.
 ## Sections
 
 - [Enabling RBAC](platform/rbac/enabling.md) - Feature flags, Helm configuration, authorization modes
+- [Predefined Roles](platform/rbac/predefined_roles.md) - The operator-managed role catalog: assigning, scoping, and extending
 - [Policies and Roles](platform/rbac/policies.md) - Defining permissions with policies, roles, bindings, and scopes
 - [Permission Tokens](platform/rbac/tokens.md) - Creating JWT tokens via ArangoPermissionToken CRD
 - [User Role Bindings](platform/rbac/user_bindings.md) - Assigning roles to users with per-user scopes

--- a/docs/platform/rbac/faq.md
+++ b/docs/platform/rbac/faq.md
@@ -3,7 +3,7 @@ layout: page
 title: FAQ
 parent: RBAC
 grand_parent: ArangoDBPlatform
-nav_order: 6
+nav_order: 7
 ---
 
 # RBAC FAQ

--- a/docs/platform/rbac/identity.md
+++ b/docs/platform/rbac/identity.md
@@ -3,7 +3,7 @@ layout: page
 title: Identity and Permissions
 parent: RBAC
 grand_parent: ArangoDBPlatform
-nav_order: 5
+nav_order: 6
 ---
 
 # Identity and Permission Checks

--- a/docs/platform/rbac/policies.md
+++ b/docs/platform/rbac/policies.md
@@ -3,7 +3,7 @@ layout: page
 title: Policies and Roles
 parent: RBAC
 grand_parent: ArangoDBPlatform
-nav_order: 2
+nav_order: 3
 ---
 
 # Policies and Roles

--- a/docs/platform/rbac/predefined_roles.md
+++ b/docs/platform/rbac/predefined_roles.md
@@ -1,0 +1,147 @@
+---
+layout: page
+title: Predefined Roles
+parent: RBAC
+grand_parent: ArangoDBPlatform
+nav_order: 2
+---
+
+# Predefined Roles
+
+When RBAC is enabled, the operator automatically creates a catalog of
+**predefined roles** in every deployment's authorization sidecar. You assign and
+scope these roles to users; you cannot edit or delete them (they are
+operator-managed and visible but not editable).
+
+Predefined roles are named under the reserved prefix `managed:predefined:`, e.g.
+`managed:predefined:coredb-reader`.
+
+| Role | Purpose |
+|---|---|
+| `managed:predefined:super-admin` | Full access. Reserved - bound automatically to the `root` user and **not assignable** by customers. |
+| `managed:predefined:tenant-admin` | Manages users and role bindings. |
+| `managed:predefined:coredb-reader` | Read-only database operations on scoped resources. |
+| `managed:predefined:coredb-developer` | Read and write database operations on scoped resources. |
+| `managed:predefined:coredb-admin` | Manages scoped resources' structures and lifecycle. |
+| `managed:predefined:ai-user` | Executes AI workflows and reads outputs on scoped resources. |
+| `managed:predefined:ai-developer` | Builds, configures, manages, and executes AI workflows on scoped resources. |
+| `managed:predefined:platform-operator` | Operates platform and bundled services, views observability, starts containers. |
+| `managed:predefined:secret-admin` | Manages secrets on scoped resources. |
+
+The full catalog, with the intended access per role and its implementation
+status, is described in the [design notes](../../../design/rbac/predefined_roles.md).
+By default no access is granted (default deny); a role grants nothing until it is
+bound to a user with a scope.
+
+## Assigning a predefined role to a user
+
+Bind a user to a predefined role with an `ArangoPermissionRoleUserBinding`. The
+binding carries the **scope** that restricts where the role applies (resource-type
+level, with one/many/pattern matching). Reference the predefined role by its
+`managed:predefined:…` name:
+
+```yaml
+apiVersion: permission.arangodb.com/v1alpha1
+kind: ArangoPermissionRoleUserBinding
+metadata:
+  name: alice-coredb-reader
+spec:
+  deployment:
+    name: my-deployment
+  userName: alice
+  role:
+    name: managed:predefined:coredb-reader
+  scope:
+    statements:
+      - effect: Allow
+        actions: ["*"]
+        resources: ["reports", "reports/*"]
+```
+
+The `scope` above limits Alice's `coredb-reader` access to the `reports` database
+and everything under it. To grant the role everywhere, use an Allow-all scope
+(`actions: ["*"]`, `resources: ["*"]`).
+
+You can also assign and scope roles through the management API (see
+[User Role Bindings](user_bindings.md)):
+
+```bash
+curl -X PUT https://<gateway>/_management/permissions/user/alice/role/managed:predefined:coredb-reader \
+  -H 'Content-Type: application/json' \
+  -d '{"scope": {"statements": [{"effect": "Allow", "actions": ["*"], "resources": ["reports/*"]}]}}'
+```
+
+> `super-admin` is reserved and cannot be assigned - the operator binds it to the
+> deployment `root` user automatically.
+
+## Extending predefined roles
+
+Predefined roles cannot be renamed or deleted, but you **can attach additional
+policies** to them. Define an `ArangoPermissionPolicy` and bind it to a predefined
+role by referencing the role's `managed:predefined:*` name in an
+`ArangoPermissionPolicyRoleBinding` (predefined roles have no `ArangoPermissionRole`
+CRD - they are referenced by their sidecar name directly). The operator merges the
+bound policy into the predefined role, alongside its bundled policy.
+
+For example, to grant everyone with `coredb-reader` write access on `reports`:
+
+```yaml
+# 1. Define the extra policy
+apiVersion: permission.arangodb.com/v1alpha1
+kind: ArangoPermissionPolicy
+metadata:
+  name: reports-writer
+spec:
+  deployment:
+    name: my-deployment
+  policy:
+    statements:
+      - effect: Allow
+        actions: ["database:read", "database:write"]
+        resources: ["reports/*"]
+---
+# 2. Attach it to the predefined role by its managed:predefined: name
+apiVersion: permission.arangodb.com/v1alpha1
+kind: ArangoPermissionPolicyRoleBinding
+metadata:
+  name: coredb-reader-reports-writer
+spec:
+  deployment:
+    name: my-deployment
+  role:
+    name: managed:predefined:coredb-reader   # a predefined role - referenced by sidecar name
+  policy:
+    name: reports-writer
+```
+
+Every user bound to `coredb-reader` now additionally carries the `reports-writer`
+policy. Deleting the binding removes the extra policy again.
+
+Notes:
+
+- The attached policy extends the role for **everyone** assigned it (it is not
+  per-user). The operator reconciles the change within a short interval.
+- `super-admin` already grants everything, so attaching policies to it has no
+  effect.
+- The predefined role's own bundled policy is preserved - bound policies are
+  merged in, not replaced, and the operator does not clobber them on sync.
+
+See [Policies and Roles](policies.md) for the object model and the action /
+resource formats.
+
+### Per-user extension (composition)
+
+To grant a **single user** more than a predefined role provides (rather than
+extending the role for everyone), bind them to an additional custom role. A user's
+effective permissions are the **union of all their role bindings**, with `Deny`
+taking precedence. Create a custom `ArangoPermissionPolicy` + `ArangoPermissionRole`
++ `ArangoPermissionPolicyRoleBinding`, then add a second
+`ArangoPermissionRoleUserBinding` for that user - the user keeps their predefined
+role and gains the custom one. Removing the extra binding reverts them.
+
+## Errors on insufficient permissions
+
+Services do not proactively hide unavailable actions; instead they return an
+actionable error when an unauthorized action is attempted. If a user is denied,
+verify that a role is bound to them and that the binding's **scope** covers the
+target resource.

--- a/docs/platform/rbac/predefined_roles.md
+++ b/docs/platform/rbac/predefined_roles.md
@@ -72,8 +72,11 @@ curl -X PUT https://<gateway>/_management/permissions/user/alice/role/managed:pr
   -d '{"scope": {"statements": [{"effect": "Allow", "actions": ["*"], "resources": ["reports/*"]}]}}'
 ```
 
-> `super-admin` is reserved and cannot be assigned - the operator binds it to the
-> deployment `root` user automatically.
+> `super-admin` is reserved: the operator binds it to the deployment `root` user
+> automatically and **rejects** any `ArangoPermissionRoleUserBinding` or
+> `ArangoPermissionPolicyRoleBinding` that references it (the binding is marked
+> `SpecValid: false` and never applied), so customers cannot assign it or attach
+> policies to it.
 
 ## Extending predefined roles
 

--- a/docs/platform/rbac/predefined_roles.md
+++ b/docs/platform/rbac/predefined_roles.md
@@ -37,8 +37,9 @@ bound to a user with a scope.
 
 Bind a user to a predefined role with an `ArangoPermissionRoleUserBinding`. The
 binding carries the **scope** that restricts where the role applies (resource-type
-level, with one/many/pattern matching). Reference the predefined role by its
-`managed:predefined:…` name:
+level, with one/many/pattern matching). Predefined roles have no `ArangoPermissionRole`
+CRD, so reference them with the `direct` field (their exact sidecar name) rather than
+`name` (which resolves an `ArangoPermissionRole` CRD):
 
 ```yaml
 apiVersion: permission.arangodb.com/v1alpha1
@@ -50,7 +51,7 @@ spec:
     name: my-deployment
   userName: alice
   role:
-    name: managed:predefined:coredb-reader
+    direct: managed:predefined:coredb-reader   # direct sidecar name (no CRD)
   scope:
     statements:
       - effect: Allow
@@ -78,10 +79,10 @@ curl -X PUT https://<gateway>/_management/permissions/user/alice/role/managed:pr
 
 Predefined roles cannot be renamed or deleted, but you **can attach additional
 policies** to them. Define an `ArangoPermissionPolicy` and bind it to a predefined
-role by referencing the role's `managed:predefined:*` name in an
+role by referencing the role's exact sidecar name through the `direct` field of an
 `ArangoPermissionPolicyRoleBinding` (predefined roles have no `ArangoPermissionRole`
-CRD - they are referenced by their sidecar name directly). The operator merges the
-bound policy into the predefined role, alongside its bundled policy.
+CRD, so `direct` is used instead of the CRD-resolving `name` field). The operator
+merges the bound policy into the predefined role, alongside its bundled policy.
 
 For example, to grant everyone with `coredb-reader` write access on `reports`:
 
@@ -109,7 +110,7 @@ spec:
   deployment:
     name: my-deployment
   role:
-    name: managed:predefined:coredb-reader   # a predefined role - referenced by sidecar name
+    direct: managed:predefined:coredb-reader   # a predefined role - referenced directly by name
   policy:
     name: reports-writer
 ```

--- a/docs/platform/rbac/tokens.md
+++ b/docs/platform/rbac/tokens.md
@@ -3,7 +3,7 @@ layout: page
 title: Permission Tokens
 parent: RBAC
 grand_parent: ArangoDBPlatform
-nav_order: 3
+nav_order: 4
 ---
 
 # Permission Tokens

--- a/docs/platform/rbac/user_bindings.md
+++ b/docs/platform/rbac/user_bindings.md
@@ -3,7 +3,7 @@ layout: page
 title: User Role Bindings
 parent: RBAC
 grand_parent: ArangoDBPlatform
-nav_order: 4
+nav_order: 5
 ---
 
 # User Role Bindings

--- a/internal/actions.yaml
+++ b/internal/actions.yaml
@@ -291,3 +291,7 @@ actions:
     timeout: 24h
     scopes:
       - High
+  SyncRBACPermissions:
+    description: Sync the operator managed predefined RBAC roles into the authorization sidecar (super-admin ships an Allow-all policy bound to the root user; other roles are created empty)
+    scopes:
+      - High

--- a/pkg/apis/deployment/v1/actions.generated.go
+++ b/pkg/apis/deployment/v1/actions.generated.go
@@ -251,6 +251,9 @@ const (
 	// ActionShutdownMemberDefaultTimeout define default timeout for action ActionShutdownMember
 	ActionShutdownMemberDefaultTimeout time.Duration = 1800 * time.Second // 30m0s
 
+	// ActionSyncRBACPermissionsDefaultTimeout define default timeout for action ActionSyncRBACPermissions
+	ActionSyncRBACPermissionsDefaultTimeout time.Duration = ActionsDefaultTimeout
+
 	// ActionTLSKeyStatusUpdateDefaultTimeout define default timeout for action ActionTLSKeyStatusUpdate
 	ActionTLSKeyStatusUpdateDefaultTimeout time.Duration = ActionsDefaultTimeout
 
@@ -527,6 +530,9 @@ const (
 	// ActionTypeShutdownMember in scopes Normal. Sends Shutdown requests and waits for container to be stopped
 	ActionTypeShutdownMember ActionType = "ShutdownMember"
 
+	// ActionTypeSyncRBACPermissions in scopes High. Sync the operator managed predefined RBAC roles into the authorization sidecar (super-admin ships an Allow-all policy bound to the root user; other roles are created empty)
+	ActionTypeSyncRBACPermissions ActionType = "SyncRBACPermissions"
+
 	// ActionTypeTLSKeyStatusUpdate in scopes Normal. Update Status of TLS propagation process
 	ActionTypeTLSKeyStatusUpdate ActionType = "TLSKeyStatusUpdate"
 
@@ -719,6 +725,8 @@ func (a ActionType) DefaultTimeout() time.Duration {
 		return ActionSetMemberCurrentImageDefaultTimeout
 	case ActionTypeShutdownMember:
 		return ActionShutdownMemberDefaultTimeout
+	case ActionTypeSyncRBACPermissions:
+		return ActionSyncRBACPermissionsDefaultTimeout
 	case ActionTypeTLSKeyStatusUpdate:
 		return ActionTLSKeyStatusUpdateDefaultTimeout
 	case ActionTypeTLSPropagated:
@@ -903,6 +911,8 @@ func (a ActionType) Priority() ActionPriority {
 		return ActionPriorityNormal
 	case ActionTypeShutdownMember:
 		return ActionPriorityNormal
+	case ActionTypeSyncRBACPermissions:
+		return ActionPriorityHigh
 	case ActionTypeTLSKeyStatusUpdate:
 		return ActionPriorityNormal
 	case ActionTypeTLSPropagated:
@@ -1112,6 +1122,8 @@ func (a ActionType) Optional() bool {
 	case ActionTypeSetMemberCurrentImage:
 		return false
 	case ActionTypeShutdownMember:
+		return false
+	case ActionTypeSyncRBACPermissions:
 		return false
 	case ActionTypeTLSKeyStatusUpdate:
 		return false

--- a/pkg/apis/deployment/v1/conditions.go
+++ b/pkg/apis/deployment/v1/conditions.go
@@ -65,6 +65,10 @@ const (
 	ConditionTypeTerminating ConditionType = "Terminating"
 	// ConditionTypeUpToDate indicates that the deployment is up to date.
 	ConditionTypeUpToDate ConditionType = "UpToDate"
+	// ConditionTypeRBACBootstrapped indicates that the operator-managed RBAC roles have been
+	// synced to the authorization sidecar. It is present only while RBAC (the gateway
+	// authorization sidecar) is enabled.
+	ConditionTypeRBACBootstrapped ConditionType = "RBACBootstrapped"
 	// ConditionTypeSpecAccepted indicates that the deployment spec has been accepted.
 	ConditionTypeSpecAccepted ConditionType = "SpecAccepted"
 	// ConditionTypeSpecPropagated indicates that the deployment has been at least once UpToDate after spec acceptance.

--- a/pkg/apis/deployment/v2alpha1/actions.generated.go
+++ b/pkg/apis/deployment/v2alpha1/actions.generated.go
@@ -251,6 +251,9 @@ const (
 	// ActionShutdownMemberDefaultTimeout define default timeout for action ActionShutdownMember
 	ActionShutdownMemberDefaultTimeout time.Duration = 1800 * time.Second // 30m0s
 
+	// ActionSyncRBACPermissionsDefaultTimeout define default timeout for action ActionSyncRBACPermissions
+	ActionSyncRBACPermissionsDefaultTimeout time.Duration = ActionsDefaultTimeout
+
 	// ActionTLSKeyStatusUpdateDefaultTimeout define default timeout for action ActionTLSKeyStatusUpdate
 	ActionTLSKeyStatusUpdateDefaultTimeout time.Duration = ActionsDefaultTimeout
 
@@ -527,6 +530,9 @@ const (
 	// ActionTypeShutdownMember in scopes Normal. Sends Shutdown requests and waits for container to be stopped
 	ActionTypeShutdownMember ActionType = "ShutdownMember"
 
+	// ActionTypeSyncRBACPermissions in scopes High. Sync the operator managed predefined RBAC roles into the authorization sidecar (super-admin ships an Allow-all policy bound to the root user; other roles are created empty)
+	ActionTypeSyncRBACPermissions ActionType = "SyncRBACPermissions"
+
 	// ActionTypeTLSKeyStatusUpdate in scopes Normal. Update Status of TLS propagation process
 	ActionTypeTLSKeyStatusUpdate ActionType = "TLSKeyStatusUpdate"
 
@@ -719,6 +725,8 @@ func (a ActionType) DefaultTimeout() time.Duration {
 		return ActionSetMemberCurrentImageDefaultTimeout
 	case ActionTypeShutdownMember:
 		return ActionShutdownMemberDefaultTimeout
+	case ActionTypeSyncRBACPermissions:
+		return ActionSyncRBACPermissionsDefaultTimeout
 	case ActionTypeTLSKeyStatusUpdate:
 		return ActionTLSKeyStatusUpdateDefaultTimeout
 	case ActionTypeTLSPropagated:
@@ -903,6 +911,8 @@ func (a ActionType) Priority() ActionPriority {
 		return ActionPriorityNormal
 	case ActionTypeShutdownMember:
 		return ActionPriorityNormal
+	case ActionTypeSyncRBACPermissions:
+		return ActionPriorityHigh
 	case ActionTypeTLSKeyStatusUpdate:
 		return ActionPriorityNormal
 	case ActionTypeTLSPropagated:
@@ -1112,6 +1122,8 @@ func (a ActionType) Optional() bool {
 	case ActionTypeSetMemberCurrentImage:
 		return false
 	case ActionTypeShutdownMember:
+		return false
+	case ActionTypeSyncRBACPermissions:
 		return false
 	case ActionTypeTLSKeyStatusUpdate:
 		return false

--- a/pkg/apis/deployment/v2alpha1/conditions.go
+++ b/pkg/apis/deployment/v2alpha1/conditions.go
@@ -65,6 +65,10 @@ const (
 	ConditionTypeTerminating ConditionType = "Terminating"
 	// ConditionTypeUpToDate indicates that the deployment is up to date.
 	ConditionTypeUpToDate ConditionType = "UpToDate"
+	// ConditionTypeRBACBootstrapped indicates that the operator-managed RBAC roles have been
+	// synced to the authorization sidecar. It is present only while RBAC (the gateway
+	// authorization sidecar) is enabled.
+	ConditionTypeRBACBootstrapped ConditionType = "RBACBootstrapped"
 	// ConditionTypeSpecAccepted indicates that the deployment spec has been accepted.
 	ConditionTypeSpecAccepted ConditionType = "SpecAccepted"
 	// ConditionTypeSpecPropagated indicates that the deployment has been at least once UpToDate after spec acceptance.

--- a/pkg/apis/permission/definitions.go
+++ b/pkg/apis/permission/definitions.go
@@ -46,4 +46,10 @@ const (
 	// LabelPolicyRoleBindingRole is a label set on ArangoPermissionPolicyRoleBinding
 	// with the name of the referenced ArangoPermissionRole CRD.
 	LabelPolicyRoleBindingRole = ArangoPermissionGroupName + "/role"
+
+	// ManagedPredefinedPrefix is the reserved name prefix of operator-managed predefined roles
+	// (and their policies) created directly in the authorization sidecar. An
+	// ArangoPermissionPolicyRoleBinding may reference such a role by this direct sidecar name -
+	// predefined roles have no ArangoPermissionRole CRD - to attach a policy to it.
+	ManagedPredefinedPrefix = "managed:predefined:"
 )

--- a/pkg/apis/permission/predefined_roles.go
+++ b/pkg/apis/permission/predefined_roles.go
@@ -1,0 +1,66 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package permission
+
+// Predefined role short identifiers. These are the operator-managed roles seeded into every
+// RBAC-enabled deployment's authorization sidecar under the ManagedPredefinedPrefix. This list is
+// the single source of truth for the role names: the reconcile catalog must cover exactly this set,
+// and tests reference these identifiers instead of hard-coding strings.
+const (
+	PredefinedRoleSuperAdmin       = "super-admin"
+	PredefinedRoleTenantAdmin      = "tenant-admin"
+	PredefinedRoleCoreDBReader     = "coredb-reader"
+	PredefinedRoleCoreDBDeveloper  = "coredb-developer"
+	PredefinedRoleCoreDBAdmin      = "coredb-admin"
+	PredefinedRoleAIUser           = "ai-user"
+	PredefinedRoleAIDeveloper      = "ai-developer"
+	PredefinedRolePlatformOperator = "platform-operator"
+	PredefinedRoleSecretAdmin      = "secret-admin"
+)
+
+// PredefinedRoleNames is the ordered catalog of predefined role short identifiers created in every
+// RBAC-enabled deployment. The reconcile catalog must cover exactly this set (asserted by unit
+// test), and tests iterate it to verify every role exists in the sidecar.
+var PredefinedRoleNames = []string{
+	PredefinedRoleSuperAdmin,
+	PredefinedRoleTenantAdmin,
+	PredefinedRoleCoreDBReader,
+	PredefinedRoleCoreDBDeveloper,
+	PredefinedRoleCoreDBAdmin,
+	PredefinedRoleAIUser,
+	PredefinedRoleAIDeveloper,
+	PredefinedRolePlatformOperator,
+	PredefinedRoleSecretAdmin,
+}
+
+// ManagedPredefinedRoleName returns the reserved sidecar object name for a predefined role short
+// identifier, e.g. "coredb-reader" -> "managed:predefined:coredb-reader".
+func ManagedPredefinedRoleName(name string) string {
+	return ManagedPredefinedPrefix + name
+}
+
+// IsReservedRoleName reports whether an authorization role name is reserved and must not be
+// referenced by customer-created bindings. The predefined super-admin role is reserved: it grants
+// full access and the operator binds it to the deployment root user automatically, so allowing a
+// customer to assign it would be a privilege escalation.
+func IsReservedRoleName(name string) bool {
+	return name == ManagedPredefinedRoleName(PredefinedRoleSuperAdmin)
+}

--- a/pkg/apis/permission/v1alpha1/binding_ref.go
+++ b/pkg/apis/permission/v1alpha1/binding_ref.go
@@ -27,17 +27,29 @@ import (
 	"github.com/arangodb/kube-arangodb/pkg/util/errors"
 )
 
-// ArangoPermissionBindingRef defines a reference to a permission resource by ArangoPermission CRD name.
+// ArangoPermissionBindingRef defines a reference to a permission resource, either an
+// ArangoPermission CRD by name or an existing authorization sidecar object by its direct name.
 type ArangoPermissionBindingRef struct {
 	// Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
 	Name string `json:"name,omitempty"`
+
+	// Direct references an existing authorization object (role or policy) by its exact name, without
+	// a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+	// "managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+	// must be set.
+	Direct string `json:"direct,omitempty"`
 }
 
 func (r *ArangoPermissionBindingRef) Hash() string {
 	if r == nil {
 		return ""
 	}
-	return util.SHA256FromStringArray(r.Name)
+	return util.SHA256FromStringArray(r.Name, r.Direct)
+}
+
+// IsDirect reports whether this reference targets an authorization object directly by name (no CRD lookup).
+func (r *ArangoPermissionBindingRef) IsDirect() bool {
+	return r != nil && r.Direct != ""
 }
 
 func (r *ArangoPermissionBindingRef) Validate() error {
@@ -45,8 +57,12 @@ func (r *ArangoPermissionBindingRef) Validate() error {
 		return errors.Errorf("is required")
 	}
 
-	if r.Name == "" {
-		return errors.Errorf("name is required")
+	if r.Name != "" && r.Direct != "" {
+		return errors.Errorf("name and direct are mutually exclusive")
+	}
+
+	if r.Name == "" && r.Direct == "" {
+		return errors.Errorf("one of name or direct is required")
 	}
 
 	return nil
@@ -63,12 +79,16 @@ func (l ArangoPermissionBindingRefList) Hash() string {
 	return util.SHA256FromStringArray(hashes...)
 }
 
-// GetReference returns the CRD name if set, empty string otherwise
+// GetReference returns the effective reference: the direct name when Direct is set (used as-is),
+// otherwise the CRD name.
 func (r *ArangoPermissionBindingRef) GetReference() string {
-	if r != nil {
-		return r.Name
+	if r == nil {
+		return ""
 	}
-	return ""
+	if r.Direct != "" {
+		return r.Direct
+	}
+	return r.Name
 }
 
 // ArangoPermissionScope defines a scope boundary as either an inline policy

--- a/pkg/apis/permission/v1alpha1/binding_ref_test.go
+++ b/pkg/apis/permission/v1alpha1/binding_ref_test.go
@@ -1,0 +1,57 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ArangoPermissionBindingRef(t *testing.T) {
+	t.Run("Validate", func(t *testing.T) {
+		require.Error(t, (*ArangoPermissionBindingRef)(nil).Validate())
+		require.Error(t, (&ArangoPermissionBindingRef{}).Validate(), "neither name nor direct")
+		require.Error(t, (&ArangoPermissionBindingRef{Name: "r", Direct: "managed:predefined:coredb-reader"}).Validate(), "both set is mutually exclusive")
+		require.NoError(t, (&ArangoPermissionBindingRef{Name: "r"}).Validate())
+		require.NoError(t, (&ArangoPermissionBindingRef{Direct: "managed:predefined:coredb-reader"}).Validate())
+	})
+
+	t.Run("IsDirect", func(t *testing.T) {
+		require.False(t, (*ArangoPermissionBindingRef)(nil).IsDirect())
+		require.False(t, (&ArangoPermissionBindingRef{Name: "r"}).IsDirect())
+		require.True(t, (&ArangoPermissionBindingRef{Direct: "managed:predefined:coredb-reader"}).IsDirect())
+	})
+
+	t.Run("GetReference", func(t *testing.T) {
+		require.Equal(t, "", (*ArangoPermissionBindingRef)(nil).GetReference())
+		require.Equal(t, "r", (&ArangoPermissionBindingRef{Name: "r"}).GetReference())
+		// Direct is used as-is and takes precedence over the resolved CRD name.
+		require.Equal(t, "managed:predefined:coredb-reader", (&ArangoPermissionBindingRef{Direct: "managed:predefined:coredb-reader"}).GetReference())
+	})
+
+	t.Run("Hash reacts to direct", func(t *testing.T) {
+		require.NotEqual(t,
+			(&ArangoPermissionBindingRef{Name: "coredb-reader"}).Hash(),
+			(&ArangoPermissionBindingRef{Direct: "coredb-reader"}).Hash(),
+			"a CRD name and a direct name must not collide")
+	})
+}

--- a/pkg/apis/permission/v1alpha1/policy_role_binding_spec.go
+++ b/pkg/apis/permission/v1alpha1/policy_role_binding_spec.go
@@ -21,6 +21,7 @@
 package v1alpha1
 
 import (
+	"github.com/arangodb/kube-arangodb/pkg/apis/permission"
 	shared "github.com/arangodb/kube-arangodb/pkg/apis/shared"
 	sharedApi "github.com/arangodb/kube-arangodb/pkg/apis/shared/v1"
 	"github.com/arangodb/kube-arangodb/pkg/util"
@@ -64,5 +65,13 @@ func (c *ArangoPermissionPolicyRoleBindingSpec) Validate() error {
 		shared.ValidateRequiredInterfacePath("deployment", c.Deployment),
 		shared.ValidateRequiredInterfacePath("policy", c.Policy),
 		shared.ValidateRequiredInterfacePath("role", c.Role),
+		func() error {
+			// The super-admin role is reserved and already grants full access; customers must not
+			// attach policies to it.
+			if permission.IsReservedRoleName(c.Role.GetReference()) {
+				return errors.Errorf("role %q is reserved and cannot be modified", c.Role.GetReference())
+			}
+			return nil
+		}(),
 	)
 }

--- a/pkg/apis/permission/v1alpha1/reserved_role_test.go
+++ b/pkg/apis/permission/v1alpha1/reserved_role_test.go
@@ -1,0 +1,68 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arangodb/kube-arangodb/pkg/apis/permission"
+	permissionApiPolicy "github.com/arangodb/kube-arangodb/pkg/apis/permission/v1alpha1/policy"
+	sharedApi "github.com/arangodb/kube-arangodb/pkg/apis/shared/v1"
+)
+
+// Test_ReservedRole_NotAssignable asserts the operator refuses customer bindings that reference the
+// reserved super-admin role - the enforcement behind the "not assignable by customers" guarantee.
+func Test_ReservedRole_NotAssignable(t *testing.T) {
+	depl := &sharedApi.Object{Name: "depl"}
+	scope := &permissionApiPolicy.Policy{Statements: permissionApiPolicy.Statements{
+		{Effect: permissionApiPolicy.EffectAllow, Actions: permissionApiPolicy.Actions{"*"}, Resources: permissionApiPolicy.Resources{"*"}},
+	}}
+	superAdmin := permission.ManagedPredefinedRoleName(permission.PredefinedRoleSuperAdmin)
+	coreDBReader := permission.ManagedPredefinedRoleName(permission.PredefinedRoleCoreDBReader)
+
+	t.Run("RoleUserBinding rejects super-admin", func(t *testing.T) {
+		require.ErrorContains(t, (&ArangoPermissionRoleUserBindingSpec{
+			Deployment: depl,
+			Role:       &ArangoPermissionBindingRef{Direct: superAdmin},
+			UserName:   "alice",
+			Scope:      scope,
+		}).Validate(), "reserved")
+	})
+
+	t.Run("RoleUserBinding allows a normal predefined role", func(t *testing.T) {
+		require.NoError(t, (&ArangoPermissionRoleUserBindingSpec{
+			Deployment: depl,
+			Role:       &ArangoPermissionBindingRef{Direct: coreDBReader},
+			UserName:   "alice",
+			Scope:      scope,
+		}).Validate())
+	})
+
+	t.Run("PolicyRoleBinding rejects super-admin", func(t *testing.T) {
+		require.ErrorContains(t, (&ArangoPermissionPolicyRoleBindingSpec{
+			Deployment: depl,
+			Policy:     &ArangoPermissionBindingRef{Name: "p"},
+			Role:       &ArangoPermissionBindingRef{Direct: superAdmin},
+		}).Validate(), "reserved")
+	})
+}

--- a/pkg/apis/permission/v1alpha1/role_user_binding_spec.go
+++ b/pkg/apis/permission/v1alpha1/role_user_binding_spec.go
@@ -21,6 +21,7 @@
 package v1alpha1
 
 import (
+	"github.com/arangodb/kube-arangodb/pkg/apis/permission"
 	permissionApiPolicy "github.com/arangodb/kube-arangodb/pkg/apis/permission/v1alpha1/policy"
 	shared "github.com/arangodb/kube-arangodb/pkg/apis/shared"
 	sharedApi "github.com/arangodb/kube-arangodb/pkg/apis/shared/v1"
@@ -69,6 +70,14 @@ func (c *ArangoPermissionRoleUserBindingSpec) Validate() error {
 	return shared.WithErrors(
 		shared.ValidateRequiredInterfacePath("deployment", c.Deployment),
 		shared.ValidateRequiredInterfacePath("role", c.Role),
+		func() error {
+			// The super-admin role is reserved: it grants full access and is bound to the root user
+			// automatically, so it must not be assignable to a user by a customer binding.
+			if permission.IsReservedRoleName(c.Role.GetReference()) {
+				return errors.Errorf("role %q is reserved and cannot be assigned", c.Role.GetReference())
+			}
+			return nil
+		}(),
 		func() error {
 			if c.UserName == "" {
 				return errors.Errorf("userName is required")

--- a/pkg/crd/crds/permission-policy-role-binding.schema.generated.yaml
+++ b/pkg/crd/crds/permission-policy-role-binding.schema.generated.yaml
@@ -15,6 +15,13 @@ v1alpha1:
           policy:
             description: Policy defines the policy to bind, either by CRD name or direct sidecar name
             properties:
+              direct:
+                description: |-
+                  Direct references an existing authorization object (role or policy) by its exact name, without
+                  a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+                  "managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+                  must be set.
+                type: string
               name:
                 description: Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
                 type: string
@@ -22,6 +29,13 @@ v1alpha1:
           role:
             description: Role defines the role to bind to, either by CRD name or direct sidecar name
             properties:
+              direct:
+                description: |-
+                  Direct references an existing authorization object (role or policy) by its exact name, without
+                  a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+                  "managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+                  must be set.
+                type: string
               name:
                 description: Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
                 type: string

--- a/pkg/crd/crds/permission-role-user-binding.schema.generated.yaml
+++ b/pkg/crd/crds/permission-role-user-binding.schema.generated.yaml
@@ -15,6 +15,13 @@ v1alpha1:
           role:
             description: Role defines the role to bind, either by CRD name or direct sidecar name
             properties:
+              direct:
+                description: |-
+                  Direct references an existing authorization object (role or policy) by its exact name, without
+                  a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+                  "managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+                  must be set.
+                type: string
               name:
                 description: Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
                 type: string

--- a/pkg/crd/crds/permission-token.schema.generated.yaml
+++ b/pkg/crd/crds/permission-token.schema.generated.yaml
@@ -61,6 +61,13 @@ v1alpha1:
                 role:
                   description: Role references an ArangoPermissionRole CRD by name
                   properties:
+                    direct:
+                      description: |-
+                        Direct references an existing authorization object (role or policy) by its exact name, without
+                        a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+                        "managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+                        must be set.
+                      type: string
                     name:
                       description: Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
                       type: string
@@ -111,6 +118,13 @@ v1alpha1:
                     ref:
                       description: Ref references an ArangoPermissionPolicy CRD to use as boundary
                       properties:
+                        direct:
+                          description: |-
+                            Direct references an existing authorization object (role or policy) by its exact name, without
+                            a backing ArangoPermission CRD - e.g. an operator-managed predefined role
+                            "managed:predefined:coredb-reader". The value is used as-is. Exactly one of Name or Direct
+                            must be set.
+                          type: string
                         name:
                           description: Name references an ArangoPermission CRD by name. The operator resolves it to the sidecar name.
                           type: string

--- a/pkg/deployment/deployment_inspector.go
+++ b/pkg/deployment/deployment_inspector.go
@@ -372,6 +372,26 @@ func (d *Deployment) inspectDeploymentWithError(ctx context.Context, lastInterva
 		}
 	}
 
+	// RBAC bootstrap condition. While the authorization sidecar (RBAC) is enabled, ensure the
+	// condition is present (starting false) so UpToDate waits until the SyncRBACPermissions
+	// action reports the sync as successful (which sets it true). When RBAC is disabled, remove
+	// the condition. This is managed here - not behind the sync back-off - so the condition
+	// appears without delay.
+	_, rbacConditionExists := status.Conditions.Get(api.ConditionTypeRBACBootstrapped)
+	if status.Conditions.IsTrue(api.ConditionTypeGatewaySidecarEnabled) {
+		if !rbacConditionExists {
+			if err = d.updateConditionWithHash(ctx, api.ConditionTypeRBACBootstrapped, false, "RBAC Bootstrap Pending", "Waiting for RBAC permissions to be synced", ""); err != nil {
+				return minInspectionInterval, errors.Wrapf(err, "Unable to update RBACBootstrapped condition")
+			}
+		}
+	} else if rbacConditionExists {
+		if err = d.WithStatusUpdate(ctx, func(s *api.DeploymentStatus) bool {
+			return s.Conditions.Remove(api.ConditionTypeRBACBootstrapped)
+		}); err != nil {
+			return minInspectionInterval, errors.Wrapf(err, "Unable to remove RBACBootstrapped condition")
+		}
+	}
+
 	if v := status.AcceptedSpecVersion; v != nil && d.currentObject.Status.IsPlanEmpty() && status.AppliedVersion != *v {
 		if err := d.WithStatusUpdate(ctx, func(s *api.DeploymentStatus) bool {
 			s.AppliedVersion = *v
@@ -480,6 +500,13 @@ func (d *Deployment) isUpToDateStatus(spec api.DeploymentSpec, status api.Deploy
 
 	if !status.Conditions.Check(api.ConditionTypeReachable).Exists().IsTrue().Evaluate() {
 		reason = "ArangoDB is not reachable"
+		upToDate = false
+		return
+	}
+
+	if status.Conditions.IsTrue(api.ConditionTypeGatewaySidecarEnabled) &&
+		!status.Conditions.Check(api.ConditionTypeRBACBootstrapped).Exists().IsTrue().Evaluate() {
+		reason = "RBAC is not bootstrapped"
 		upToDate = false
 		return
 	}

--- a/pkg/deployment/reconcile/action.register.generated.go
+++ b/pkg/deployment/reconcile/action.register.generated.go
@@ -19,8 +19,9 @@
 package reconcile
 
 import (
-	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
 	"time"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
 )
 
 var (

--- a/pkg/deployment/reconcile/action.register.generated.go
+++ b/pkg/deployment/reconcile/action.register.generated.go
@@ -19,9 +19,8 @@
 package reconcile
 
 import (
-	"time"
-
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"time"
 )
 
 var (
@@ -236,6 +235,9 @@ var (
 
 	_ Action        = &actionShutdownMember{}
 	_ actionFactory = newShutdownMemberAction
+
+	_ Action        = &actionSyncRBACPermissions{}
+	_ actionFactory = newSyncRBACPermissionsAction
 
 	_ Action        = &actionTLSKeyStatusUpdate{}
 	_ actionFactory = newTLSKeyStatusUpdateAction
@@ -1329,6 +1331,20 @@ func init() {
 
 		// With StartupFailureGracePeriod
 		function = withActionStartFailureGracePeriod(function, 60*time.Second)
+
+		// Register action
+		registerAction(action, function)
+	}
+
+	// SyncRBACPermissions
+	{
+		// Get Action type
+		action := api.ActionTypeSyncRBACPermissions
+
+		// Get Action defition
+		function := newSyncRBACPermissionsAction
+
+		// Wrap action main function
 
 		// Register action
 		registerAction(action, function)

--- a/pkg/deployment/reconcile/action.register.generated_test.go
+++ b/pkg/deployment/reconcile/action.register.generated_test.go
@@ -798,6 +798,16 @@ func Test_Actions(t *testing.T) {
 		})
 	})
 
+	t.Run("SyncRBACPermissions", func(t *testing.T) {
+		ActionsExistence(t, api.ActionTypeSyncRBACPermissions)
+		t.Run("Internal", func(t *testing.T) {
+			require.False(t, api.ActionTypeSyncRBACPermissions.Internal())
+		})
+		t.Run("Optional", func(t *testing.T) {
+			require.False(t, api.ActionTypeSyncRBACPermissions.Optional())
+		})
+	})
+
 	t.Run("TLSKeyStatusUpdate", func(t *testing.T) {
 		ActionsExistence(t, api.ActionTypeTLSKeyStatusUpdate)
 		t.Run("Internal", func(t *testing.T) {

--- a/pkg/deployment/reconcile/action_sync_rbac_permissions.go
+++ b/pkg/deployment/reconcile/action_sync_rbac_permissions.go
@@ -1,0 +1,83 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package reconcile
+
+import (
+	"context"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/util/errors"
+)
+
+func newSyncRBACPermissionsAction(action api.Action, actionCtx ActionContext) Action {
+	a := &actionSyncRBACPermissions{}
+
+	a.actionImpl = newActionImplDefRef(action, actionCtx)
+
+	return a
+}
+
+// actionSyncRBACPermissions ensures the operator-managed predefined roles are present in the
+// authorization sidecar. It connects to the sidecar and upserts the predefined roles (and, for
+// super-admin, its policy and the root user binding) directly through the authorization API (no
+// intermediate CRs). It is idempotent, so the throttled high plan builder can re-run it to
+// recreate or repair drift.
+type actionSyncRBACPermissions struct {
+	actionImpl
+
+	actionEmptyCheckProgress
+}
+
+func (a actionSyncRBACPermissions) Start(ctx context.Context) (bool, error) {
+	depl, ok := a.actionCtx.GetAPIObject().(*api.ArangoDeployment)
+	if !ok {
+		return false, errors.Errorf("Unable to sync RBAC permissions: API object is not an ArangoDeployment")
+	}
+
+	client := a.actionCtx.ACS().CurrentClusterCache().Client()
+	ns := a.actionCtx.GetNamespace()
+
+	conn, closeConn, enabled, err := managedRBACClient(client.Kubernetes(), depl)
+	if err != nil {
+		return false, err
+	}
+
+	if !enabled {
+		// Authorization sidecar is not enabled - nothing to sync. The plan builder gates on
+		// the same condition, so this is only reached on a race.
+		return true, nil
+	}
+	defer closeConn()
+
+	if err := syncRBACPermissions(ctx, conn, func(roleName string) ([]string, error) {
+		return collectBoundPolicies(ctx, client.Arango(), ns, roleName)
+	}); err != nil {
+		return false, err
+	}
+
+	// Report the sync as successful so the RBACBootstrapped condition (and UpToDate through it)
+	// can become true.
+	if err := a.actionCtx.UpdateClusterCondition(ctx, api.ConditionTypeRBACBootstrapped, true, "RBAC Bootstrapped", "RBAC permissions have been synced"); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/deployment/reconcile/plan_builder.go
+++ b/pkg/deployment/reconcile/plan_builder.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/deployment/reconcile/plan_builder.go
+++ b/pkg/deployment/reconcile/plan_builder.go
@@ -32,9 +32,10 @@ const (
 )
 
 const (
-	BackOffCheck  api.BackOffKey = "check"
-	LicenseCheck  api.BackOffKey = "license"
-	TimezoneCheck api.BackOffKey = "timezone"
+	BackOffCheck             api.BackOffKey = "check"
+	LicenseCheck             api.BackOffKey = "license"
+	TimezoneCheck            api.BackOffKey = "timezone"
+	SyncRBACPermissionsCheck api.BackOffKey = "syncRBACPermissions"
 )
 
 // CreatePlan considers the current specification & status of the deployment creates a plan to

--- a/pkg/deployment/reconcile/plan_builder_high.go
+++ b/pkg/deployment/reconcile/plan_builder_high.go
@@ -76,6 +76,7 @@ func (r *Reconciler) createHighPlan(ctx context.Context, apiObject k8sutil.APIOb
 		ApplyIfEmpty(r.volumeMemberReplacement).
 		ApplyWithBackOff(BackOffCheck, time.Minute, r.emptyPlanBuilder)).
 		ApplyIfEmptyWithBackOff(TimezoneCheck, time.Minute, r.createTimezoneUpdatePlan).
+		ApplyIfEmptyWithBackOff(SyncRBACPermissionsCheck, 30*time.Second, r.createSyncRBACPermissionsPlan).
 		Apply(r.createBackupInProgressConditionPlan).
 		Apply(r.createMaintenanceConditionPlan).
 		Apply(r.cleanupConditions).
@@ -332,5 +333,27 @@ func (r *Reconciler) updateMemberRotationConditions(apiObject k8sutil.APIObject,
 		default:
 			return nil, nil
 		}
+	}
+}
+
+// createSyncRBACPermissionsPlan proposes the SyncRBACPermissions action once the deployment
+// bootstrap has completed (the root user has been created) and the authorization sidecar is
+// enabled. The action ensures the operator-managed root RBAC objects (Allow-all policy, role
+// and root user binding) exist in the sidecar so the root user retains full access. It is
+// registered under a back-off, so it re-runs periodically to recreate or repair those objects
+// should they be deleted or drift.
+func (r *Reconciler) createSyncRBACPermissionsPlan(ctx context.Context, apiObject k8sutil.APIObject,
+	spec api.DeploymentSpec, status api.DeploymentStatus,
+	context PlanBuilderContext) api.Plan {
+	if !status.Conditions.IsTrue(api.ConditionTypeBootstrapCompleted) {
+		return nil
+	}
+
+	if !status.Conditions.IsTrue(api.ConditionTypeGatewaySidecarEnabled) {
+		return nil
+	}
+
+	return api.Plan{
+		actions.NewClusterAction(api.ActionTypeSyncRBACPermissions, "Sync operator managed root RBAC objects"),
 	}
 }

--- a/pkg/deployment/reconcile/plan_builder_rbac.go
+++ b/pkg/deployment/reconcile/plan_builder_rbac.go
@@ -88,41 +88,41 @@ type predefinedRole struct {
 // authorization sidecar. Descriptions are taken from the RBAC product definition.
 var predefinedRoles = []predefinedRole{
 	{
-		Name:         "super-admin",
+		Name:         permission.PredefinedRoleSuperAdmin,
 		Description:  "Reserved role providing full access to all functionality. Cannot be assigned by the customer.",
 		Statements:   allowAllStatements(),
 		BindRootUser: true,
 	},
 	{
-		Name:        "tenant-admin",
+		Name:        permission.PredefinedRoleTenantAdmin,
 		Description: "Manages users and role bindings.",
 	},
 	{
-		Name:        "coredb-reader",
+		Name:        permission.PredefinedRoleCoreDBReader,
 		Description: "Reads scoped resources and executes read-only database operations.",
 	},
 	{
-		Name:        "coredb-developer",
+		Name:        permission.PredefinedRoleCoreDBDeveloper,
 		Description: "Reads and writes scoped resources and executes read and write database operations.",
 	},
 	{
-		Name:        "coredb-admin",
+		Name:        permission.PredefinedRoleCoreDBAdmin,
 		Description: "Manages scoped resources' structures and lifecycle.",
 	},
 	{
-		Name:        "ai-user",
+		Name:        permission.PredefinedRoleAIUser,
 		Description: "Executes AI workflows and reads resulting outputs within scoped resources.",
 	},
 	{
-		Name:        "ai-developer",
+		Name:        permission.PredefinedRoleAIDeveloper,
 		Description: "Builds, configures, manages, and executes AI workflows and artifacts within scoped resources.",
 	},
 	{
-		Name:        "platform-operator",
+		Name:        permission.PredefinedRolePlatformOperator,
 		Description: "Operates platform services, manages bundled services, views observability, and starts containers within scoped resources.",
 	},
 	{
-		Name:        "secret-admin",
+		Name:        permission.PredefinedRoleSecretAdmin,
 		Description: "Manages secrets within scoped resources.",
 	},
 }

--- a/pkg/deployment/reconcile/plan_builder_rbac.go
+++ b/pkg/deployment/reconcile/plan_builder_rbac.go
@@ -1,0 +1,346 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package reconcile
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/apis/permission"
+	permissionApi "github.com/arangodb/kube-arangodb/pkg/apis/permission/v1alpha1"
+	versioned "github.com/arangodb/kube-arangodb/pkg/generated/clientset/versioned"
+	sidecarSvcAuthzDefinition "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/definition"
+	sidecarSvcAuthzTypes "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/types"
+	"github.com/arangodb/kube-arangodb/pkg/util"
+	"github.com/arangodb/kube-arangodb/pkg/util/integration"
+	utilToken "github.com/arangodb/kube-arangodb/pkg/util/token"
+)
+
+// managedObjectPrefix marks these authorization sidecar objects as operator-managed predefined
+// roles. Predefined roles are visible to customers but not editable; a policy can be attached
+// to one through an ArangoPermissionPolicyRoleBinding that references it by this name.
+const managedObjectPrefix = permission.ManagedPredefinedPrefix
+
+// managedRoleName builds the sidecar object name for a predefined role. A role and its policy
+// share the same name (they live in separate policy/role collections, so there is no clash).
+func managedRoleName(name string) string { return managedObjectPrefix + name }
+
+// allowAllStatements permits every action on every resource (`*` action / `*` resource).
+func allowAllStatements() []*sidecarSvcAuthzTypes.PolicyStatement {
+	return []*sidecarSvcAuthzTypes.PolicyStatement{
+		{
+			Effect:    sidecarSvcAuthzTypes.Effect_Allow,
+			Actions:   []string{"*"},
+			Resources: []string{"*"},
+		},
+	}
+}
+
+// allowAllScope is the Allow-all scope bound to the root user (`*` with scoping `*`).
+func allowAllScope() *sidecarSvcAuthzTypes.Policy {
+	return &sidecarSvcAuthzTypes.Policy{Statements: allowAllStatements()}
+}
+
+// predefinedRole is an operator-managed role synced into the authorization sidecar. Customers
+// can assign and scope these roles but cannot edit them. Only the super-admin role ships with
+// a policy and is bound to the root user; the remaining roles are created as empty containers
+// whose policies are defined in a later iteration.
+type predefinedRole struct {
+	// Name is the short, hyphenated role identifier, e.g. "coredb-reader".
+	Name string
+
+	// Description is the human-readable description surfaced to the UI.
+	Description string
+
+	// Statements, when set, are attached to the role through an operator-managed policy.
+	Statements []*sidecarSvcAuthzTypes.PolicyStatement
+
+	// BindRootUser binds the deployment root user to this role with an Allow-all scope.
+	BindRootUser bool
+}
+
+// predefinedRoles is the catalog of operator-managed roles created in every deployment's
+// authorization sidecar. Descriptions are taken from the RBAC product definition.
+var predefinedRoles = []predefinedRole{
+	{
+		Name:         "super-admin",
+		Description:  "Reserved role providing full access to all functionality. Cannot be assigned by the customer.",
+		Statements:   allowAllStatements(),
+		BindRootUser: true,
+	},
+	{
+		Name:        "tenant-admin",
+		Description: "Manages users and role bindings.",
+	},
+	{
+		Name:        "coredb-reader",
+		Description: "Reads scoped resources and executes read-only database operations.",
+	},
+	{
+		Name:        "coredb-developer",
+		Description: "Reads and writes scoped resources and executes read and write database operations.",
+	},
+	{
+		Name:        "coredb-admin",
+		Description: "Manages scoped resources' structures and lifecycle.",
+	},
+	{
+		Name:        "ai-user",
+		Description: "Executes AI workflows and reads resulting outputs within scoped resources.",
+	},
+	{
+		Name:        "ai-developer",
+		Description: "Builds, configures, manages, and executes AI workflows and artifacts within scoped resources.",
+	},
+	{
+		Name:        "platform-operator",
+		Description: "Operates platform services, manages bundled services, views observability, and starts containers within scoped resources.",
+	},
+	{
+		Name:        "secret-admin",
+		Description: "Manages secrets within scoped resources.",
+	},
+}
+
+// managedRBACClient opens an authorization sidecar client for the deployment. `enabled` is
+// false (with a nil client) when the deployment does not run the gateway/authorization
+// sidecar. The returned close function must be called when the client is no longer needed.
+func managedRBACClient(kube kubernetes.Interface, depl *api.ArangoDeployment) (sidecarSvcAuthzDefinition.AuthorizationAPIClient, func() error, bool, error) {
+	conn, enabled, err := integration.NewIntegrationConnectionFromDeployment(kube, depl, utilToken.WithRelativeDuration(time.Minute))
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	if !enabled {
+		return nil, nil, false, nil
+	}
+
+	return sidecarSvcAuthzDefinition.NewAuthorizationAPIClient(conn), conn.Close, true, nil
+}
+
+// syncRBACPermissions ensures the operator-managed predefined roles exist in the authorization
+// sidecar and match their canonical definition, merged with any policies customers have attached
+// through ArangoPermissionPolicyRoleBindings. `boundPolicies` returns the sidecar policy names
+// attached to a role by such bindings. It is idempotent - missing objects are created and
+// drifted ones are repaired - so it is safe to run repeatedly.
+func syncRBACPermissions(ctx context.Context, conn sidecarSvcAuthzDefinition.AuthorizationAPIClient, boundPolicies func(roleName string) ([]string, error)) error {
+	for _, role := range predefinedRoles {
+		extra, err := boundPolicies(managedRoleName(role.Name))
+		if err != nil {
+			return err
+		}
+
+		if err := ensurePredefinedRole(ctx, conn, role, extra); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensurePredefinedRole(ctx context.Context, conn sidecarSvcAuthzDefinition.AuthorizationAPIClient, r predefinedRole, boundPolicies []string) error {
+	name := managedRoleName(r.Name)
+
+	var policies []string
+
+	if len(r.Statements) > 0 {
+		// The bundled policy shares the role name.
+		if err := ensureManagedPolicy(ctx, conn, name, &sidecarSvcAuthzTypes.Policy{
+			Description: r.Description,
+			Statements:  r.Statements,
+		}); err != nil {
+			return err
+		}
+
+		policies = append(policies, name)
+	}
+
+	// Merge in policies attached to this role via ArangoPermissionPolicyRoleBindings.
+	policies = append(policies, boundPolicies...)
+	policies = util.UniqueList(policies)
+	sort.Strings(policies)
+
+	if err := ensureManagedRole(ctx, conn, name, &sidecarSvcAuthzTypes.Role{
+		Description: r.Description,
+		Policies:    policies,
+	}); err != nil {
+		return err
+	}
+
+	if r.BindRootUser {
+		return ensureRootUserRoleBinding(ctx, conn, name)
+	}
+
+	return nil
+}
+
+// collectBoundPolicies lists the ArangoPermissionPolicyRoleBindings that target the given
+// predefined role and resolves their policy CRD references to sidecar policy names, mirroring
+// the aggregation the ArangoPermissionRole handler performs for CRD roles.
+func collectBoundPolicies(ctx context.Context, arango versioned.Interface, ns, roleName string) ([]string, error) {
+	bindings, err := arango.PermissionV1alpha1().ArangoPermissionPolicyRoleBindings(ns).List(ctx, meta.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var policies []string
+	seen := map[string]struct{}{}
+
+	for i := range bindings.Items {
+		b := &bindings.Items[i]
+
+		if b.Spec.Role.GetReference() != roleName {
+			continue
+		}
+
+		if !b.Status.Conditions.IsTrue(permissionApi.ReadyPolicyCondition) || !b.Status.Conditions.IsTrue(permissionApi.ReadyRoleCondition) {
+			continue
+		}
+
+		if b.Spec.Policy == nil {
+			continue
+		}
+
+		policyObj, err := arango.PermissionV1alpha1().ArangoPermissionPolicies(ns).Get(ctx, b.Spec.Policy.GetReference(), meta.GetOptions{})
+		if err != nil {
+			continue
+		}
+
+		if !policyObj.Ready() || policyObj.Status.Policy == nil {
+			continue
+		}
+
+		name := policyObj.Status.Policy.GetName()
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		policies = append(policies, name)
+	}
+
+	sort.Strings(policies)
+
+	return policies, nil
+}
+
+func ensureManagedPolicy(ctx context.Context, conn sidecarSvcAuthzDefinition.AuthorizationAPIClient, name string, desired *sidecarSvcAuthzTypes.Policy) error {
+	existing, err := conn.APIGetPolicy(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPINamedRequest{Name: name})
+	if err != nil {
+		if status.Code(err) != codes.NotFound {
+			return err
+		}
+
+		if _, err := conn.APICreatePolicy(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPIPolicyRequest{Name: name, Item: desired}); err != nil {
+			if status.Code(err) != codes.AlreadyExists {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if existing.GetItem().Hash() == desired.Hash() {
+		return nil
+	}
+
+	_, err = conn.APIUpdatePolicy(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPIPolicyRequest{Name: name, Item: desired})
+	return err
+}
+
+func ensureManagedRole(ctx context.Context, conn sidecarSvcAuthzDefinition.AuthorizationAPIClient, name string, desired *sidecarSvcAuthzTypes.Role) error {
+	existing, err := conn.APIGetRole(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPINamedRequest{Name: name})
+	if err != nil {
+		if status.Code(err) != codes.NotFound {
+			return err
+		}
+
+		if _, err := conn.APICreateRole(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPIRoleRequest{Name: name, Item: desired}); err != nil {
+			if status.Code(err) != codes.AlreadyExists {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if existing.GetItem().Hash() == desired.Hash() {
+		return nil
+	}
+
+	_, err = conn.APIUpdateRole(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPIRoleRequest{Name: name, Item: desired})
+	return err
+}
+
+func ensureRootUserRoleBinding(ctx context.Context, conn sidecarSvcAuthzDefinition.AuthorizationAPIClient, roleName string) error {
+	desiredScope := allowAllScope()
+
+	bindings, err := conn.APIListUserRoleBindings(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPIUserRequest{User: api.UserNameRoot})
+	if err != nil {
+		if status.Code(err) != codes.NotFound {
+			return err
+		}
+	}
+
+	if bindings != nil {
+		for _, b := range bindings.GetBindings() {
+			if b.GetRole() != roleName {
+				continue
+			}
+
+			// Binding exists - repair the scope only when it has drifted.
+			var currentScopeHash string
+			if s := b.GetScope(); s != nil {
+				currentScopeHash = s.Hash()
+			}
+
+			if currentScopeHash == desiredScope.Hash() {
+				return nil
+			}
+
+			_, err := conn.APIReplaceUserRoleScope(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingRequest{
+				User:  api.UserNameRoot,
+				Role:  roleName,
+				Scope: desiredScope,
+			})
+			return err
+		}
+	}
+
+	// Binding missing - assign it.
+	if _, err := conn.APIAssignUserRole(ctx, &sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingRequest{
+		User:  api.UserNameRoot,
+		Role:  roleName,
+		Scope: desiredScope,
+	}); err != nil {
+		if status.Code(err) != codes.AlreadyExists {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/deployment/reconcile/plan_builder_rbac_test.go
+++ b/pkg/deployment/reconcile/plan_builder_rbac_test.go
@@ -1,0 +1,260 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package reconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	sidecarSvcAuthzDefinition "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/definition"
+	sidecarSvcAuthzTypes "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/types"
+)
+
+// Test_predefinedRoles_catalog verifies the predefined-role catalog: super-admin is the only
+// role that ships with an Allow-all policy and a root binding, every role is namespaced under
+// managed:predefined:, hyphenated and described, and names are unique.
+func Test_predefinedRoles_catalog(t *testing.T) {
+	require.Equal(t, "managed:predefined:", managedObjectPrefix)
+	require.Equal(t, "managed:predefined:super-admin", managedRoleName("super-admin"))
+
+	names := map[string]bool{}
+	var bound []string
+
+	for _, r := range predefinedRoles {
+		require.NotEmpty(t, r.Description, "%s must have a description", r.Name)
+		require.Regexp(t, `^[a-z]+(-[a-z]+)*$`, r.Name, "role name must be hyphenated lower-case")
+		require.False(t, names[r.Name], "duplicate role %s", r.Name)
+		names[r.Name] = true
+
+		if r.BindRootUser {
+			bound = append(bound, r.Name)
+		}
+
+		// Only super-admin carries a policy; the rest are empty containers.
+		if r.Name == "super-admin" {
+			require.NotEmpty(t, r.Statements, "super-admin must ship a policy")
+			require.True(t, r.BindRootUser, "super-admin must be bound to root")
+		} else {
+			require.Empty(t, r.Statements, "%s must be created without a policy", r.Name)
+			require.False(t, r.BindRootUser, "%s must not be bound to root", r.Name)
+		}
+	}
+
+	require.Equal(t, []string{"super-admin"}, bound, "only super-admin is bound to the root user")
+
+	// The PRD predefined roles must all be present.
+	for _, expected := range []string{
+		"super-admin", "tenant-admin",
+		"coredb-reader", "coredb-developer", "coredb-admin",
+		"ai-user", "ai-developer",
+		"platform-operator", "secret-admin",
+	} {
+		require.True(t, names[expected], "missing predefined role %s", expected)
+	}
+}
+
+// fakeAuthzClient is an in-memory authorization sidecar client. The embedded nil interface
+// makes any method not overridden below panic, so the test fails loudly if the sync starts
+// depending on an unexpected call.
+type fakeAuthzClient struct {
+	sidecarSvcAuthzDefinition.AuthorizationAPIClient
+
+	policies map[string]*sidecarSvcAuthzTypes.Policy
+	roles    map[string]*sidecarSvcAuthzTypes.Role
+	bindings map[string]*sidecarSvcAuthzTypes.UserRoleBinding // key: user/role
+
+	writes int
+}
+
+func newFakeAuthzClient() *fakeAuthzClient {
+	return &fakeAuthzClient{
+		policies: map[string]*sidecarSvcAuthzTypes.Policy{},
+		roles:    map[string]*sidecarSvcAuthzTypes.Role{},
+		bindings: map[string]*sidecarSvcAuthzTypes.UserRoleBinding{},
+	}
+}
+
+func (f *fakeAuthzClient) APIGetPolicy(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPINamedRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIPolicyResponse, error) {
+	if p, ok := f.policies[in.GetName()]; ok {
+		return &sidecarSvcAuthzDefinition.AuthorizationAPIPolicyResponse{Item: p}, nil
+	}
+	return nil, grpcStatus.Error(codes.NotFound, "not found")
+}
+
+func (f *fakeAuthzClient) APICreatePolicy(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPIPolicyRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIPolicyResponse, error) {
+	f.writes++
+	f.policies[in.GetName()] = in.GetItem()
+	return &sidecarSvcAuthzDefinition.AuthorizationAPIPolicyResponse{Item: in.GetItem()}, nil
+}
+
+func (f *fakeAuthzClient) APIUpdatePolicy(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPIPolicyRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIPolicyResponse, error) {
+	f.writes++
+	f.policies[in.GetName()] = in.GetItem()
+	return &sidecarSvcAuthzDefinition.AuthorizationAPIPolicyResponse{Item: in.GetItem()}, nil
+}
+
+func (f *fakeAuthzClient) APIGetRole(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPINamedRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIRoleResponse, error) {
+	if r, ok := f.roles[in.GetName()]; ok {
+		return &sidecarSvcAuthzDefinition.AuthorizationAPIRoleResponse{Item: r}, nil
+	}
+	return nil, grpcStatus.Error(codes.NotFound, "not found")
+}
+
+func (f *fakeAuthzClient) APICreateRole(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPIRoleRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIRoleResponse, error) {
+	f.writes++
+	f.roles[in.GetName()] = in.GetItem()
+	return &sidecarSvcAuthzDefinition.AuthorizationAPIRoleResponse{Item: in.GetItem()}, nil
+}
+
+func (f *fakeAuthzClient) APIUpdateRole(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPIRoleRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIRoleResponse, error) {
+	f.writes++
+	f.roles[in.GetName()] = in.GetItem()
+	return &sidecarSvcAuthzDefinition.AuthorizationAPIRoleResponse{Item: in.GetItem()}, nil
+}
+
+func (f *fakeAuthzClient) APIListUserRoleBindings(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPIUserRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingListResponse, error) {
+	var out []*sidecarSvcAuthzTypes.UserRoleBinding
+	prefix := in.GetUser() + "/"
+	for k, b := range f.bindings {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			out = append(out, b)
+		}
+	}
+	return &sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingListResponse{Bindings: out}, nil
+}
+
+func (f *fakeAuthzClient) APIAssignUserRole(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingResponse, error) {
+	f.writes++
+	f.bindings[in.GetUser()+"/"+in.GetRole()] = &sidecarSvcAuthzTypes.UserRoleBinding{Role: in.GetRole(), Scope: in.GetScope()}
+	return &sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingResponse{}, nil
+}
+
+func (f *fakeAuthzClient) APIReplaceUserRoleScope(_ context.Context, in *sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingRequest, _ ...grpc.CallOption) (*sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingResponse, error) {
+	f.writes++
+	f.bindings[in.GetUser()+"/"+in.GetRole()] = &sidecarSvcAuthzTypes.UserRoleBinding{Role: in.GetRole(), Scope: in.GetScope()}
+	return &sidecarSvcAuthzDefinition.AuthorizationAPIUserRoleBindingResponse{}, nil
+}
+
+// noBoundPolicies is a bound-policy resolver that returns nothing (no customer-attached policies).
+func noBoundPolicies(string) ([]string, error) { return nil, nil }
+
+func Test_syncRBACPermissions(t *testing.T) {
+	ctx := context.Background()
+	superRole := managedRoleName("super-admin")
+
+	t.Run("creates the full catalog from empty", func(t *testing.T) {
+		f := newFakeAuthzClient()
+
+		require.NoError(t, syncRBACPermissions(ctx, f, noBoundPolicies))
+
+		// Every predefined role exists, with its description.
+		require.Len(t, f.roles, len(predefinedRoles))
+		for _, r := range predefinedRoles {
+			role, ok := f.roles[managedRoleName(r.Name)]
+			require.True(t, ok, "role %s must be created", r.Name)
+			require.Equal(t, r.Description, role.GetDescription())
+		}
+
+		// Only super-admin has a policy.
+		require.Len(t, f.policies, 1)
+		require.Contains(t, f.policies, managedRoleName("super-admin"))
+		require.Equal(t, allowAllScope().Hash(), f.policies[managedRoleName("super-admin")].Hash())
+		require.Equal(t, []string{managedRoleName("super-admin")}, f.roles[superRole].GetPolicies())
+
+		// The empty roles carry no policy.
+		require.Empty(t, f.roles[managedRoleName("coredb-reader")].GetPolicies())
+
+		// Only the root user is bound, to super-admin, with an Allow-all scope.
+		require.Len(t, f.bindings, 1)
+		b, ok := f.bindings[api.UserNameRoot+"/"+superRole]
+		require.True(t, ok)
+		require.Equal(t, allowAllScope().Hash(), b.GetScope().Hash())
+	})
+
+	t.Run("idempotent - no writes when already in sync", func(t *testing.T) {
+		f := newFakeAuthzClient()
+		require.NoError(t, syncRBACPermissions(ctx, f, noBoundPolicies))
+
+		f.writes = 0
+		require.NoError(t, syncRBACPermissions(ctx, f, noBoundPolicies))
+		require.Equal(t, 0, f.writes, "a second sync must not write anything")
+	})
+
+	t.Run("recreates a deleted role", func(t *testing.T) {
+		f := newFakeAuthzClient()
+		require.NoError(t, syncRBACPermissions(ctx, f, noBoundPolicies))
+
+		delete(f.roles, managedRoleName("secret-admin"))
+
+		f.writes = 0
+		require.NoError(t, syncRBACPermissions(ctx, f, noBoundPolicies))
+		require.Equal(t, 1, f.writes, "only the deleted role is recreated")
+		require.Contains(t, f.roles, managedRoleName("secret-admin"))
+	})
+
+	t.Run("repairs a drifted super-admin policy", func(t *testing.T) {
+		f := newFakeAuthzClient()
+		require.NoError(t, syncRBACPermissions(ctx, f, noBoundPolicies))
+
+		f.policies[managedRoleName("super-admin")] = &sidecarSvcAuthzTypes.Policy{
+			Statements: []*sidecarSvcAuthzTypes.PolicyStatement{
+				{Effect: sidecarSvcAuthzTypes.Effect_Deny, Actions: []string{"meta:GetKey"}, Resources: []string{"x"}},
+			},
+		}
+
+		f.writes = 0
+		require.NoError(t, syncRBACPermissions(ctx, f, noBoundPolicies))
+		require.Equal(t, 1, f.writes, "only the drifted policy is rewritten")
+		require.Equal(t, allowAllScope().Hash(), f.policies[managedRoleName("super-admin")].Hash())
+	})
+
+	t.Run("merges policies bound to a predefined role", func(t *testing.T) {
+		f := newFakeAuthzClient()
+
+		// A customer attaches a policy to coredb-reader via an ArangoPermissionPolicyRoleBinding.
+		readerRole := managedRoleName("coredb-reader")
+		bound := func(roleName string) ([]string, error) {
+			if roleName == readerRole {
+				return []string{"managed:operator:my-policy"}, nil
+			}
+			return nil, nil
+		}
+
+		require.NoError(t, syncRBACPermissions(ctx, f, bound))
+
+		// The bound policy is attached to the predefined role...
+		require.Equal(t, []string{"managed:operator:my-policy"}, f.roles[readerRole].GetPolicies())
+		// ...and super-admin still keeps its own bundled policy.
+		require.Equal(t, []string{superRole}, f.roles[superRole].GetPolicies())
+
+		// Re-running without the binding removes the policy again (drift repair does not clobber
+		// bound policies, but does remove ones that are no longer bound).
+		f.writes = 0
+		require.NoError(t, syncRBACPermissions(ctx, f, noBoundPolicies))
+		require.Empty(t, f.roles[readerRole].GetPolicies())
+	})
+}

--- a/pkg/deployment/reconcile/plan_builder_rbac_test.go
+++ b/pkg/deployment/reconcile/plan_builder_rbac_test.go
@@ -30,6 +30,7 @@ import (
 	grpcStatus "google.golang.org/grpc/status"
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/apis/permission"
 	sidecarSvcAuthzDefinition "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/definition"
 	sidecarSvcAuthzTypes "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/types"
 )
@@ -39,7 +40,7 @@ import (
 // managed:predefined:, hyphenated and described, and names are unique.
 func Test_predefinedRoles_catalog(t *testing.T) {
 	require.Equal(t, "managed:predefined:", managedObjectPrefix)
-	require.Equal(t, "managed:predefined:super-admin", managedRoleName("super-admin"))
+	require.Equal(t, permission.ManagedPredefinedRoleName(permission.PredefinedRoleSuperAdmin), managedRoleName(permission.PredefinedRoleSuperAdmin))
 
 	names := map[string]bool{}
 	var bound []string
@@ -55,7 +56,7 @@ func Test_predefinedRoles_catalog(t *testing.T) {
 		}
 
 		// Only super-admin carries a policy; the rest are empty containers.
-		if r.Name == "super-admin" {
+		if r.Name == permission.PredefinedRoleSuperAdmin {
 			require.NotEmpty(t, r.Statements, "super-admin must ship a policy")
 			require.True(t, r.BindRootUser, "super-admin must be bound to root")
 		} else {
@@ -64,17 +65,19 @@ func Test_predefinedRoles_catalog(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, []string{"super-admin"}, bound, "only super-admin is bound to the root user")
+	require.Equal(t, []string{permission.PredefinedRoleSuperAdmin}, bound, "only super-admin is bound to the root user")
 
-	// The PRD predefined roles must all be present.
-	for _, expected := range []string{
-		"super-admin", "tenant-admin",
-		"coredb-reader", "coredb-developer", "coredb-admin",
-		"ai-user", "ai-developer",
-		"platform-operator", "secret-admin",
-	} {
-		require.True(t, names[expected], "missing predefined role %s", expected)
+	// The catalog must cover exactly the exported PredefinedRoleNames (the single source of truth
+	// shared with the handlers and the e2e tests) - no missing and no extra roles.
+	catalog := make([]string, 0, len(predefinedRoles))
+	for _, r := range predefinedRoles {
+		catalog = append(catalog, r.Name)
 	}
+	require.ElementsMatch(t, permission.PredefinedRoleNames, catalog, "predefinedRoles must match permission.PredefinedRoleNames")
+
+	// super-admin is the reserved role and must be reported as such.
+	require.True(t, permission.IsReservedRoleName(permission.ManagedPredefinedRoleName(permission.PredefinedRoleSuperAdmin)))
+	require.False(t, permission.IsReservedRoleName(permission.ManagedPredefinedRoleName(permission.PredefinedRoleCoreDBReader)))
 }
 
 // fakeAuthzClient is an in-memory authorization sidecar client. The embedded nil interface

--- a/pkg/handlers/permission/policy_role_binding/handler_references.go
+++ b/pkg/handlers/permission/policy_role_binding/handler_references.go
@@ -22,7 +22,6 @@ package policy_role_binding
 
 import (
 	"context"
-	goStrings "strings"
 
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,12 +79,12 @@ func (h *handler) handlePolicyReference(ctx context.Context, extension *permissi
 func (h *handler) handleRoleReference(ctx context.Context, extension *permissionApi.ArangoPermissionPolicyRoleBinding, status *permissionApi.ArangoPermissionPolicyRoleBindingStatus) (bool, error) {
 	roleName := extension.Spec.Role.GetReference()
 
-	// Predefined (operator-managed) roles are created directly in the authorization sidecar and
-	// have no ArangoPermissionRole CRD. Accept them as direct sidecar references so a policy can
-	// be attached to a predefined role. The deployment reconciler (SyncRBACPermissions) picks up
-	// the binding and merges the policy into the sidecar role. No CRD lookup and no role label -
-	// the reconciler discovers these bindings by the referenced role name.
-	if goStrings.HasPrefix(roleName, permission.ManagedPredefinedPrefix) {
+	// A direct reference targets a role that lives only in the authorization sidecar and has no
+	// ArangoPermissionRole CRD (e.g. an operator-managed predefined role). The `direct` reference
+	// field addresses it directly by name so a policy can be attached to it. The deployment
+	// reconciler (SyncRBACPermissions) picks up the binding and merges the policy into the sidecar
+	// role. No CRD lookup and no role label - the reconciler discovers these bindings by role name.
+	if extension.Spec.Role.IsDirect() {
 		if status.Role == nil || status.Role.GetName() != roleName {
 			status.Role = &sharedApi.Object{Name: roleName}
 			return true, operator.Reconcile("Predefined role reference set")

--- a/pkg/handlers/permission/policy_role_binding/handler_references.go
+++ b/pkg/handlers/permission/policy_role_binding/handler_references.go
@@ -22,6 +22,7 @@ package policy_role_binding
 
 import (
 	"context"
+	goStrings "strings"
 
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,6 +79,24 @@ func (h *handler) handlePolicyReference(ctx context.Context, extension *permissi
 
 func (h *handler) handleRoleReference(ctx context.Context, extension *permissionApi.ArangoPermissionPolicyRoleBinding, status *permissionApi.ArangoPermissionPolicyRoleBindingStatus) (bool, error) {
 	roleName := extension.Spec.Role.GetReference()
+
+	// Predefined (operator-managed) roles are created directly in the authorization sidecar and
+	// have no ArangoPermissionRole CRD. Accept them as direct sidecar references so a policy can
+	// be attached to a predefined role. The deployment reconciler (SyncRBACPermissions) picks up
+	// the binding and merges the policy into the sidecar role. No CRD lookup and no role label -
+	// the reconciler discovers these bindings by the referenced role name.
+	if goStrings.HasPrefix(roleName, permission.ManagedPredefinedPrefix) {
+		if status.Role == nil || status.Role.GetName() != roleName {
+			status.Role = &sharedApi.Object{Name: roleName}
+			return true, operator.Reconcile("Predefined role reference set")
+		}
+
+		if status.Conditions.Update(permissionApi.ReadyRoleCondition, true, "Role Ready", "Predefined role") {
+			return true, operator.Reconcile("Role ready")
+		}
+
+		return false, nil
+	}
 
 	// CRD reference — resolve the ArangoPermissionRole
 	roleObj, err := h.client.PermissionV1alpha1().ArangoPermissionRoles(extension.GetNamespace()).Get(ctx, roleName, meta.GetOptions{})

--- a/pkg/handlers/permission/role_user_binding/handler_binding.go
+++ b/pkg/handlers/permission/role_user_binding/handler_binding.go
@@ -22,6 +22,7 @@ package role_user_binding
 
 import (
 	"context"
+	goStrings "strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -30,6 +31,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/apis/permission"
 	permissionApi "github.com/arangodb/kube-arangodb/pkg/apis/permission/v1alpha1"
 	permissionApiPolicy "github.com/arangodb/kube-arangodb/pkg/apis/permission/v1alpha1/policy"
 	sharedApi "github.com/arangodb/kube-arangodb/pkg/apis/shared/v1"
@@ -75,31 +77,44 @@ func (h *handler) HandleArangoDBBinding(ctx context.Context, item operation.Item
 	// Resolve the referenced ArangoPermissionRole and ensure it is reconciled into the sidecar.
 	roleName := extension.Spec.Role.GetReference()
 
-	roleObj, err := h.client.PermissionV1alpha1().ArangoPermissionRoles(extension.GetNamespace()).Get(ctx, roleName, meta.GetOptions{})
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			if st.Conditions.Update(permissionApi.ReadyRoleCondition, false, "Role not found", "ArangoPermissionRole not found") {
-				return true, operator.Reconcile("Role not found")
+	var sidecarRole string
+
+	if goStrings.HasPrefix(roleName, permission.ManagedPredefinedPrefix) {
+		// Predefined (operator-managed) roles are created directly in the authorization sidecar
+		// and have no ArangoPermissionRole CRD; the reference is the sidecar role name itself.
+		if st.Role == nil || st.Role.GetName() != roleName {
+			st.Role = &sharedApi.Object{Name: roleName}
+			return true, operator.Reconcile("Predefined role reference set")
+		}
+
+		sidecarRole = roleName
+	} else {
+		roleObj, err := h.client.PermissionV1alpha1().ArangoPermissionRoles(extension.GetNamespace()).Get(ctx, roleName, meta.GetOptions{})
+		if err != nil {
+			if apiErrors.IsNotFound(err) {
+				if st.Conditions.Update(permissionApi.ReadyRoleCondition, false, "Role not found", "ArangoPermissionRole not found") {
+					return true, operator.Reconcile("Role not found")
+				}
+				return false, operator.Stop("Role not found")
 			}
-			return false, operator.Stop("Role not found")
+			return false, err
 		}
-		return false, err
-	}
 
-	if !roleObj.Ready() || roleObj.Status.Role == nil {
-		if st.Conditions.Update(permissionApi.ReadyRoleCondition, false, "Role not ready", "ArangoPermissionRole is not ready") {
-			return true, operator.Reconcile("Role not ready")
+		if !roleObj.Ready() || roleObj.Status.Role == nil {
+			if st.Conditions.Update(permissionApi.ReadyRoleCondition, false, "Role not ready", "ArangoPermissionRole is not ready") {
+				return true, operator.Reconcile("Role not ready")
+			}
+			return false, operator.Stop("Role not ready")
 		}
-		return false, operator.Stop("Role not ready")
-	}
 
-	if st.Role == nil || !st.Role.Equals(roleObj) {
-		st.Role = util.NewType(sharedApi.NewObject(roleObj))
-		return true, operator.Reconcile("Role reference updated")
-	}
+		if st.Role == nil || !st.Role.Equals(roleObj) {
+			st.Role = util.NewType(sharedApi.NewObject(roleObj))
+			return true, operator.Reconcile("Role reference updated")
+		}
 
-	// The sidecar role name matches the ArangoPermissionRole status reference.
-	sidecarRole := roleObj.Status.Role.GetName()
+		// The sidecar role name matches the ArangoPermissionRole status reference.
+		sidecarRole = roleObj.Status.Role.GetName()
+	}
 
 	scope, err := renderScope(extension.Spec.Scope)
 	if err != nil {

--- a/pkg/handlers/permission/role_user_binding/handler_binding.go
+++ b/pkg/handlers/permission/role_user_binding/handler_binding.go
@@ -22,7 +22,6 @@ package role_user_binding
 
 import (
 	"context"
-	goStrings "strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -31,7 +30,6 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
-	"github.com/arangodb/kube-arangodb/pkg/apis/permission"
 	permissionApi "github.com/arangodb/kube-arangodb/pkg/apis/permission/v1alpha1"
 	permissionApiPolicy "github.com/arangodb/kube-arangodb/pkg/apis/permission/v1alpha1/policy"
 	sharedApi "github.com/arangodb/kube-arangodb/pkg/apis/shared/v1"
@@ -79,9 +77,9 @@ func (h *handler) HandleArangoDBBinding(ctx context.Context, item operation.Item
 
 	var sidecarRole string
 
-	if goStrings.HasPrefix(roleName, permission.ManagedPredefinedPrefix) {
-		// Predefined (operator-managed) roles are created directly in the authorization sidecar
-		// and have no ArangoPermissionRole CRD; the reference is the sidecar role name itself.
+	if extension.Spec.Role.IsDirect() {
+		// A direct sidecar reference targets a role that lives only in the authorization sidecar
+		// and has no ArangoPermissionRole CRD; the reference resolves to the sidecar role name.
 		if st.Role == nil || st.Role.GetName() != roleName {
 			st.Role = &sharedApi.Object{Name: roleName}
 			return true, operator.Reconcile("Predefined role reference set")


### PR DESCRIPTION
## Summary

Bootstraps the operator-managed **predefined RBAC roles** into each deployment's authorization sidecar, right after the root user is created, and gates deployment readiness on the sync. Predefined roles are visible to customers but not editable, and can be extended by attaching policies to them.

## Predefined roles

A catalog of operator-managed roles is synced into the sidecar under the reserved prefix `managed:predefined:`:

| Role | Access |
|------|--------|
| `super-admin` | Allow `*` on `*`. Reserved - bound automatically to the deployment `root` user with an Allow-all scope; not assignable by customers. |
| `tenant-admin`, `coredb-reader`, `coredb-developer`, `coredb-admin`, `ai-user`, `ai-developer`, `platform-operator`, `secret-admin` | Created as empty role containers (default deny) - assignable, scopable, and extensible; their bundled policies are a later iteration. |

Descriptions come from the RBAC product definition. Only `super-admin` ships a concrete policy in this iteration.

## How it works

- **Action `SyncRBACPermissions`** (High scope) connects to the authorization sidecar and upserts the predefined roles directly through the management API - no intermediate `ArangoPermission*` CRs. It is idempotent (create-if-missing, repair-on-drift) and, for `super-admin`, also upserts its Allow-all policy and the root user binding.
- **Plan builder `createSyncRBACPermissionsPlan`** (high plan) proposes the action once `BootstrapCompleted` and `GatewaySidecarEnabled` are true, under a 30s back-off, so the catalog is recreated/repaired periodically.

## Readiness: the `RBACBootstrapped` condition

- The deployment inspector sets `RBACBootstrapped=false` as soon as RBAC (the gateway/authorization sidecar) is enabled and the condition is missing - without delay - and removes it when RBAC is disabled.
- The `SyncRBACPermissions` action sets it `true` once the sync succeeds.
- `UpToDate` now waits for `RBACBootstrapped` (only when RBAC is enabled), so a deployment is not reported up to date until its RBAC roles are synced.

## Extending predefined roles

Predefined roles cannot be edited, but policies can be **attached** to them: an `ArangoPermissionPolicyRoleBinding` (and an `ArangoPermissionRoleUserBinding`) may now reference a predefined role by its `managed:predefined:*` sidecar name - the `policy_role_binding` and `role_user_binding` handlers accept the direct sidecar name (predefined roles have no `ArangoPermissionRole` CRD). The sync merges policies bound to a predefined role into its sidecar role (alongside the bundled policy) and does not clobber them on drift-repair; unbinding removes them again. Per-user extension by composition (union of role bindings) also works.

## Tests

- `Test_predefinedRoles_catalog` - catalog shape: prefix/hyphenation/descriptions, only `super-admin` carries a policy + root binding, all PRD roles present.
- `Test_syncRBACPermissions` (in-memory sidecar fake) - creates the full catalog from empty, idempotent (no writes when in sync), recreates a deleted role, repairs a drifted `super-admin` policy, and **merges/unmerges policies bound to a predefined role**.
- Generated registration test covers the new action.

`go build`, `go vet -tags testing`, `golangci-lint`, gofmt and the unit tests all pass.

## Docs

- `design/rbac/predefined_roles.md` - the catalog, model, granularity, lifecycle, and extension.
- `docs/platform/rbac/predefined_roles.md` - how to assign/scope predefined roles and how to extend them via `ArangoPermissionPolicyRoleBinding` / composition.
