### PR TITLE
Propagate service and chart overrides into the generated platform release values.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) (Platform) Propagate service overrides into the generated release values.yaml and deep-merge chart overrides onto chart defaults instead of dropping them
 - (Maintenance) Bump golang.org/x/text to v0.39.0 and golang.org/x/net to v0.56.0 to fix known vulnerabilities
 - (Maintenance) Bump google.golang.org/grpc to v1.82.1, go.opentelemetry.io/otel/sdk to v1.43.0 and oras.land/oras-go/v2 to v2.6.1 to fix known vulnerabilities
 - (Feature) (Platform) Aggregate the container images declared by each bundled chart's images.yaml into a Container Images section of the generated platform release chart README and an aggregated images.yaml for air-gapped mirroring

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -111,6 +111,10 @@ type packageChartRenderInputImage struct {
 type packageChartRenderInputService struct {
 	Name     string
 	ChartRef string
+
+	// Values are the default value overrides for the service, sourced from the release overrides in
+	// the package definition. They are rendered as services.<name>.values in the release values.yaml.
+	Values map[string]interface{}
 }
 
 // packageChartRenderInputValue is a single documented top-level value of a service.
@@ -198,7 +202,10 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 	}
 
 	for k, v := range r.Releases {
-		o := packageChartRelease(k, v)
+		o, err := packageChartRelease(k, v)
+		if err != nil {
+			return err
+		}
 
 		if o != nil {
 			input.Services[k] = *o
@@ -235,7 +242,7 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 
 	// Generate per-service templates
 	for _, s := range input.Services {
-		builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateResourceService, packageChartRenderInputServiceTemplate(s)), "%s/templates/services/%s.yaml", input.Name, s.Name)
+		builder = builder.File(util.GZipBuilderProcessTemplate(packageChartTemplateResourceService, packageChartRenderInputServiceTemplate{Name: s.Name, ChartRef: s.ChartRef}), "%s/templates/services/%s.yaml", input.Name, s.Name)
 	}
 
 	builder = builder.File(util.GZipBuilderProcessBytes(licenseData.Full()), "%s/LICENSE", input.Name)
@@ -251,11 +258,43 @@ func packageChartRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func packageChartRelease(name string, packageSpec helm.PackageRelease) *packageChartRenderInputService {
-	return &packageChartRenderInputService{
+func packageChartRelease(name string, packageSpec helm.PackageRelease) (*packageChartRenderInputService, error) {
+	svc := &packageChartRenderInputService{
 		Name:     name,
 		ChartRef: packageSpec.Package,
 	}
+
+	// Carry the release overrides into the generated values.yaml as the service default values.
+	if len(packageSpec.Overrides) > 0 {
+		values, err := packageSpec.Overrides.Marshal()
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid overrides for service %s", name)
+		}
+		svc.Values = values
+	}
+
+	return svc, nil
+}
+
+// mergeChartValues deep-merges the given overrides on top of the chart defaults. Overrides win and
+// nested maps are merged rather than replaced. Empty overrides return the defaults unchanged; a
+// malformed overrides document is returned as an error rather than being silently dropped.
+func mergeChartValues(defaults map[string]interface{}, overrides helm.Values) (map[string]interface{}, error) {
+	if len(overrides) == 0 {
+		return defaults, nil
+	}
+
+	defaultValues, err := helm.NewValues(defaults)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to encode default values")
+	}
+
+	merged, err := helm.NewMergeRawValues(helm.MergeMaps, defaultValues, overrides)
+	if err != nil {
+		return nil, err
+	}
+
+	return merged.Marshal()
 }
 
 func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint string, name string, packageSpec helm.PackageSpec) (*packageChartRenderInputChart, error) {
@@ -272,14 +311,10 @@ func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint s
 	// Remove internal platform keys not meant for user configuration
 	delete(defaults, "arangodb_platform")
 
-	// Merge platform.yaml overrides on top of chart defaults
-	if len(packageSpec.Overrides) > 0 {
-		var overrides map[string]interface{}
-		if err := json.Unmarshal(packageSpec.Overrides, &overrides); err == nil {
-			for k, v := range overrides {
-				defaults[k] = v
-			}
-		}
+	// Deep-merge the platform.yaml overrides on top of the chart defaults.
+	defaults, err = mergeChartValues(defaults, packageSpec.Overrides)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to merge overrides for chart %s", name)
 	}
 
 	// A chart that ships a values.schema.json we cannot parse is a chart bug: silently

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
+
+	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/helm"
 )
 
 // newTestChart builds a gzipped tar chart archive from the given entries.
@@ -622,4 +624,74 @@ func Test_packageChartTemplateReadme_Images(t *testing.T) {
 		require.Contains(t, string(out), "This release declares no container images.")
 		require.NotContains(t, string(out), "{{")
 	})
+}
+
+// Test_mergeChartValues_DeepMerge ensures chart overrides are deep-merged on top of the chart
+// defaults (nested maps preserved, overrides win), empty overrides are a no-op, and a malformed
+// override document is surfaced rather than silently dropped.
+func Test_mergeChartValues_DeepMerge(t *testing.T) {
+	defaults := map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": "default-repo",
+			"tag":        "1.0",
+		},
+		"replicas": float64(1),
+	}
+
+	t.Run("deep merge keeps sibling keys", func(t *testing.T) {
+		out, err := mergeChartValues(defaults, helm.Values(`{"image":{"repository":"custom-repo"},"replicas":3}`))
+		require.NoError(t, err)
+
+		img := out["image"].(map[string]interface{})
+		require.EqualValues(t, "custom-repo", img["repository"], "override applied")
+		require.EqualValues(t, "1.0", img["tag"], "sibling key preserved by deep merge")
+		require.EqualValues(t, float64(3), out["replicas"])
+	})
+
+	t.Run("empty overrides is a no-op", func(t *testing.T) {
+		out, err := mergeChartValues(defaults, nil)
+		require.NoError(t, err)
+		require.Equal(t, defaults, out)
+	})
+
+	t.Run("malformed overrides surface an error", func(t *testing.T) {
+		_, err := mergeChartValues(defaults, helm.Values(`{not valid json`))
+		require.Error(t, err)
+	})
+}
+
+// Test_packageChartTemplateValues_Overrides ensures release (service) overrides and chart overrides
+// are rendered into the generated values.yaml, rather than being dropped as an empty object.
+func Test_packageChartTemplateValues_Overrides(t *testing.T) {
+	input := packageChartRenderInput{
+		Name: "r", Version: "1",
+		Charts: map[string]packageChartRenderInputChart{
+			"c": {Name: "c", Version: "1", Values: map[string]interface{}{"image": map[string]interface{}{"repository": "custom-repo"}}},
+		},
+		Services: map[string]packageChartRenderInputService{
+			"withValues": {Name: "withValues", ChartRef: "c", Values: map[string]interface{}{"foo": "bar", "nested": map[string]interface{}{"x": float64(1)}}},
+			"empty":      {Name: "empty", ChartRef: "c"},
+		},
+	}
+
+	out, err := packageChartTemplateValues.RenderBytes(input)
+	require.NoError(t, err)
+
+	var doc map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &doc), "values.yaml must parse: %s", string(out))
+
+	charts := doc["charts"].(map[string]interface{})
+	cVals := charts["c"].(map[string]interface{})
+	require.EqualValues(t, "custom-repo", cVals["image"].(map[string]interface{})["repository"], "chart override must be rendered")
+
+	services := doc["services"].(map[string]interface{})
+
+	withValues := services["withValues"].(map[string]interface{})
+	vals := withValues["values"].(map[string]interface{})
+	require.EqualValues(t, "bar", vals["foo"], "service override must be rendered, not dropped")
+	require.EqualValues(t, float64(1), vals["nested"].(map[string]interface{})["x"])
+
+	empty := services["empty"].(map[string]interface{})
+	require.NotNil(t, empty["values"], "service without overrides keeps an empty-object values")
+	require.Empty(t, empty["values"], "service without overrides renders {}")
 }

--- a/pkg/platform/templates/values.yaml
+++ b/pkg/platform/templates/values.yaml
@@ -30,6 +30,8 @@ deployment: ""
 {{ end }}
 {{ if .Services }}services:
 {{ range $key, $value := .Services }}  {{ $value.Name }}:
-    values: {}
-{{ end }}{{ else }}services: {}
+{{ if $value.Values }}    values:
+{{ $value.Values | toYaml | indent 6 }}
+{{ else }}    values: {}
+{{ end }}{{ end }}{{ else }}services: {}
 {{ end }}


### PR DESCRIPTION
## Problem

Overrides defined in the package definition YAML were not reaching the generated release `values.yaml`:

- **Service (release) overrides were fully dropped** — the service render struct carried no values and the `values.yaml` template hardcoded `services.<name>.values: {}`, so a release's `overrides:` never appeared.
- **Chart (package) overrides were shallow-merged** — `defaults[k] = v` at the top level replaced whole nested maps (e.g. overriding `image.repository` wiped `image.tag`), and a malformed override was silently swallowed (`if err := json.Unmarshal(...); err == nil`).

## Fix

- Add a `Values` field to the service render input and populate it from `packageSpec.Overrides`; render it in the `values.yaml` template (with a `{}` fallback). `packageChartRelease` now returns an error on malformed overrides.
- Extract `mergeChartValues`, which **deep-merges** overrides onto chart defaults via `helm.NewMergeRawValues(helm.MergeMaps, …)` and **propagates** errors instead of dropping them.

## Verification

Rendered the real template — `services.<name>.values` now carries the overrides, and chart deep-merge preserves sibling keys. Added `Test_mergeChartValues_DeepMerge` and `Test_packageChartTemplateValues_Overrides`; full `pkg/platform` suite and vet pass.