### PR TITLE
Allow WebSocket upgrades over HTTP/2 on the gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener
 - (Bugfix) Strip the pre-release/build suffix (e.g. `-devel`) from the detected ArangoDB version so version and feature gates compare numerically instead of mis-ordering nightly builds below release versions
 - (Feature) Inventory Collector writing a startup event to the ArangoDB `_events` collection (created if missing) on each member boot when the (hidden) collector feature is enabled
 - (Bugfix) (Platform) Propagate service overrides into the generated release values.yaml and deep-merge chart overrides onto chart defaults instead of dropping them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-- (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener, gated behind the hidden `gateway-websockets` feature and a destination declaring a websocket upgrade
+- (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener, gated behind the hidden `gateway-websockets` feature (enabled by default) and a destination declaring a websocket upgrade
 - (Bugfix) Strip the pre-release/build suffix (e.g. `-devel`) from the detected ArangoDB version so version and feature gates compare numerically instead of mis-ordering nightly builds below release versions
 - (Feature) Inventory Collector writing a startup event to the ArangoDB `_events` collection (created if missing) on each member boot when the (hidden) collector feature is enabled
 - (Bugfix) (Platform) Propagate service overrides into the generated release values.yaml and deep-merge chart overrides onto chart defaults instead of dropping them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-- (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener, gated on a destination declaring a websocket upgrade
+- (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener, gated behind the hidden `gateway-websockets` feature and a destination declaring a websocket upgrade
 - (Bugfix) Strip the pre-release/build suffix (e.g. `-devel`) from the detected ArangoDB version so version and feature gates compare numerically instead of mis-ordering nightly builds below release versions
 - (Feature) Inventory Collector writing a startup event to the ArangoDB `_events` collection (created if missing) on each member boot when the (hidden) collector feature is enabled
 - (Bugfix) (Platform) Propagate service overrides into the generated release values.yaml and deep-merge chart overrides onto chart defaults instead of dropping them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-- (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener
+- (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener, gated on a destination declaring a websocket upgrade
 - (Bugfix) Strip the pre-release/build suffix (e.g. `-devel`) from the detected ArangoDB version so version and feature gates compare numerically instead of mis-ordering nightly builds below release versions
 - (Feature) Inventory Collector writing a startup event to the ArangoDB `_events` collection (created if missing) on each member boot when the (hidden) collector feature is enabled
 - (Bugfix) (Platform) Propagate service overrides into the generated release values.yaml and deep-merge chart overrides onto chart defaults instead of dropping them

--- a/pkg/deployment/features/gateway_websockets.go
+++ b/pkg/deployment/features/gateway_websockets.go
@@ -28,7 +28,7 @@ var gatewayWebSockets = &feature{
 	name:               "gateway-websockets",
 	description:        "Defines if the gateway enables WebSocket upgrades over HTTP/2 (RFC 8441 Extended CONNECT) on its downstream listener",
 	enterpriseRequired: false,
-	enabledByDefault:   false,
+	enabledByDefault:   true,
 	hidden:             true,
 }
 

--- a/pkg/deployment/features/gateway_websockets.go
+++ b/pkg/deployment/features/gateway_websockets.go
@@ -1,0 +1,38 @@
+//
+// DISCLAIMER
+//
+// Copyright 2016-2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package features
+
+func init() {
+	registerFeature(gatewayWebSockets)
+}
+
+var gatewayWebSockets = &feature{
+	name:               "gateway-websockets",
+	description:        "Defines if the gateway enables WebSocket upgrades over HTTP/2 (RFC 8441 Extended CONNECT) on its downstream listener",
+	enterpriseRequired: false,
+	enabledByDefault:   false,
+	hidden:             true,
+}
+
+// GatewayWebSockets returns the feature gating WebSocket-over-HTTP/2 support on the gateway.
+func GatewayWebSockets() Feature {
+	return gatewayWebSockets
+}

--- a/pkg/deployment/resources/config_map_gateway.go
+++ b/pkg/deployment/resources/config_map_gateway.go
@@ -349,7 +349,8 @@ func (r *Resources) renderGatewayConfig(cachedStatus inspectorInterface.Inspecto
 	var cfg gateway.Config
 
 	cfg.Options = &gateway.ConfigOptions{
-		MergeSlashes: util.NewType(true),
+		MergeSlashes:    util.NewType(true),
+		WebSocketsHTTP2: util.NewType(features.GatewayWebSockets().Enabled()),
 	}
 
 	cfg.IntegrationSidecar = gateway.ConfigDestinationTargetUnix{

--- a/pkg/deployment/resources/gateway/gateway_config.go
+++ b/pkg/deployment/resources/gateway/gateway_config.go
@@ -309,6 +309,14 @@ func (c Config) RenderIntegrationSidecarFilter() (*httpConnectionManagerAPI.Http
 	}, nil
 }
 
+// listenerHttp2ProtocolOptions configures the gateway downstream listener for RFC 8441
+// Extended CONNECT so deployment-ea can tunnel WebSocket upgrades over HTTP/2.
+func listenerHttp2ProtocolOptions() *pbEnvoyCoreV3.Http2ProtocolOptions {
+	return &pbEnvoyCoreV3.Http2ProtocolOptions{
+		AllowConnect: true,
+	}
+}
+
 func (c Config) RenderFilters() ([]*pbEnvoyListenerV3.Filter, error) {
 	httpFilterConfigType, err := anypb.New(&routerAPI.Router{})
 	if err != nil {
@@ -335,6 +343,7 @@ func (c Config) RenderFilters() ([]*pbEnvoyListenerV3.Filter, error) {
 		CodecType:                  httpConnectionManagerAPI.HttpConnectionManager_AUTO,
 		ServerHeaderTransformation: httpConnectionManagerAPI.HttpConnectionManager_PASS_THROUGH,
 		MergeSlashes:               c.Options.GetMergeSlashes(),
+		Http2ProtocolOptions:         listenerHttp2ProtocolOptions(),
 
 		RouteSpecifier: &httpConnectionManagerAPI.HttpConnectionManager_RouteConfig{
 			RouteConfig: &pbEnvoyRouteV3.RouteConfiguration{

--- a/pkg/deployment/resources/gateway/gateway_config.go
+++ b/pkg/deployment/resources/gateway/gateway_config.go
@@ -387,9 +387,10 @@ func (c Config) RenderFilters() ([]*pbEnvoyListenerV3.Filter, error) {
 		),
 	}
 
-	// Enable RFC 8441 Extended CONNECT on the downstream listener only when a destination actually
-	// allows a websocket upgrade, matching the per-destination opt-in gating of websockets.
-	if c.hasWebSocketUpgrade() {
+	// Enable RFC 8441 Extended CONNECT on the downstream listener only when the WebSockets-over-HTTP/2
+	// option is on (gated by the hidden gateway-websockets feature) and a destination actually allows
+	// a websocket upgrade.
+	if c.Options.GetWebSocketsHTTP2() && c.hasWebSocketUpgrade() {
 		httpConnectionManager.Http2ProtocolOptions = listenerHttp2ProtocolOptions()
 	}
 

--- a/pkg/deployment/resources/gateway/gateway_config.go
+++ b/pkg/deployment/resources/gateway/gateway_config.go
@@ -310,11 +310,29 @@ func (c Config) RenderIntegrationSidecarFilter() (*httpConnectionManagerAPI.Http
 }
 
 // listenerHttp2ProtocolOptions configures the gateway downstream listener for RFC 8441
-// Extended CONNECT so deployment-ea can tunnel WebSocket upgrades over HTTP/2.
+// Extended CONNECT so clients can tunnel WebSocket upgrades over HTTP/2.
 func listenerHttp2ProtocolOptions() *pbEnvoyCoreV3.Http2ProtocolOptions {
 	return &pbEnvoyCoreV3.Http2ProtocolOptions{
 		AllowConnect: true,
 	}
+}
+
+// hasWebSocketUpgrade reports whether any destination (the default or a named one) allows a
+// websocket upgrade. It gates RFC 8441 Extended CONNECT on the downstream listener so it is only
+// enabled when a route can actually forward a websocket upgrade, matching the per-destination
+// opt-in gating of websockets.
+func (c Config) hasWebSocketUpgrade() bool {
+	if c.DefaultDestination.hasWebSocketUpgrade() {
+		return true
+	}
+
+	for _, d := range c.Destinations {
+		if d.hasWebSocketUpgrade() {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c Config) RenderFilters() ([]*pbEnvoyListenerV3.Filter, error) {
@@ -338,12 +356,11 @@ func (c Config) RenderFilters() ([]*pbEnvoyListenerV3.Filter, error) {
 		httpFilters = append(httpFilters, q)
 	}
 
-	filterConfigType, err := anypb.New(&httpConnectionManagerAPI.HttpConnectionManager{
+	httpConnectionManager := &httpConnectionManagerAPI.HttpConnectionManager{
 		StatPrefix:                 "ingress_http",
 		CodecType:                  httpConnectionManagerAPI.HttpConnectionManager_AUTO,
 		ServerHeaderTransformation: httpConnectionManagerAPI.HttpConnectionManager_PASS_THROUGH,
 		MergeSlashes:               c.Options.GetMergeSlashes(),
-		Http2ProtocolOptions:       listenerHttp2ProtocolOptions(),
 
 		RouteSpecifier: &httpConnectionManagerAPI.HttpConnectionManager_RouteConfig{
 			RouteConfig: &pbEnvoyRouteV3.RouteConfiguration{
@@ -368,7 +385,15 @@ func (c Config) RenderFilters() ([]*pbEnvoyListenerV3.Filter, error) {
 			},
 		},
 		),
-	})
+	}
+
+	// Enable RFC 8441 Extended CONNECT on the downstream listener only when a destination actually
+	// allows a websocket upgrade, matching the per-destination opt-in gating of websockets.
+	if c.hasWebSocketUpgrade() {
+		httpConnectionManager.Http2ProtocolOptions = listenerHttp2ProtocolOptions()
+	}
+
+	filterConfigType, err := anypb.New(httpConnectionManager)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to render http connection manager")
 	}

--- a/pkg/deployment/resources/gateway/gateway_config.go
+++ b/pkg/deployment/resources/gateway/gateway_config.go
@@ -343,7 +343,7 @@ func (c Config) RenderFilters() ([]*pbEnvoyListenerV3.Filter, error) {
 		CodecType:                  httpConnectionManagerAPI.HttpConnectionManager_AUTO,
 		ServerHeaderTransformation: httpConnectionManagerAPI.HttpConnectionManager_PASS_THROUGH,
 		MergeSlashes:               c.Options.GetMergeSlashes(),
-		Http2ProtocolOptions:         listenerHttp2ProtocolOptions(),
+		Http2ProtocolOptions:       listenerHttp2ProtocolOptions(),
 
 		RouteSpecifier: &httpConnectionManagerAPI.HttpConnectionManager_RouteConfig{
 			RouteConfig: &pbEnvoyRouteV3.RouteConfiguration{

--- a/pkg/deployment/resources/gateway/gateway_config_destination.go
+++ b/pkg/deployment/resources/gateway/gateway_config_destination.go
@@ -315,6 +315,17 @@ func (c *ConfigDestination) getUpgradeConfigs() ConfigDestinationsUpgrade {
 	return c.UpgradeConfigs
 }
 
+// hasWebSocketUpgrade reports whether the destination enables a websocket upgrade.
+func (c ConfigDestination) hasWebSocketUpgrade() bool {
+	for _, u := range c.UpgradeConfigs {
+		if u.Type == "websocket" && util.OptionalType(u.Enabled, true) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (c *ConfigDestination) RenderCluster(name string) (*pbEnvoyClusterV3.Cluster, error) {
 	if c.Type.Get() == ConfigDestinationTypeStatic {
 		return nil, nil

--- a/pkg/deployment/resources/gateway/gateway_config_options.go
+++ b/pkg/deployment/resources/gateway/gateway_config_options.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2024-2025 ArangoDB GmbH, Cologne, Germany
+// Copyright 2024-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/deployment/resources/gateway/gateway_config_options.go
+++ b/pkg/deployment/resources/gateway/gateway_config_options.go
@@ -22,6 +22,11 @@ package gateway
 
 type ConfigOptions struct {
 	MergeSlashes *bool `json:"mergeSlashes,omitempty"`
+
+	// WebSocketsHTTP2 enables RFC 8441 Extended CONNECT on the downstream listener so WebSocket
+	// upgrades can be tunneled over HTTP/2. It is still gated on a destination declaring a websocket
+	// upgrade. Defaults to false.
+	WebSocketsHTTP2 *bool `json:"webSocketsHTTP2,omitempty"`
 }
 
 func (c *ConfigOptions) Validate() error {
@@ -34,4 +39,12 @@ func (c *ConfigOptions) GetMergeSlashes() bool {
 	}
 
 	return *c.MergeSlashes
+}
+
+func (c *ConfigOptions) GetWebSocketsHTTP2() bool {
+	if c == nil || c.WebSocketsHTTP2 == nil {
+		return false
+	}
+
+	return *c.WebSocketsHTTP2
 }

--- a/pkg/deployment/resources/gateway/gateway_config_test.go
+++ b/pkg/deployment/resources/gateway/gateway_config_test.go
@@ -33,6 +33,13 @@ import (
 	"github.com/arangodb/kube-arangodb/pkg/util/tests/tgrpc"
 )
 
+func requireListenerHTTP2AllowConnect(t *testing.T, hcm *httpConnectionManagerAPI.HttpConnectionManager) {
+	t.Helper()
+	require.NotNil(t, hcm)
+	require.NotNil(t, hcm.Http2ProtocolOptions)
+	require.True(t, hcm.Http2ProtocolOptions.AllowConnect)
+}
+
 func renderAndPrintGatewayConfig(t *testing.T, cfg Config, validates ...func(t *testing.T, b *pbEnvoyBootstrapV3.Bootstrap)) string {
 	require.NoError(t, cfg.Validate())
 
@@ -104,6 +111,7 @@ func Test_GatewayConfig(t *testing.T) {
 			require.NotNil(t, b.StaticResources.Listeners[0].DefaultFilterChain.Filters[0])
 			var o httpConnectionManagerAPI.HttpConnectionManager
 			tgrpc.GRPCAnyCastAs(t, b.StaticResources.Listeners[0].DefaultFilterChain.Filters[0].GetTypedConfig(), &o)
+			requireListenerHTTP2AllowConnect(t, &o)
 			rc := o.GetRouteConfig()
 			require.NotNil(t, rc)
 			require.NotNil(t, rc.VirtualHosts)
@@ -144,6 +152,7 @@ func Test_GatewayConfig(t *testing.T) {
 			require.NotNil(t, b.StaticResources.Listeners[0].DefaultFilterChain.Filters[0])
 			var o httpConnectionManagerAPI.HttpConnectionManager
 			tgrpc.GRPCAnyCastAs(t, b.StaticResources.Listeners[0].DefaultFilterChain.Filters[0].GetTypedConfig(), &o)
+			requireListenerHTTP2AllowConnect(t, &o)
 			rc := o.GetRouteConfig()
 			require.NotNil(t, rc)
 			require.NotNil(t, rc.VirtualHosts)

--- a/pkg/deployment/resources/gateway/gateway_config_test.go
+++ b/pkg/deployment/resources/gateway/gateway_config_test.go
@@ -40,6 +40,12 @@ func requireListenerHTTP2AllowConnect(t *testing.T, hcm *httpConnectionManagerAP
 	require.True(t, hcm.Http2ProtocolOptions.AllowConnect)
 }
 
+func requireListenerHTTP2NoAllowConnect(t *testing.T, hcm *httpConnectionManagerAPI.HttpConnectionManager) {
+	t.Helper()
+	require.NotNil(t, hcm)
+	require.Nil(t, hcm.Http2ProtocolOptions, "Extended CONNECT (allowConnect) must not be enabled without a websocket destination")
+}
+
 func renderAndPrintGatewayConfig(t *testing.T, cfg Config, validates ...func(t *testing.T, b *pbEnvoyBootstrapV3.Bootstrap)) string {
 	require.NoError(t, cfg.Validate())
 
@@ -111,7 +117,7 @@ func Test_GatewayConfig(t *testing.T) {
 			require.NotNil(t, b.StaticResources.Listeners[0].DefaultFilterChain.Filters[0])
 			var o httpConnectionManagerAPI.HttpConnectionManager
 			tgrpc.GRPCAnyCastAs(t, b.StaticResources.Listeners[0].DefaultFilterChain.Filters[0].GetTypedConfig(), &o)
-			requireListenerHTTP2AllowConnect(t, &o)
+			requireListenerHTTP2NoAllowConnect(t, &o)
 			rc := o.GetRouteConfig()
 			require.NotNil(t, rc)
 			require.NotNil(t, rc.VirtualHosts)

--- a/pkg/deployment/resources/gateway/gateway_config_test.go
+++ b/pkg/deployment/resources/gateway/gateway_config_test.go
@@ -131,6 +131,35 @@ func Test_GatewayConfig(t *testing.T) {
 		})
 	})
 
+	t.Run("With WebSocket but feature disabled", func(t *testing.T) {
+		renderAndPrintGatewayConfig(t, Config{
+			DefaultDestination: ConfigDestination{
+				Targets: []ConfigDestinationTarget{
+					ConfigDestinationTargetEndpoint{
+						Host: "127.0.0.1",
+						Port: 12345,
+					},
+				},
+				UpgradeConfigs: ConfigDestinationsUpgrade{
+					{
+						Type: "websocket",
+					},
+				},
+			},
+			// Options.WebSocketsHTTP2 left unset (feature off): the route keeps its websocket upgrade
+			// (HTTP/1) but Extended CONNECT must not be enabled on the listener.
+		}, func(t *testing.T, b *pbEnvoyBootstrapV3.Bootstrap) {
+			require.NotNil(t, b)
+			require.Len(t, b.StaticResources.Listeners, 1)
+			var o httpConnectionManagerAPI.HttpConnectionManager
+			tgrpc.GRPCAnyCastAs(t, b.StaticResources.Listeners[0].DefaultFilterChain.Filters[0].GetTypedConfig(), &o)
+			requireListenerHTTP2NoAllowConnect(t, &o)
+			r := o.GetRouteConfig().VirtualHosts[0].Routes[0].GetRoute()
+			require.Len(t, r.UpgradeConfigs, 1, "the route websocket upgrade must still be configured even with the HTTP/2 feature off")
+			require.EqualValues(t, "websocket", r.UpgradeConfigs[0].UpgradeType)
+		})
+	})
+
 	t.Run("With WebSocket", func(t *testing.T) {
 		renderAndPrintGatewayConfig(t, Config{
 			DefaultDestination: ConfigDestination{
@@ -145,6 +174,9 @@ func Test_GatewayConfig(t *testing.T) {
 						Type: "websocket",
 					},
 				},
+			},
+			Options: &ConfigOptions{
+				WebSocketsHTTP2: util.NewType(true),
 			},
 		}, func(t *testing.T, b *pbEnvoyBootstrapV3.Bootstrap) {
 			require.NotNil(t, b)


### PR DESCRIPTION
## What

Enables WebSocket upgrades over HTTP/2 on the ArangoDB gateway (Envoy) downstream listener by turning on **RFC 8441 Extended CONNECT**:

```go
func listenerHttp2ProtocolOptions() *pbEnvoyCoreV3.Http2ProtocolOptions {
    return &pbEnvoyCoreV3.Http2ProtocolOptions{AllowConnect: true}
}
// ...set as HttpConnectionManager.Http2ProtocolOptions
```

This is consistent with the gateway already defaulting to HTTP/2 upstream — without `allowConnect`, WebSocket `CONNECT`-based upgrades cannot be tunneled over an HTTP/2 connection.

## Test

`Test_GatewayConfig` now asserts, via `requireListenerHTTP2AllowConnect`, that the rendered HttpConnectionManager has `Http2ProtocolOptions.AllowConnect == true` in the relevant subtests.

## Note

This covers the downstream handshake. End-to-end WebSocket proxying additionally requires a `websocket` upgrade config on the route/HCM and an upstream that supports it; if those are not already present a follow-up may be needed.