### PR TITLE
Aggregate bundled-chart container images into the platform release chart README and images.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) (Platform) Aggregate the container images declared by each bundled chart's images.yaml into a Container Images section of the generated platform release chart README and an aggregated images.yaml for air-gapped mirroring
 - (Feature) (Platform) Generate README.md in the platform release chart and validate chart overrides against each subchart values.schema.json
 
 ## [1.4.4](https://github.com/arangodb/kube-arangodb/tree/1.4.4) (2026-07-20)

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -75,6 +75,11 @@ type packageChartRenderInput struct {
 
 	Charts   map[string]packageChartRenderInputChart
 	Services map[string]packageChartRenderInputService
+
+	// Images is the aggregated, de-duplicated list of container images declared by the bundled
+	// charts (via their images.yaml), sorted by image reference. It backs both the README section
+	// and the generated top-level images.yaml.
+	Images []packageChartRenderInputImage
 }
 type packageChartRenderInputChart struct {
 	Name      string
@@ -86,6 +91,16 @@ type packageChartRenderInputChart struct {
 	// DocumentedValues flattens Values into individual override paths, described using
 	// Schema where it provides descriptions.
 	DocumentedValues []packageChartRenderInputValue
+
+	// Images are the container images the chart declares in its images.yaml, if any.
+	Images []packageChartRenderInputImage
+}
+
+// packageChartRenderInputImage is a single container image a chart declares in its images.yaml.
+// Fields are exported for template rendering; the json tags match the images.yaml document.
+type packageChartRenderInputImage struct {
+	Name  string `json:"name"`
+	Image string `json:"image"`
 }
 
 type packageChartRenderInputService struct {
@@ -185,6 +200,9 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Aggregate the images every bundled chart declares into the release-wide list.
+	input.Images = aggregateImages(input.Charts)
+
 	schema := generateValuesSchema(input)
 
 	builder := util.NewGZipBuilder(out)
@@ -196,6 +214,9 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 	builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateValues, input), "%s/values.yaml", input.Name)
 
 	builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateReadme, input), "%s/README.md", input.Name)
+
+	// Aggregated, machine-readable image list for air-gapped mirroring. Helm ignores it.
+	builder = builder.File(util.GZipBuilderProcessBytes(renderImagesFile(input)), "%s/images.yaml", input.Name)
 
 	builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateCheck, input), "%s/templates/check.yaml", input.Name)
 
@@ -264,6 +285,13 @@ func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint s
 		return nil, errors.Wrapf(err, "invalid values.schema.json in chart %s", name)
 	}
 
+	// A chart that ships an unparsable images.yaml is a chart bug; fail packaging rather than
+	// silently dropping images from the air-gapped list (same policy as values.schema.json).
+	images, err := extractChartImages(chart)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid images.yaml in chart %s", name)
+	}
+
 	return &packageChartRenderInputChart{
 		Name:             name,
 		Version:          packageSpec.Version,
@@ -271,6 +299,7 @@ func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint s
 		Values:           defaults,
 		Schema:           schema,
 		DocumentedValues: documentedValues(defaults, schema),
+		Images:           images,
 	}, nil
 }
 
@@ -332,6 +361,81 @@ func extractChartValues(chartData []byte) (map[string]interface{}, error) {
 	}
 
 	return values, nil
+}
+
+// extractChartImages reads images.yaml from a gzipped tar chart archive and returns the container
+// images the chart declares. Returns nil when the chart ships no images.yaml.
+func extractChartImages(chartData []byte) ([]packageChartRenderInputImage, error) {
+	data, err := extractChartFile(chartData, "images.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	if data == nil {
+		return nil, nil
+	}
+
+	var doc struct {
+		Images []packageChartRenderInputImage `json:"images"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+
+	return doc.Images, nil
+}
+
+// aggregateImages flattens the images declared by every bundled chart into a single list,
+// de-duplicated by image reference and sorted deterministically (by image, then name) so the
+// generated README and images.yaml are reproducible regardless of chart map iteration order.
+func aggregateImages(charts map[string]packageChartRenderInputChart) []packageChartRenderInputImage {
+	names := make([]string, 0, len(charts))
+	for name := range charts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	seen := map[string]struct{}{}
+	var out []packageChartRenderInputImage
+
+	// Iterate charts in name order so the entry kept for a duplicated image is deterministic.
+	for _, name := range names {
+		for _, img := range charts[name].Images {
+			if img.Image == "" {
+				continue
+			}
+			if _, ok := seen[img.Image]; ok {
+				continue
+			}
+			seen[img.Image] = struct{}{}
+			out = append(out, img)
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Image != out[j].Image {
+			return out[i].Image < out[j].Image
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	return out
+}
+
+// renderImagesFile marshals the aggregated image list into the images.yaml document shipped at the
+// root of the release chart - informational only, Helm does not consume it.
+func renderImagesFile(input packageChartRenderInput) []byte {
+	doc := struct {
+		Images []packageChartRenderInputImage `json:"images"`
+	}{Images: input.Images}
+
+	data, _ := yaml.Marshal(doc)
+
+	header := "# Container images bundled by " + input.Name + " " + input.Version + ".\n" +
+		"# For an air-gapped installation, pull each image, re-tag it to your private registry and push it.\n" +
+		"# Generated when the release chart is packaged - do not edit by hand. Helm does not consume this file.\n"
+
+	return append([]byte(header), data...)
 }
 
 // extractChartSchema reads values.schema.json from a gzipped tar chart archive.

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -97,11 +97,15 @@ type packageChartRenderInputChart struct {
 	Images []packageChartRenderInputImage
 }
 
-// packageChartRenderInputImage is a single container image a chart declares in its images.yaml.
+// packageChartRenderInputImage is a single container image referenced by a bundled chart, together
+// with the values path at which it can be overridden (e.g. to repoint it at a private registry).
 // Fields are exported for template rendering; the json tags match the images.yaml document.
 type packageChartRenderInputImage struct {
-	Name  string `json:"name"`
-	Image string `json:"image"`
+	// OverridePath is the dotted values path of the image spec. In the aggregated list it is
+	// chart-prefixed (e.g. "charts.arangodb-gral.images.application"), so it is the exact key to
+	// override in the release values.yaml.
+	OverridePath string `json:"overridePath"`
+	Image        string `json:"image"`
 }
 
 type packageChartRenderInputService struct {
@@ -399,26 +403,19 @@ func imagesFromValues(values map[string]interface{}) []packageChartRenderInputIm
 	seen := map[string]struct{}{}
 	var out []packageChartRenderInputImage
 
-	collectImagesFromValues(values, "", "", &out, seen)
+	collectImagesFromValues(values, "", &out, seen)
 
 	return out
 }
 
-func collectImagesFromValues(node interface{}, key, parentKey string, out *[]packageChartRenderInputImage, seen map[string]struct{}) {
+func collectImagesFromValues(node interface{}, path string, out *[]packageChartRenderInputImage, seen map[string]struct{}) {
 	switch v := node.(type) {
 	case map[string]interface{}:
 		if ref := imageRefFromMap(v); ref != "" {
 			if _, ok := seen[ref]; !ok {
 				seen[ref] = struct{}{}
-
-				// The image-spec map usually sits under a descriptive key (e.g. "engine"); when it
-				// sits under a literal "image"/"images" key, the parent key is the better name.
-				name := key
-				if name == "" || name == "image" || name == "images" {
-					name = parentKey
-				}
-
-				*out = append(*out, packageChartRenderInputImage{Name: name, Image: ref})
+				// path is the dotted values path of this image-spec map, e.g. "images.application".
+				*out = append(*out, packageChartRenderInputImage{OverridePath: path, Image: ref})
 			}
 		}
 
@@ -428,13 +425,21 @@ func collectImagesFromValues(node interface{}, key, parentKey string, out *[]pac
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			collectImagesFromValues(v[k], k, key, out, seen)
+			collectImagesFromValues(v[k], joinPath(path, k), out, seen)
 		}
 	case []interface{}:
-		for _, e := range v {
-			collectImagesFromValues(e, key, parentKey, out, seen)
+		for i, e := range v {
+			collectImagesFromValues(e, fmt.Sprintf("%s[%d]", path, i), out, seen)
 		}
 	}
+}
+
+// joinPath appends a key to a dotted values path.
+func joinPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
 }
 
 // imageRefFromMap builds a full image reference from an image-spec map, or "" if it is not one.
@@ -508,7 +513,11 @@ func aggregateImages(charts map[string]packageChartRenderInputChart) []packageCh
 				continue
 			}
 			seen[img.Image] = struct{}{}
-			out = append(out, img)
+			out = append(out, packageChartRenderInputImage{
+				// Chart-prefix the path so it is the exact override key in the release values.yaml.
+				OverridePath: joinPath("charts."+name, img.OverridePath),
+				Image:        img.Image,
+			})
 		}
 	}
 
@@ -516,7 +525,7 @@ func aggregateImages(charts map[string]packageChartRenderInputChart) []packageCh
 		if out[i].Image != out[j].Image {
 			return out[i].Image < out[j].Image
 		}
-		return out[i].Name < out[j].Name
+		return out[i].OverridePath < out[j].OverridePath
 	})
 
 	return out

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -292,6 +293,11 @@ func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint s
 		return nil, errors.Wrapf(err, "invalid images.yaml in chart %s", name)
 	}
 
+	// When a chart does not ship an explicit images.yaml, derive its images from values.yaml.
+	if images == nil {
+		images = imagesFromValues(defaults)
+	}
+
 	return &packageChartRenderInputChart{
 		Name:             name,
 		Version:          packageSpec.Version,
@@ -383,6 +389,100 @@ func extractChartImages(chartData []byte) ([]packageChartRenderInputImage, error
 	}
 
 	return doc.Images, nil
+}
+
+// imagesFromValues derives container image references from a chart's values by walking them and
+// recognising image-spec maps: a map carrying an "image" or "repository" string, optionally combined
+// with a sibling "registry" and "tag". It is the fallback source when a chart ships no explicit
+// images.yaml, so the air-gapped list reflects what the chart actually references.
+func imagesFromValues(values map[string]interface{}) []packageChartRenderInputImage {
+	seen := map[string]struct{}{}
+	var out []packageChartRenderInputImage
+
+	collectImagesFromValues(values, "", "", &out, seen)
+
+	return out
+}
+
+func collectImagesFromValues(node interface{}, key, parentKey string, out *[]packageChartRenderInputImage, seen map[string]struct{}) {
+	switch v := node.(type) {
+	case map[string]interface{}:
+		if ref := imageRefFromMap(v); ref != "" {
+			if _, ok := seen[ref]; !ok {
+				seen[ref] = struct{}{}
+
+				// The image-spec map usually sits under a descriptive key (e.g. "engine"); when it
+				// sits under a literal "image"/"images" key, the parent key is the better name.
+				name := key
+				if name == "" || name == "image" || name == "images" {
+					name = parentKey
+				}
+
+				*out = append(*out, packageChartRenderInputImage{Name: name, Image: ref})
+			}
+		}
+
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			collectImagesFromValues(v[k], k, key, out, seen)
+		}
+	case []interface{}:
+		for _, e := range v {
+			collectImagesFromValues(e, key, parentKey, out, seen)
+		}
+	}
+}
+
+// imageRefFromMap builds a full image reference from an image-spec map, or "" if it is not one.
+// It composes "[registry/]repo[:tag]" from the "image"/"repository", "registry" and "tag" fields.
+func imageRefFromMap(m map[string]interface{}) string {
+	repo := firstScalarString(m, "image", "repository")
+	if repo == "" {
+		return ""
+	}
+
+	ref := repo
+	if reg := scalarString(m["registry"]); reg != "" && !goStrings.HasPrefix(ref, reg+"/") {
+		ref = reg + "/" + ref
+	}
+
+	if tag := scalarString(m["tag"]); tag != "" {
+		last := ref
+		if i := goStrings.LastIndex(ref, "/"); i >= 0 {
+			last = ref[i+1:]
+		}
+		// Only append a tag when the repo does not already carry one (":") or a digest ("@").
+		if !goStrings.ContainsAny(last, ":@") {
+			ref = ref + ":" + tag
+		}
+	}
+
+	return ref
+}
+
+func firstScalarString(m map[string]interface{}, keys ...string) string {
+	for _, k := range keys {
+		if s := scalarString(m[k]); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// scalarString renders a scalar value (string, number, bool) as a string; other kinds yield "".
+func scalarString(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool, float64, float32, int, int64, int32, json.Number:
+		return fmt.Sprintf("%v", t)
+	default:
+		return ""
+	}
 }
 
 // aggregateImages flattens the images declared by every bundled chart into a single list,

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -425,9 +425,16 @@ func aggregateImages(charts map[string]packageChartRenderInputChart) []packageCh
 // renderImagesFile marshals the aggregated image list into the images.yaml document shipped at the
 // root of the release chart - informational only, Helm does not consume it.
 func renderImagesFile(input packageChartRenderInput) []byte {
+	// Marshal an empty list as `[]` rather than `null` so the file is always a valid, uniform
+	// document for consumers - e.g. when no bundled chart declares any images.
+	images := input.Images
+	if images == nil {
+		images = []packageChartRenderInputImage{}
+	}
+
 	doc := struct {
 		Images []packageChartRenderInputImage `json:"images"`
-	}{Images: input.Images}
+	}{Images: images}
 
 	data, _ := yaml.Marshal(doc)
 

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -411,7 +411,7 @@ func imagesFromValues(values map[string]interface{}) []packageChartRenderInputIm
 func collectImagesFromValues(node interface{}, path string, out *[]packageChartRenderInputImage, seen map[string]struct{}) {
 	switch v := node.(type) {
 	case map[string]interface{}:
-		if ref := imageRefFromMap(v); ref != "" {
+		if ref := imageRefFromMap(v); ref != "" && !imageIsTest(path, ref) {
 			if _, ok := seen[ref]; !ok {
 				seen[ref] = struct{}{}
 				// path is the dotted values path of this image-spec map, e.g. "images.application".
@@ -440,6 +440,30 @@ func joinPath(path, key string) string {
 		return key
 	}
 	return path + "." + key
+}
+
+// imageIsTest reports whether a derived image is a test image that should be excluded from the
+// air-gapped list: the ArangoDB charts expose it under an `images.test` key, and its repository
+// name ends with "-test" (e.g. gral/engine-test, ml-api/service-test, featurization/job-test).
+func imageIsTest(overridePath, ref string) bool {
+	// The image-spec map sits under a literal "test" key (…images.test).
+	seg := overridePath
+	if i := goStrings.LastIndex(seg, "."); i >= 0 {
+		seg = seg[i+1:]
+	}
+	if seg == "test" {
+		return true
+	}
+
+	// The repository name (last path segment, tag/digest stripped) ends with "-test".
+	repo := ref
+	if i := goStrings.LastIndex(repo, "/"); i >= 0 {
+		repo = repo[i+1:]
+	}
+	if i := goStrings.IndexAny(repo, ":@"); i >= 0 {
+		repo = repo[:i]
+	}
+	return goStrings.HasSuffix(repo, "-test")
 }
 
 // imageRefFromMap builds a full image reference from an image-spec map, or "" if it is not one.

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -502,11 +502,18 @@ func Test_imagesFromValues(t *testing.T) {
 				"registry": "registry.license.arango.ai",
 				"tag":      "v1.1.12",
 			},
+			// Excluded: sits under the "test" key.
 			"test": map[string]interface{}{
 				"image":    "gral/engine-test",
 				"registry": "registry.license.arango.ai",
 				"tag":      "v1.1.12",
 			},
+		},
+		// Excluded: repository ends with -test even though the key is not "test".
+		"extra": map[string]interface{}{
+			"image":    "foo/bar-test",
+			"registry": "docker.io",
+			"tag":      "1.0",
 		},
 		// Upstream convention: .image.{registry,repository,tag}
 		"imageRenderer": map[string]interface{}{
@@ -530,9 +537,9 @@ func Test_imagesFromValues(t *testing.T) {
 
 	got := imagesFromValues(values)
 
+	// Test images (the "test" key and the -test repository) are excluded.
 	require.ElementsMatch(t, []packageChartRenderInputImage{
 		{OverridePath: "images.application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
-		{OverridePath: "images.test", Image: "registry.license.arango.ai/gral/engine-test:v1.1.12"},
 		{OverridePath: "imageRenderer.image", Image: "docker.io/grafana/grafana-image-renderer:latest"},
 		{OverridePath: "other", Image: "docker.io/library/busybox:1.31"},
 	}, got)

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -466,16 +466,16 @@ func Test_packageChartTemplateValues_EmptySections(t *testing.T) {
 func Test_extractChartImages(t *testing.T) {
 	t.Run("reads own images.yaml, ignores subcharts", func(t *testing.T) {
 		files := map[string]string{
-			"mychart/charts/sub/images.yaml": "images:\n  - name: sub\n    image: sub/img:1\n",
-			"mychart/images.yaml":            "images:\n  - name: operator\n    image: arangodb/kube-arangodb:1.4.4\n  - name: db\n    image: arangodb/arangodb-enterprise:3.12.5\n",
+			"mychart/charts/sub/images.yaml": "images:\n  - overridePath: sub\n    image: sub/img:1\n",
+			"mychart/images.yaml":            "images:\n  - overridePath: images.operator\n    image: arangodb/kube-arangodb:1.4.4\n  - overridePath: images.db\n    image: arangodb/arangodb-enterprise:3.12.5\n",
 		}
 		order := []string{"mychart/charts/sub/images.yaml", "mychart/images.yaml"}
 
 		imgs, err := extractChartImages(newTestChart(t, files, order))
 		require.NoError(t, err)
 		require.Equal(t, []packageChartRenderInputImage{
-			{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"},
-			{Name: "db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+			{OverridePath: "images.operator", Image: "arangodb/kube-arangodb:1.4.4"},
+			{OverridePath: "images.db", Image: "arangodb/arangodb-enterprise:3.12.5"},
 		}, imgs)
 	})
 
@@ -531,10 +531,10 @@ func Test_imagesFromValues(t *testing.T) {
 	got := imagesFromValues(values)
 
 	require.ElementsMatch(t, []packageChartRenderInputImage{
-		{Name: "application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
-		{Name: "test", Image: "registry.license.arango.ai/gral/engine-test:v1.1.12"},
-		{Name: "imageRenderer", Image: "docker.io/grafana/grafana-image-renderer:latest"},
-		{Name: "other", Image: "docker.io/library/busybox:1.31"},
+		{OverridePath: "images.application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
+		{OverridePath: "images.test", Image: "registry.license.arango.ai/gral/engine-test:v1.1.12"},
+		{OverridePath: "imageRenderer.image", Image: "docker.io/grafana/grafana-image-renderer:latest"},
+		{OverridePath: "other", Image: "docker.io/library/busybox:1.31"},
 	}, got)
 }
 
@@ -543,21 +543,21 @@ func Test_imagesFromValues(t *testing.T) {
 func Test_aggregateImages(t *testing.T) {
 	charts := map[string]packageChartRenderInputChart{
 		"a": {Name: "a", Images: []packageChartRenderInputImage{
-			{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"},
-			{Name: "db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+			{OverridePath: "images.operator", Image: "arangodb/kube-arangodb:1.4.4"},
+			{OverridePath: "images.db", Image: "arangodb/arangodb-enterprise:3.12.5"},
 		}},
 		"b": {Name: "b", Images: []packageChartRenderInputImage{
-			{Name: "operator-dup", Image: "arangodb/kube-arangodb:1.4.4"}, // duplicate image, dropped
-			{Name: "webui", Image: "arangodb/webui:2.0.0"},
-			{Name: "empty", Image: ""}, // empty image, skipped
+			{OverridePath: "images.dup", Image: "arangodb/kube-arangodb:1.4.4"}, // duplicate image, dropped
+			{OverridePath: "images.webui", Image: "arangodb/webui:2.0.0"},
+			{OverridePath: "images.empty", Image: ""}, // empty image, skipped
 		}},
 	}
 
-	// Sorted by image reference; the entry kept for the duplicate comes from chart "a" (name order).
+	// Sorted by image; paths chart-prefixed; the duplicate keeps chart "a" (name order).
 	require.Equal(t, []packageChartRenderInputImage{
-		{Name: "db", Image: "arangodb/arangodb-enterprise:3.12.5"},
-		{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"},
-		{Name: "webui", Image: "arangodb/webui:2.0.0"},
+		{OverridePath: "charts.a.images.db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+		{OverridePath: "charts.a.images.operator", Image: "arangodb/kube-arangodb:1.4.4"},
+		{OverridePath: "charts.b.images.webui", Image: "arangodb/webui:2.0.0"},
 	}, aggregateImages(charts))
 }
 
@@ -566,12 +566,12 @@ func Test_aggregateImages(t *testing.T) {
 func Test_renderImagesFile(t *testing.T) {
 	out := string(renderImagesFile(packageChartRenderInput{
 		Name: "arango-platform-release", Version: "1.0.0",
-		Images: []packageChartRenderInputImage{{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"}},
+		Images: []packageChartRenderInputImage{{OverridePath: "charts.op.images.application", Image: "arangodb/kube-arangodb:1.4.4"}},
 	}))
 
 	require.Contains(t, out, "# Container images bundled by arango-platform-release 1.0.0.")
 	require.Contains(t, out, "Helm does not consume this file")
-	require.Contains(t, out, "name: operator")
+	require.Contains(t, out, "overridePath: charts.op.images.application")
 	require.Contains(t, out, "image: arangodb/kube-arangodb:1.4.4")
 
 	// It must be a valid images.yaml document.
@@ -579,7 +579,7 @@ func Test_renderImagesFile(t *testing.T) {
 		Images []packageChartRenderInputImage `json:"images"`
 	}
 	require.NoError(t, yaml.Unmarshal([]byte(out), &doc))
-	require.Equal(t, []packageChartRenderInputImage{{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"}}, doc.Images)
+	require.Equal(t, []packageChartRenderInputImage{{OverridePath: "charts.op.images.application", Image: "arangodb/kube-arangodb:1.4.4"}}, doc.Images)
 
 	// With no images the document renders an empty list, never null.
 	empty := string(renderImagesFile(packageChartRenderInput{Name: "r", Version: "1"}))
@@ -594,16 +594,16 @@ func Test_packageChartTemplateReadme_Images(t *testing.T) {
 		out, err := packageChartTemplateReadme.RenderBytes(packageChartRenderInput{
 			Name: "arango-platform-release", Version: "1.0.0",
 			Images: []packageChartRenderInputImage{
-				{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"},
-				{Name: "db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+				{OverridePath: "charts.op.images.application", Image: "arangodb/kube-arangodb:1.4.4"},
+				{OverridePath: "charts.db.images.application", Image: "arangodb/arangodb-enterprise:3.12.5"},
 			},
 		})
 		require.NoError(t, err)
 
 		readme := string(out)
 		require.Contains(t, readme, "## Container Images")
-		require.Contains(t, readme, "| `operator` | `arangodb/kube-arangodb:1.4.4` |")
-		require.Contains(t, readme, "| `db` | `arangodb/arangodb-enterprise:3.12.5` |")
+		require.Contains(t, readme, "| `arangodb/kube-arangodb:1.4.4` | `charts.op.images.application` |")
+		require.Contains(t, readme, "| `arangodb/arangodb-enterprise:3.12.5` | `charts.db.images.application` |")
 		require.Contains(t, readme, "images.yaml")
 		require.NotContains(t, readme, "{{")
 		require.NotContains(t, readme, "<no value>")

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -533,6 +533,11 @@ func Test_renderImagesFile(t *testing.T) {
 	}
 	require.NoError(t, yaml.Unmarshal([]byte(out), &doc))
 	require.Equal(t, []packageChartRenderInputImage{{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"}}, doc.Images)
+
+	// With no images the document renders an empty list, never null.
+	empty := string(renderImagesFile(packageChartRenderInput{Name: "r", Version: "1"}))
+	require.Contains(t, empty, "images: []")
+	require.NotContains(t, empty, "images: null")
 }
 
 // Test_packageChartTemplateReadme_Images ensures the README renders the aggregated container-image

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -460,3 +460,107 @@ func Test_packageChartTemplateValues_EmptySections(t *testing.T) {
 		})
 	}
 }
+
+// Test_extractChartImages ensures images.yaml is read from the chart's own root (not a subchart's)
+// and that a missing file is not an error while a malformed one is surfaced.
+func Test_extractChartImages(t *testing.T) {
+	t.Run("reads own images.yaml, ignores subcharts", func(t *testing.T) {
+		files := map[string]string{
+			"mychart/charts/sub/images.yaml": "images:\n  - name: sub\n    image: sub/img:1\n",
+			"mychart/images.yaml":            "images:\n  - name: operator\n    image: arangodb/kube-arangodb:1.4.4\n  - name: db\n    image: arangodb/arangodb-enterprise:3.12.5\n",
+		}
+		order := []string{"mychart/charts/sub/images.yaml", "mychart/images.yaml"}
+
+		imgs, err := extractChartImages(newTestChart(t, files, order))
+		require.NoError(t, err)
+		require.Equal(t, []packageChartRenderInputImage{
+			{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"},
+			{Name: "db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+		}, imgs)
+	})
+
+	t.Run("missing images.yaml returns nil", func(t *testing.T) {
+		imgs, err := extractChartImages(newTestChart(t, map[string]string{"mychart/Chart.yaml": "name: mychart\n"}, []string{"mychart/Chart.yaml"}))
+		require.NoError(t, err)
+		require.Nil(t, imgs)
+	})
+
+	t.Run("malformed images.yaml is an error", func(t *testing.T) {
+		_, err := extractChartImages(newTestChart(t, map[string]string{"mychart/images.yaml": "images: [not: valid"}, []string{"mychart/images.yaml"}))
+		require.Error(t, err)
+	})
+}
+
+// Test_aggregateImages ensures images from every chart are merged, de-duplicated by image
+// reference, and ordered deterministically regardless of chart map iteration order.
+func Test_aggregateImages(t *testing.T) {
+	charts := map[string]packageChartRenderInputChart{
+		"a": {Name: "a", Images: []packageChartRenderInputImage{
+			{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"},
+			{Name: "db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+		}},
+		"b": {Name: "b", Images: []packageChartRenderInputImage{
+			{Name: "operator-dup", Image: "arangodb/kube-arangodb:1.4.4"}, // duplicate image, dropped
+			{Name: "webui", Image: "arangodb/webui:2.0.0"},
+			{Name: "empty", Image: ""}, // empty image, skipped
+		}},
+	}
+
+	// Sorted by image reference; the entry kept for the duplicate comes from chart "a" (name order).
+	require.Equal(t, []packageChartRenderInputImage{
+		{Name: "db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+		{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"},
+		{Name: "webui", Image: "arangodb/webui:2.0.0"},
+	}, aggregateImages(charts))
+}
+
+// Test_renderImagesFile ensures the aggregated images.yaml carries the informational header and the
+// image entries.
+func Test_renderImagesFile(t *testing.T) {
+	out := string(renderImagesFile(packageChartRenderInput{
+		Name: "arango-platform-release", Version: "1.0.0",
+		Images: []packageChartRenderInputImage{{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"}},
+	}))
+
+	require.Contains(t, out, "# Container images bundled by arango-platform-release 1.0.0.")
+	require.Contains(t, out, "Helm does not consume this file")
+	require.Contains(t, out, "name: operator")
+	require.Contains(t, out, "image: arangodb/kube-arangodb:1.4.4")
+
+	// It must be a valid images.yaml document.
+	var doc struct {
+		Images []packageChartRenderInputImage `json:"images"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(out), &doc))
+	require.Equal(t, []packageChartRenderInputImage{{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"}}, doc.Images)
+}
+
+// Test_packageChartTemplateReadme_Images ensures the README renders the aggregated container-image
+// section, and degrades cleanly when a release declares none.
+func Test_packageChartTemplateReadme_Images(t *testing.T) {
+	t.Run("with images", func(t *testing.T) {
+		out, err := packageChartTemplateReadme.RenderBytes(packageChartRenderInput{
+			Name: "arango-platform-release", Version: "1.0.0",
+			Images: []packageChartRenderInputImage{
+				{Name: "operator", Image: "arangodb/kube-arangodb:1.4.4"},
+				{Name: "db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+			},
+		})
+		require.NoError(t, err)
+
+		readme := string(out)
+		require.Contains(t, readme, "## Container Images")
+		require.Contains(t, readme, "| `operator` | `arangodb/kube-arangodb:1.4.4` |")
+		require.Contains(t, readme, "| `db` | `arangodb/arangodb-enterprise:3.12.5` |")
+		require.Contains(t, readme, "images.yaml")
+		require.NotContains(t, readme, "{{")
+		require.NotContains(t, readme, "<no value>")
+	})
+
+	t.Run("no images", func(t *testing.T) {
+		out, err := packageChartTemplateReadme.RenderBytes(packageChartRenderInput{Name: "r", Version: "1"})
+		require.NoError(t, err)
+		require.Contains(t, string(out), "This release declares no container images.")
+		require.NotContains(t, string(out), "{{")
+	})
+}

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -491,6 +491,53 @@ func Test_extractChartImages(t *testing.T) {
 	})
 }
 
+// Test_imagesFromValues ensures container images are derived from a chart's values by composing
+// registry/repository/tag, covering both the ArangoDB `images:` blocks and upstream image specs.
+func Test_imagesFromValues(t *testing.T) {
+	values := map[string]interface{}{
+		// ArangoDB convention: images.<name>.{image,registry,tag}
+		"images": map[string]interface{}{
+			"application": map[string]interface{}{
+				"image":    "gral/engine",
+				"registry": "registry.license.arango.ai",
+				"tag":      "v1.1.12",
+			},
+			"test": map[string]interface{}{
+				"image":    "gral/engine-test",
+				"registry": "registry.license.arango.ai",
+				"tag":      "v1.1.12",
+			},
+		},
+		// Upstream convention: .image.{registry,repository,tag}
+		"imageRenderer": map[string]interface{}{
+			"image": map[string]interface{}{
+				"registry":   "docker.io",
+				"repository": "grafana/grafana-image-renderer",
+				"tag":        "latest",
+			},
+		},
+		// A repo that already carries its registry must not be double-prefixed, and a numeric tag
+		// still composes.
+		"other": map[string]interface{}{
+			"image":    "docker.io/library/busybox",
+			"registry": "docker.io",
+			"tag":      1.31,
+		},
+		// Not an image spec - must be ignored.
+		"imagePullPolicy": "IfNotPresent",
+		"replicas":        3,
+	}
+
+	got := imagesFromValues(values)
+
+	require.ElementsMatch(t, []packageChartRenderInputImage{
+		{Name: "application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
+		{Name: "test", Image: "registry.license.arango.ai/gral/engine-test:v1.1.12"},
+		{Name: "imageRenderer", Image: "docker.io/grafana/grafana-image-renderer:latest"},
+		{Name: "other", Image: "docker.io/library/busybox:1.31"},
+	}, got)
+}
+
 // Test_aggregateImages ensures images from every chart are merged, de-duplicated by image
 // reference, and ordered deterministically regardless of chart map iteration order.
 func Test_aggregateImages(t *testing.T) {

--- a/pkg/platform/templates/readme.md
+++ b/pkg/platform/templates/readme.md
@@ -38,6 +38,35 @@ helm install <release-name> <chart> \
   --set deployment=<arango-deployment-name>
 ```
 
+## Container Images
+{{ if .Images }}
+This release uses the container images below, aggregated from the bundled charts. For an air-gapped
+installation, pull each image, re-tag it to your private registry, push it, and override the
+corresponding image values.
+
+| Name | Image |
+|------|-------|
+{{- range $i := .Images }}
+| `{{ $i.Name }}` | `{{ $i.Image }}` |
+{{- end }}
+
+The same list is available as a machine-readable `images.yaml` at the root of this chart. To mirror
+every image to `my.registry.example.com`:
+
+```bash
+for img in \
+{{- range $i := .Images }}
+  {{ $i.Image }} \
+{{- end }}
+  ; do
+  docker pull "$img"
+  docker tag "$img" "my.registry.example.com/${img#*/}"
+  docker push "my.registry.example.com/${img#*/}"
+done
+```
+{{ else }}
+This release declares no container images.
+{{ end }}
 ## Values
 
 | Key | Type | Required | Description |

--- a/pkg/platform/templates/readme.md
+++ b/pkg/platform/templates/readme.md
@@ -41,13 +41,13 @@ helm install <release-name> <chart> \
 ## Container Images
 {{ if .Images }}
 This release uses the container images below, aggregated from the bundled charts. For an air-gapped
-installation, pull each image, re-tag it to your private registry, push it, and override the
-corresponding image values.
+installation, pull each image, re-tag it to your private registry, push it, and override it at the
+listed values path.
 
-| Name | Image |
-|------|-------|
+| Image | Override path |
+|-------|---------------|
 {{- range $i := .Images }}
-| `{{ $i.Name }}` | `{{ $i.Image }}` |
+| `{{ $i.Image }}` | `{{ $i.OverridePath }}` |
 {{- end }}
 
 The same list is available as a machine-readable `images.yaml` at the root of this chart. To mirror


### PR DESCRIPTION
## Summary

The platform `package chart` command now surfaces **every container image** a release needs, so air-gapped customers know exactly what to mirror. It reads the images from the bundled charts and produces two outputs in the packaged release chart:

- a **`## Container Images`** section in the generated `README.md`, and
- a machine-readable **`images.yaml`** at the chart root (informational only — Helm does not consume it).

## How it works

- For each bundled chart, images are taken from an explicit **`images.yaml`** if the chart ships one; otherwise they are **derived from `values.yaml`** by walking it for image-spec maps (`{image|repository, registry, tag}`) and composing `registry/repo:tag`. This covers both the ArangoDB `images.<name>` convention and upstream `.image` / `repository` layouts (grafana, curl, busybox, k8s-sidecar, …).
- Each entry is `{image, overridePath}`, where `overridePath` is the **chart-prefixed values path** (e.g. `charts.arangodb-gral.images.application`) — the exact key to override to repoint the image at a private registry.
- The aggregated list is **de-duplicated by image** and **sorted** deterministically.
- **Test images are excluded** (the `images.test` key / repositories ending in `-test`).
- An empty list renders as `images: []` (never `null`).

## Validation

Verified end-to-end through the real command against the production release definition (25 component charts pulled from the registry): the release chart builds and `images.yaml` lists 34 production images, each with its `overridePath`. New unit tests cover extraction, values-derivation, test-image filtering, aggregation/dedup, the rendered file, and the README section.