### PR TITLE
Fix data race in the test log scanner that made Test_Apply flaky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Maintenance) Fix a data race in the test log scanner that made Test_Apply flaky by guarding its shared buffer
 - (Feature) (Platform) Generate README.md in the platform release chart and validate chart overrides against each subchart values.schema.json
 
 ## [1.4.4](https://github.com/arangodb/kube-arangodb/tree/1.4.4) (2026-07-20)

--- a/pkg/util/tests/logging.go
+++ b/pkg/util/tests/logging.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/util/tests/logging.go
+++ b/pkg/util/tests/logging.go
@@ -23,6 +23,7 @@ package tests
 import (
 	"bytes"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +32,33 @@ import (
 
 	"github.com/arangodb/kube-arangodb/pkg/logging"
 )
+
+// syncBuffer is a bytes.Buffer safe for concurrent use. The log factory is shared by handlers that
+// run in parallel goroutines, so several zerolog writers append concurrently while the scanner
+// goroutine reads; an unguarded bytes.Buffer is a data race that corrupts log lines (partial JSON,
+// dropped/merged entries) and made Test_Apply flaky.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) ReadRune() (rune, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.ReadRune()
+}
+
+func (s *syncBuffer) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Len()
+}
 
 type LogScanner interface {
 	Factory() logging.Factory
@@ -74,7 +102,7 @@ func (l *logScanner) Get(timeout time.Duration) (string, bool) {
 
 func WithLogScanner(t *testing.T, name string, in func(t *testing.T, s LogScanner)) {
 	t.Run(name, func(t *testing.T) {
-		b := bytes.NewBuffer(nil)
+		b := &syncBuffer{}
 		l := zerolog.New(b)
 		f := logging.NewFactory(l)
 


### PR DESCRIPTION
## Problem

`Test_Apply` (`pkg/crd`) has been intermittently failing in CI — e.g. `invalid character '…'` while parsing a log line, or `expected "CRD Updated", actual "CRD Created"` on CRDs the test never changed. Plain retries turned it green, and it reproduces locally under `go test -count=8`.

## Root cause

`WithLogScanner` (`pkg/util/tests/logging.go`) points zerolog at a plain `bytes.Buffer` and a background goroutine reads from the *same* buffer via `ReadRune`/`Len`. The log factory is shared by handlers that run in parallel goroutines, so several writers append **concurrently** with each other and with the reader. `bytes.Buffer` is not safe for concurrent use — `go test -race` reports a `DATA RACE` on `bytes.Buffer.Write`. The corruption drops/merges log lines and yields partial JSON, which surfaces as the flaky `Test_Apply` assertions that scrape those log messages.

## Fix

Guard the shared buffer with a mutex (`syncBuffer` wrapping `bytes.Buffer` for `Write`/`ReadRune`/`Len`). This is the minimal change that removes the race while preserving the existing accumulate-then-read behaviour.

## Verification

- `go test -race -tags testing ./pkg/crd/ -run Test_Apply -count=10` — was `DATA RACE`, now `ok`.
- `go test -tags testing ./pkg/crd/ -run Test_Apply -count=30` — was flaky at `-count=8`, now `ok`.
- Other `WithLogScanner` users (`pkg/util/tests`, `pkg/util/errors/panics`) pass under `-race`.