### PR TITLE
ci: add warn-only image CVE scan, bump trivy-scan orb to 1.0

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@4.1
-  trivy-scan: arangodb/trivy-scan@0.1.1
+  trivy-scan: arangodb/trivy-scan@1.0.0
 
 parameters:
   manifests-verify:
@@ -90,6 +90,57 @@ jobs:
           fail-on-findings: false
           store-junit-results: true
 
+  # Image-layer CVE gate (warn-only): the published operator image bundles
+  # the base OS packages and the compiled arangodb_operator/envoy binaries,
+  # none of which are visible to the fs scan above (pre-build analyzers,
+  # lockfiles only). Scans the already-published Docker Hub tag directly via
+  # the registry (image-src: remote), so no image build/docker daemon is
+  # needed in CI. The tag is read from VERSION rather than hardcoded so the
+  # scan tracks whatever this checkout's release line actually ships -
+  # the repo's own "latest" Docker Hub tag was found stale (unrelated to any
+  # recent release) when this job was added.
+  image-cve-scan:
+    executor: golang-executor
+    steps:
+      - checkout
+      - run:
+          name: Resolve released image tag from VERSION
+          command: |
+            echo "export OPERATOR_IMAGE_TAG=$(cut -f1 -d'+' VERSION)" >> "$BASH_ENV"
+      - trivy-scan/scan:
+          scan-type: image
+          image-ref: "arangodb/kube-arangodb-enterprise:${OPERATOR_IMAGE_TAG}"
+          image-src: remote
+          severity: "CRITICAL,HIGH"
+          fail-on-findings: false
+          store-junit-results: true
+          sbom-output: /tmp/sbom-image.cdx.json
+      - store_artifacts:
+          path: /tmp/sbom-image.cdx.json
+          destination: sbom-image.cdx.json
+
+  # Same gate against the UBI9 variant published alongside the Debian-based
+  # image - different base OS package set, same operator/envoy binaries.
+  image-cve-scan-ubi:
+    executor: golang-executor
+    steps:
+      - checkout
+      - run:
+          name: Resolve released image tag from VERSION
+          command: |
+            echo "export OPERATOR_IMAGE_TAG=$(cut -f1 -d'+' VERSION)" >> "$BASH_ENV"
+      - trivy-scan/scan:
+          scan-type: image
+          image-ref: "arangodb/kube-arangodb-enterprise:${OPERATOR_IMAGE_TAG}-ubi"
+          image-src: remote
+          severity: "CRITICAL,HIGH"
+          fail-on-findings: false
+          store-junit-results: true
+          sbom-output: /tmp/sbom-image.cdx.json
+      - store_artifacts:
+          path: /tmp/sbom-image.cdx.json
+          destination: sbom-image.cdx.json
+
 workflows:
   version: 2
 
@@ -97,3 +148,5 @@ workflows:
     jobs:
       - check-code
       - dependency-cve-scan
+      - image-cve-scan
+      - image-cve-scan-ubi


### PR DESCRIPTION
## What

- Bumps the `arangodb/trivy-scan` orb from `0.1.1` to `1.0.0`.
- Adds `image-cve-scan` and `image-cve-scan-ubi` jobs to the `run_tests` workflow, scanning the published Docker Hub operator image (Debian and UBI9 variants) for CRITICAL/HIGH CVEs.

## Why

The only CVE coverage in this repo's CI today is `dependency-cve-scan`, a `scan-type: fs` scan of the checked-out source tree. That only runs Trivy's pre-build analyzers (lockfiles/manifests) — it never sees the base OS packages or the compiled `arangodb_operator`/envoy binaries that actually ship in `arangodb/kube-arangodb-enterprise` on Docker Hub. There's currently no scan of the published image at all before/after it goes out.

## Implementation

CI here doesn't build the operator image (the Jenkins release job does, this repo's Circle config has no `setup_remote_docker`/machine executor), so building one just to scan it would add real infra cost for no extra signal versus scanning what's actually shipped. Instead, both jobs scan the already-published Docker Hub tag directly via the registry (`scan-type: image`, `image-src: remote`), which needs no local Docker daemon.

The tag is resolved from `VERSION` at scan time (`cut -f1 -d'+' VERSION`, mirroring the Makefile's own `VERSION_MAJOR_MINOR_PATCH` derivation) rather than hardcoded to `latest`: the repo's `latest` tag on Docker Hub was found to be several releases behind the current release line, and `latest-ubi` doesn't exist as a tag at all, so neither was usable as a stand-in for "what this branch's release line ships."

Both jobs are warn-only (`fail-on-findings: false`), matching this repo's existing scan tier, and emit a CycloneDX SBOM artifact alongside the JUnit results, consistent with the image-scan convention used elsewhere in the org.

Config validated with `circleci config validate`.