### PR TITLE
Strip pre-release suffix from detected ArangoDB version so version/feature gates compare numerically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) Strip the pre-release/build suffix (e.g. `-devel`) from the detected ArangoDB version so version and feature gates compare numerically instead of mis-ordering nightly builds below release versions
 - (Feature) Inventory Collector writing a startup event to the ArangoDB `_events` collection (created if missing) on each member boot when the (hidden) collector feature is enabled
 - (Bugfix) (Platform) Propagate service overrides into the generated release values.yaml and deep-merge chart overrides onto chart defaults instead of dropping them
 - (Maintenance) Bump golang.org/x/text to v0.39.0 and golang.org/x/net to v0.56.0 to fix known vulnerabilities

--- a/pkg/deployment/images.go
+++ b/pkg/deployment/images.go
@@ -30,6 +30,8 @@ import (
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	adbDriverV2 "github.com/arangodb/go-driver/v2/arangodb"
+
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
 	schedulerApi "github.com/arangodb/kube-arangodb/pkg/apis/scheduler/v1beta1"
 	shared "github.com/arangodb/kube-arangodb/pkg/apis/shared"
@@ -52,6 +54,22 @@ import (
 
 var _ interfaces.PodCreator = &ImageUpdatePod{}
 var _ interfaces.ContainerCreator = &ContainerIdentity{}
+
+// stripArangoDBVersionSuffix removes a pre-release/build suffix - everything from the first '-'
+// (e.g. "-devel", "-nightly", "-rc1") - from a detected ArangoDB version.
+//
+// driver.Version.CompareTo compares the sub-part numerically only when it is a pure integer, and
+// otherwise falls back to a lexicographic string comparison. That makes e.g. "3.12.10-devel" (sub
+// "10-devel") compare as LOWER than "3.12.9" ("10-devel" < "9" as strings), so every version/feature
+// gate keyed on a minimum ArangoDB version is silently treated as unmet - which disables features
+// and integration provisioning (e.g. meta.v1 / storage.v2) on nightly images. Trimming the suffix
+// restores the intended numeric comparison; a "-devel" build of 3.12.10 is treated as 3.12.10.
+func stripArangoDBVersionSuffix(v adbDriverV2.Version) adbDriverV2.Version {
+	if base, _, ok := goStrings.Cut(string(v), "-"); ok {
+		return adbDriverV2.Version(base)
+	}
+	return v
+}
 
 // ImageUpdatePod describes how to launch the ID ArangoD POD.
 type ImageUpdatePod struct {
@@ -186,7 +204,7 @@ func (ib *imagesBuilder) fetchArangoDBImageIDAndVersion(ctx context.Context, cac
 			log.Err(err).Debug("Failed to fetch version from Image ID  ArangoSchedulerPod")
 			return true, nil
 		}
-		version := v.Version
+		version := stripArangoDBVersionSuffix(v.Version)
 		enterprise := goStrings.ToLower(v.License) == "enterprise"
 
 		// We have all the info we need now, kill the pod and store the image info.

--- a/pkg/deployment/images_test.go
+++ b/pkg/deployment/images_test.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2025 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	adbDriverV2 "github.com/arangodb/go-driver/v2/arangodb"
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
 	shared "github.com/arangodb/kube-arangodb/pkg/apis/shared"
@@ -540,4 +542,35 @@ func getTestTolerations() []core.Toleration {
 		tolerations.NewNoExecuteToleration(tolerations.TolerationKeyNodeUnreachable, shortDur),
 		tolerations.NewNoExecuteToleration(tolerations.TolerationKeyNodeAlphaUnreachable, shortDur),
 	}
+}
+
+// Test_stripArangoDBVersionSuffix ensures a pre-release/build suffix is trimmed so that a detected
+// nightly version (e.g. "3.12.10-devel") compares numerically like its base version, instead of
+// falling into driver.Version's lexicographic sub-part fallback which mis-orders it below "3.12.9".
+func Test_stripArangoDBVersionSuffix(t *testing.T) {
+	for in, expected := range map[adbDriverV2.Version]adbDriverV2.Version{
+		"3.12.10-devel":   "3.12.10",
+		"3.12.10-nightly": "3.12.10",
+		"3.12.10-rc1":     "3.12.10",
+		"3.12.10":         "3.12.10",  // release: unchanged
+		"3.12.9.1":        "3.12.9.1", // 4-part release (no '-'): unchanged
+		"":                "",
+	} {
+		t.Run(string(in), func(t *testing.T) {
+			require.Equal(t, expected, stripArangoDBVersionSuffix(in))
+		})
+	}
+
+	// The whole point: after stripping, the version orders correctly against release gates where the
+	// raw "-devel" string would not.
+	t.Run("comparison is fixed", func(t *testing.T) {
+		raw := adbDriverV2.Version("3.12.10-devel")
+		// Raw form is mis-ordered by the driver (lexicographic "10-devel" < "9").
+		require.Less(t, raw.CompareTo("3.12.9"), 0, "precondition: raw devel version mis-compares below 3.12.9")
+
+		norm := stripArangoDBVersionSuffix(raw)
+		require.Greater(t, norm.CompareTo("3.12.9"), 0, "normalized 3.12.10 must be >= 3.12.9")
+		require.GreaterOrEqual(t, norm.CompareTo("3.12.8"), 0)
+		require.Equal(t, 0, norm.CompareTo("3.12.10"))
+	})
 }


### PR DESCRIPTION
## Problem

On a nightly/devel ArangoDB image the operator detects a version like `3.12.10-devel`. The go-driver `Version.CompareTo` only compares the sub-part numerically when it is a pure integer, and otherwise falls back to a **lexicographic string comparison**:

```go
a, aIsInt := v.SubInt()          // Sub("3.12.10-devel") = "10-devel" -> Atoi fails
if !aIsInt || !bIsInt {
    return strings.Compare(v.Sub(), other.Sub())   // "10-devel" vs "9" -> '1' < '9' -> -1
}
```

So `3.12.10-devel` is judged **lower than `3.12.9`** (and 3.12.8, 3.12.5, …). Every version/feature gate keyed on a minimum ArangoDB version is then treated as unmet, which silently disables features and integration provisioning (e.g. `meta.v1` / `storage.v2` / central authorization). This surfaced as a full test suite hitting `rpc error: code = Unimplemented desc = unknown service …` for every central-integration test, while non-central paths passed.

## Fix

Normalize the detected version at the single ingestion point in `fetchArangoDBImageIDAndVersion` by trimming the pre-release/build suffix (everything from the first `-`). A `-devel` build of 3.12.10 is then treated as `3.12.10`, which is the operator's intent for feature gating. Release versions and 4-part versions (`3.12.9.1`) are unchanged. Fixing it at ingestion means all downstream gates compare correctly without touching the vendored driver or every call site.

## Test

`Test_stripArangoDBVersionSuffix` encodes the bug and the fix: it asserts the raw `3.12.10-devel` mis-compares below `3.12.9` (precondition), and that after stripping it compares `> 3.12.9`, `>= 3.12.8`, and `== 3.12.10`.