### PR TITLE
Gate authentication CreateToken behind the authorization integration (IAM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) (Security) Gate authentication token creation behind the authorization integration (IAM) when central services are enabled and asymmetric signing keys are in use (the remote-validation prerequisite), and remove the static `token.allowed` allow-list
 - (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener, gated behind the hidden `gateway-websockets` feature (enabled by default) and a destination declaring a websocket upgrade
 - (Bugfix) Strip the pre-release/build suffix (e.g. `-devel`) from the detected ArangoDB version so version and feature gates compare numerically instead of mis-ordering nightly builds below release versions
 - (Feature) Inventory Collector writing a startup event to the ArangoDB `_events` collection (created if missing) on each member boot when the (hidden) collector feature is enabled

--- a/docs/cli/arangodb_operator_integration.md
+++ b/docs/cli/arangodb_operator_integration.md
@@ -35,7 +35,6 @@ Flags:
       --integration.authentication.v1.external                                                 Defines if External access to service authentication.v1 is enabled (Env: INTEGRATION_AUTHENTICATION_V1_EXTERNAL)
       --integration.authentication.v1.internal                                                 Defines if Internal access to service authentication.v1 is enabled (Env: INTEGRATION_AUTHENTICATION_V1_INTERNAL) (default true)
       --integration.authentication.v1.path string                                              Path to the JWT Folder (Env: INTEGRATION_AUTHENTICATION_V1_PATH)
-      --integration.authentication.v1.token.allowed strings                                    Allowed users for the Token (Env: INTEGRATION_AUTHENTICATION_V1_TOKEN_ALLOWED)
       --integration.authentication.v1.token.max-size uint16                                    Max Token max size in bytes (Env: INTEGRATION_AUTHENTICATION_V1_TOKEN_MAX_SIZE) (default 64)
       --integration.authentication.v1.token.ttl.default duration                               Default Token TTL (Env: INTEGRATION_AUTHENTICATION_V1_TOKEN_TTL_DEFAULT) (default 1h0m0s)
       --integration.authentication.v1.token.ttl.max duration                                   Max Token TTL (Env: INTEGRATION_AUTHENTICATION_V1_TOKEN_TTL_MAX) (default 1h0m0s)

--- a/integrations/authentication/v1/configuration.go
+++ b/integrations/authentication/v1/configuration.go
@@ -21,7 +21,6 @@
 package v1
 
 import (
-	"slices"
 	"time"
 
 	"github.com/arangodb/kube-arangodb/pkg/util"
@@ -48,12 +47,11 @@ func NewConfiguration() Configuration {
 		TTL:     DefaultTTL,
 		Path:    "",
 		Create: Token{
-			DefaultUser:  DefaultUser,
-			AllowedUsers: nil,
-			MinTTL:       DefaultTokenMinTTL,
-			MaxTTL:       DefaultTokenMaxTTL,
-			DefaultTTL:   DefaultTokenDefaultTTL,
-			MaxSize:      DefaultMaxTokenSize,
+			DefaultUser: DefaultUser,
+			MinTTL:      DefaultTokenMinTTL,
+			MaxTTL:      DefaultTokenMaxTTL,
+			DefaultTTL:  DefaultTokenDefaultTTL,
+			MaxSize:     DefaultMaxTokenSize,
 		},
 	}
 }
@@ -97,8 +95,6 @@ func (c Configuration) Validate() error {
 type Token struct {
 	DefaultUser string
 
-	AllowedUsers []string
-
 	MinTTL, MaxTTL, DefaultTTL time.Duration
 
 	MaxSize uint16
@@ -123,14 +119,6 @@ func (t Token) Validate() error {
 
 	if t.MaxSize <= 0 {
 		return errors.Errorf("MaxSize cannot be less or equal 0")
-	}
-
-	if len(t.AllowedUsers) > 0 {
-		// We are enforcing allowed users
-
-		if !slices.Contains(t.AllowedUsers, t.DefaultUser) {
-			return errors.Errorf("DefaultUser should be always allowed")
-		}
 	}
 
 	return nil

--- a/integrations/authentication/v1/implementation.go
+++ b/integrations/authentication/v1/implementation.go
@@ -36,12 +36,14 @@ import (
 	adbDriverV2 "github.com/arangodb/go-driver/v2/arangodb"
 
 	pbAuthenticationV1 "github.com/arangodb/kube-arangodb/integrations/authentication/v1/definition"
+	pbAuthorizationV1 "github.com/arangodb/kube-arangodb/integrations/authorization/v1/definition"
 	pbImplAuthorizationV1Shared "github.com/arangodb/kube-arangodb/integrations/authorization/v1/shared"
 	"github.com/arangodb/kube-arangodb/integrations/envoy/auth/v3/impl/auth_cookie"
 	pbSharedV1 "github.com/arangodb/kube-arangodb/integrations/shared/v1/definition"
 	platformAuthenticationApi "github.com/arangodb/kube-arangodb/pkg/apis/platform/v1beta1/authentication"
 	sidecarSvcAuthzClient "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/client"
 	sidecarSvcAuthzDefinition "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/definition"
+	sidecarSvcAuthzTypes "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/types"
 	"github.com/arangodb/kube-arangodb/pkg/util"
 	"github.com/arangodb/kube-arangodb/pkg/util/cache"
 	utilConstants "github.com/arangodb/kube-arangodb/pkg/util/constants"
@@ -111,12 +113,17 @@ type implementation struct {
 	authz pbImplAuthorizationV1Shared.Evaluator
 }
 
-// authorizeCreateToken enforces the IAM permission for minting a token. It applies only when central
-// services are enabled AND the signing key is asymmetric: remote nodes can validate a minted token
-// only with the public half of an asymmetric key, so the central-authorization/remote-validation flow
-// is meaningful only there. With symmetric keys (or without central services) token creation keeps its
-// legacy, unrestricted behaviour.
-func (i *implementation) authorizeCreateToken(ctx context.Context, secret utilToken.Secret, user string) error {
+// authorizeCreateToken enforces the IAM permission for minting a token. The authorization subject is
+// the user the token is being minted for (request.User/Groups) - which is the identity carried by the
+// request (e.g. the gateway forwards the authenticated end-user here) - evaluated against the central
+// authorization service. A request without an explicit user (nil) is a privileged/default mint and is
+// allowed by the SuperUser wrapper.
+//
+// The gate applies only when central services are enabled AND the signing key is asymmetric: remote
+// nodes can validate a minted token only with the public half of an asymmetric key, so the central
+// authorization / remote-validation flow is meaningful only there. With symmetric keys (or without
+// central services) token creation keeps its legacy, unrestricted behaviour.
+func (i *implementation) authorizeCreateToken(ctx context.Context, secret utilToken.Secret, request *pbAuthenticationV1.CreateTokenRequest, user string) error {
 	if !utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS.Exists() {
 		return nil
 	}
@@ -126,7 +133,21 @@ func (i *implementation) authorizeCreateToken(ctx context.Context, secret utilTo
 		return nil
 	}
 
-	return authenticator.GetIdentity(ctx).EvaluatePermission(ctx, i.authz, ActionCreateToken, user)
+	resp, err := i.authz.Evaluate(ctx, &pbAuthorizationV1.AuthorizationV1PermissionRequest{
+		User:     request.User,
+		Roles:    request.GetGroups(),
+		Action:   ActionCreateToken,
+		Resource: user,
+	})
+	if err != nil {
+		return status.Errorf(codes.Internal, "Unable to evaluate token creation permission: %v", err)
+	}
+
+	if resp.GetEffect() == sidecarSvcAuthzTypes.Effect_Allow {
+		return nil
+	}
+
+	return status.Errorf(codes.PermissionDenied, "Not allowed to create token for user %q: %s", user, resp.GetMessage())
 }
 
 func (i *implementation) Name() string {
@@ -207,8 +228,8 @@ func (i *implementation) CreateToken(ctx context.Context, request *pbAuthenticat
 		duration = v.AsDuration()
 	}
 
-	// Ensure the caller is authorized to mint a token for the requested user.
-	if err := i.authorizeCreateToken(ctx, cache, user); err != nil {
+	// Ensure token minting is authorized for the requested user.
+	if err := i.authorizeCreateToken(ctx, cache, request, user); err != nil {
 		return nil, err
 	}
 

--- a/integrations/authentication/v1/implementation.go
+++ b/integrations/authentication/v1/implementation.go
@@ -23,7 +23,6 @@ package v1
 import (
 	"context"
 	goHttp "net/http"
-	"slices"
 	goStrings "strings"
 	"time"
 
@@ -37,13 +36,18 @@ import (
 	adbDriverV2 "github.com/arangodb/go-driver/v2/arangodb"
 
 	pbAuthenticationV1 "github.com/arangodb/kube-arangodb/integrations/authentication/v1/definition"
+	pbImplAuthorizationV1Shared "github.com/arangodb/kube-arangodb/integrations/authorization/v1/shared"
 	"github.com/arangodb/kube-arangodb/integrations/envoy/auth/v3/impl/auth_cookie"
 	pbSharedV1 "github.com/arangodb/kube-arangodb/integrations/shared/v1/definition"
 	platformAuthenticationApi "github.com/arangodb/kube-arangodb/pkg/apis/platform/v1beta1/authentication"
+	sidecarSvcAuthzClient "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/client"
+	sidecarSvcAuthzDefinition "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/definition"
 	"github.com/arangodb/kube-arangodb/pkg/util"
 	"github.com/arangodb/kube-arangodb/pkg/util/cache"
+	utilConstants "github.com/arangodb/kube-arangodb/pkg/util/constants"
 	utilConstantsContext "github.com/arangodb/kube-arangodb/pkg/util/constants/context"
 	"github.com/arangodb/kube-arangodb/pkg/util/errors"
+	utilIntegration "github.com/arangodb/kube-arangodb/pkg/util/integration"
 	"github.com/arangodb/kube-arangodb/pkg/util/svc"
 	"github.com/arangodb/kube-arangodb/pkg/util/svc/authenticator"
 	utilToken "github.com/arangodb/kube-arangodb/pkg/util/token"
@@ -64,6 +68,18 @@ func newInternal(ctx context.Context, cfg Configuration) (*implementation, error
 		return nil, errors.Errorf("Unable to get arangodb client")
 	}
 
+	// Token creation is gated by the authorization service when central services are enabled. Like the
+	// authorization integration, authn keeps running locally (so the per-request Validate stays local)
+	// but delegates evaluation to the central AuthorizationPool service, SuperUser-wrapped. When central
+	// services are disabled the gate is skipped entirely, so the permissive Always plugin is a harmless
+	// default.
+	var authz pbImplAuthorizationV1Shared.Evaluator = pbImplAuthorizationV1Shared.NewAlwaysPlugin()
+	if utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS.Exists() {
+		authz = pbImplAuthorizationV1Shared.SuperUser(
+			sidecarSvcAuthzClient.NewClient(ctx, utilIntegration.NewIntegrationClientCache(sidecarSvcAuthzDefinition.NewAuthorizationPoolServiceClient)),
+		)
+	}
+
 	obj := &implementation{
 		cfg: cfg,
 		ctx: ctx,
@@ -71,10 +87,14 @@ func newInternal(ctx context.Context, cfg Configuration) (*implementation, error
 		cache: cache.NewObject(utilTokenLoader.SecretCacheDirectory(cfg.Path, cfg.TTL)),
 
 		userClient: client,
+		authz:      authz,
 	}
 
 	return obj, nil
 }
+
+// ActionCreateToken is the IAM action evaluated before minting a token.
+const ActionCreateToken = "authentication:CreateToken"
 
 var _ pbAuthenticationV1.AuthenticationV1Server = &implementation{}
 var _ svc.Handler = &implementation{}
@@ -87,6 +107,26 @@ type implementation struct {
 
 	userClient cache.Object[adbDriverV2.Client]
 	cache      cache.Object[utilToken.Secret]
+
+	authz pbImplAuthorizationV1Shared.Evaluator
+}
+
+// authorizeCreateToken enforces the IAM permission for minting a token. It applies only when central
+// services are enabled AND the signing key is asymmetric: remote nodes can validate a minted token
+// only with the public half of an asymmetric key, so the central-authorization/remote-validation flow
+// is meaningful only there. With symmetric keys (or without central services) token creation keeps its
+// legacy, unrestricted behaviour.
+func (i *implementation) authorizeCreateToken(ctx context.Context, secret utilToken.Secret, user string) error {
+	if !utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS.Exists() {
+		return nil
+	}
+
+	if len(secret.PublicKey()) == 0 {
+		// Symmetric signing key - no remote validation path, so the gate does not apply.
+		return nil
+	}
+
+	return authenticator.GetIdentity(ctx).EvaluatePermission(ctx, i.authz, ActionCreateToken, user)
 }
 
 func (i *implementation) Name() string {
@@ -167,11 +207,9 @@ func (i *implementation) CreateToken(ctx context.Context, request *pbAuthenticat
 		duration = v.AsDuration()
 	}
 
-	// Check configuration
-	if v := i.cfg.Create.AllowedUsers; len(v) > 0 {
-		if !slices.Contains(v, user) {
-			return nil, errors.Errorf("User %s is not allowed", user)
-		}
+	// Ensure the caller is authorized to mint a token for the requested user.
+	if err := i.authorizeCreateToken(ctx, cache, user); err != nil {
+		return nil, err
 	}
 
 	if v := i.cfg.Create.MaxTTL; duration > v {

--- a/integrations/authentication/v1/service_test.go
+++ b/integrations/authentication/v1/service_test.go
@@ -205,10 +205,14 @@ func asymmetricSecret(t *testing.T) utilToken.Secret {
 	return s
 }
 
+func tokenRequestFor(user string) *pbAuthenticationV1.CreateTokenRequest {
+	return &pbAuthenticationV1.CreateTokenRequest{User: util.NewType(user), Groups: []string{"g"}}
+}
+
 // Without central services the IAM check is skipped entirely, even with a denying evaluator.
 func Test_authorizeCreateToken_SkippedWithoutCentral(t *testing.T) {
 	i := &implementation{authz: pbImplAuthorizationV1Shared.NewNeverPlugin()}
-	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), "root"))
+	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor("user"), "user"))
 }
 
 // With central services but a symmetric signing key there is no remote-validation path, so the IAM
@@ -217,23 +221,39 @@ func Test_authorizeCreateToken_SkippedWithSymmetricKey(t *testing.T) {
 	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
 
 	i := &implementation{authz: pbImplAuthorizationV1Shared.NewNeverPlugin()}
-	require.NoError(t, i.authorizeCreateToken(context.Background(), symmetricSecret(t), "root"))
+	require.NoError(t, i.authorizeCreateToken(context.Background(), symmetricSecret(t), tokenRequestFor("user"), "user"))
 }
 
-// With central services and an asymmetric key the IAM check is enforced: an unauthenticated caller (no
-// identity in context) is rejected before any token is minted. The allow/deny-by-policy behaviour is
-// covered by the e2e suite, which runs against a real central authorization service.
-func Test_authorizeCreateToken_EnforcedWithCentralAndAsymmetric(t *testing.T) {
+// With central services + asymmetric key, a request for a user the authorization service denies is
+// rejected with PermissionDenied.
+func Test_authorizeCreateToken_DeniesUnauthorizedUser(t *testing.T) {
 	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
 
-	i := &implementation{authz: pbImplAuthorizationV1Shared.NewAlwaysPlugin()}
+	i := &implementation{authz: pbImplAuthorizationV1Shared.NewNeverPlugin()}
 
-	err := i.authorizeCreateToken(context.Background(), asymmetricSecret(t), "root")
+	err := i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor("user"), "user")
 	require.Error(t, err)
 
 	s, ok := status.FromError(err)
 	require.True(t, ok)
-	require.Equal(t, codes.Unauthenticated, s.Code())
+	require.Equal(t, codes.PermissionDenied, s.Code())
+}
+
+// With central services + asymmetric key, a request for a user the authorization service allows passes.
+func Test_authorizeCreateToken_AllowsAuthorizedUser(t *testing.T) {
+	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
+
+	i := &implementation{authz: pbImplAuthorizationV1Shared.NewAlwaysPlugin()}
+	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor("user"), "user"))
+}
+
+// A request without an explicit user is a privileged/default mint: the SuperUser wrapper allows it even
+// when the underlying evaluator denies everything.
+func Test_authorizeCreateToken_SuperuserForDefaultUser(t *testing.T) {
+	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
+
+	i := &implementation{authz: pbImplAuthorizationV1Shared.SuperUser(pbImplAuthorizationV1Shared.NewNeverPlugin())}
+	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), &pbAuthenticationV1.CreateTokenRequest{}, "root"))
 }
 
 // New builds a central-delegating evaluator when central services are enabled, without dialing eagerly.

--- a/integrations/authentication/v1/service_test.go
+++ b/integrations/authentication/v1/service_test.go
@@ -205,14 +205,16 @@ func asymmetricSecret(t *testing.T) utilToken.Secret {
 	return s
 }
 
-func tokenRequestFor(user string) *pbAuthenticationV1.CreateTokenRequest {
-	return &pbAuthenticationV1.CreateTokenRequest{User: util.NewType(user), Groups: []string{"g"}}
+const authzTestUser = "user"
+
+func tokenRequestFor() *pbAuthenticationV1.CreateTokenRequest {
+	return &pbAuthenticationV1.CreateTokenRequest{User: util.NewType(authzTestUser), Groups: []string{"g"}}
 }
 
 // Without central services the IAM check is skipped entirely, even with a denying evaluator.
 func Test_authorizeCreateToken_SkippedWithoutCentral(t *testing.T) {
 	i := &implementation{authz: pbImplAuthorizationV1Shared.NewNeverPlugin()}
-	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor("user"), "user"))
+	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor(), authzTestUser))
 }
 
 // With central services but a symmetric signing key there is no remote-validation path, so the IAM
@@ -221,7 +223,7 @@ func Test_authorizeCreateToken_SkippedWithSymmetricKey(t *testing.T) {
 	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
 
 	i := &implementation{authz: pbImplAuthorizationV1Shared.NewNeverPlugin()}
-	require.NoError(t, i.authorizeCreateToken(context.Background(), symmetricSecret(t), tokenRequestFor("user"), "user"))
+	require.NoError(t, i.authorizeCreateToken(context.Background(), symmetricSecret(t), tokenRequestFor(), authzTestUser))
 }
 
 // With central services + asymmetric key, a request for a user the authorization service denies is
@@ -231,7 +233,7 @@ func Test_authorizeCreateToken_DeniesUnauthorizedUser(t *testing.T) {
 
 	i := &implementation{authz: pbImplAuthorizationV1Shared.NewNeverPlugin()}
 
-	err := i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor("user"), "user")
+	err := i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor(), authzTestUser)
 	require.Error(t, err)
 
 	s, ok := status.FromError(err)
@@ -244,7 +246,7 @@ func Test_authorizeCreateToken_AllowsAuthorizedUser(t *testing.T) {
 	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
 
 	i := &implementation{authz: pbImplAuthorizationV1Shared.NewAlwaysPlugin()}
-	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor("user"), "user"))
+	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), tokenRequestFor(), authzTestUser))
 }
 
 // A request without an explicit user is a privileged/default mint: the SuperUser wrapper allows it even

--- a/integrations/authentication/v1/service_test.go
+++ b/integrations/authentication/v1/service_test.go
@@ -22,19 +22,27 @@ package v1
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	pbAuthenticationV1 "github.com/arangodb/kube-arangodb/integrations/authentication/v1/definition"
+	pbImplAuthorizationV1Shared "github.com/arangodb/kube-arangodb/integrations/authorization/v1/shared"
 	"github.com/arangodb/kube-arangodb/pkg/util"
 	"github.com/arangodb/kube-arangodb/pkg/util/cache"
+	utilConstants "github.com/arangodb/kube-arangodb/pkg/util/constants"
 	utilConstantsContext "github.com/arangodb/kube-arangodb/pkg/util/constants/context"
 	"github.com/arangodb/kube-arangodb/pkg/util/svc"
 	"github.com/arangodb/kube-arangodb/pkg/util/tests"
 	"github.com/arangodb/kube-arangodb/pkg/util/tests/tgrpc"
+	utilToken "github.com/arangodb/kube-arangodb/pkg/util/token"
 )
 
 func Handler(t *testing.T, ctx context.Context, mods ...util.ModR[Configuration]) svc.Handler {
@@ -130,14 +138,11 @@ func Test_Service_DifferentDefaultUser(t *testing.T) {
 	require.EqualValues(t, token.User, valid.Details.User)
 }
 
-func Test_Service_AskForDefaultIfAllowed(t *testing.T) {
+func Test_Service_TokenForDefaultUser(t *testing.T) {
 	ctx, c := context.WithCancel(context.Background())
 	defer c()
 
-	client, directory := Client(t, ctx, func(c Configuration) Configuration {
-		c.Create.AllowedUsers = []string{"root"}
-		return c
-	})
+	client, directory := Client(t, ctx)
 
 	directory.Set(t, tests.GenerateJWTToken())
 
@@ -158,14 +163,11 @@ func Test_Service_AskForDefaultIfAllowed(t *testing.T) {
 	require.EqualValues(t, token.User, valid.Details.User)
 }
 
-func Test_Service_AskForNonDefaultIfAllowed(t *testing.T) {
+func Test_Service_TokenForNamedUser(t *testing.T) {
 	ctx, c := context.WithCancel(context.Background())
 	defer c()
 
-	client, directory := Client(t, ctx, func(c Configuration) Configuration {
-		c.Create.AllowedUsers = []string{"root", "other"}
-		return c
-	})
+	client, directory := Client(t, ctx)
 
 	directory.Set(t, tests.GenerateJWTToken())
 
@@ -188,21 +190,67 @@ func Test_Service_AskForNonDefaultIfAllowed(t *testing.T) {
 	require.EqualValues(t, token.User, valid.Details.User)
 }
 
-func Test_Service_AskForDefaultIfBlocked(t *testing.T) {
+func symmetricSecret(t *testing.T) utilToken.Secret {
+	s := utilToken.NewJWTSecret([]byte("0123456789abcdef0123456789abcdef"))
+	require.Empty(t, s.PublicKey())
+	return s
+}
+
+func asymmetricSecret(t *testing.T) utilToken.Secret {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	s, err := utilToken.NewECDSASignSecret(key)
+	require.NoError(t, err)
+	require.NotEmpty(t, s.PublicKey())
+	return s
+}
+
+// Without central services the IAM check is skipped entirely, even with a denying evaluator.
+func Test_authorizeCreateToken_SkippedWithoutCentral(t *testing.T) {
+	i := &implementation{authz: pbImplAuthorizationV1Shared.NewNeverPlugin()}
+	require.NoError(t, i.authorizeCreateToken(context.Background(), asymmetricSecret(t), "root"))
+}
+
+// With central services but a symmetric signing key there is no remote-validation path, so the IAM
+// check is skipped even with a denying evaluator.
+func Test_authorizeCreateToken_SkippedWithSymmetricKey(t *testing.T) {
+	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
+
+	i := &implementation{authz: pbImplAuthorizationV1Shared.NewNeverPlugin()}
+	require.NoError(t, i.authorizeCreateToken(context.Background(), symmetricSecret(t), "root"))
+}
+
+// With central services and an asymmetric key the IAM check is enforced: an unauthenticated caller (no
+// identity in context) is rejected before any token is minted. The allow/deny-by-policy behaviour is
+// covered by the e2e suite, which runs against a real central authorization service.
+func Test_authorizeCreateToken_EnforcedWithCentralAndAsymmetric(t *testing.T) {
+	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
+
+	i := &implementation{authz: pbImplAuthorizationV1Shared.NewAlwaysPlugin()}
+
+	err := i.authorizeCreateToken(context.Background(), asymmetricSecret(t), "root")
+	require.Error(t, err)
+
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Unauthenticated, s.Code())
+}
+
+// New builds a central-delegating evaluator when central services are enabled, without dialing eagerly.
+func Test_New_BuildsCentralEvaluator(t *testing.T) {
+	t.Setenv(string(utilConstants.CENTRAL_INTEGRATION_SERVICE_ADDRESS), "127.0.0.1:0")
+
 	ctx, c := context.WithCancel(context.Background())
 	defer c()
 
-	client, directory := Client(t, ctx, func(c Configuration) Configuration {
-		c.Create.AllowedUsers = []string{"root"}
+	ctx = utilConstantsContext.ArangoDBClientCache.Set(ctx, cache.NewObject(tests.TestArangoClientCacheFunc(t)))
+
+	i, err := newInternal(ctx, NewConfiguration().With(func(c Configuration) Configuration {
+		c.Path = tests.NewTokenManager(t).Path()
 		return c
-	})
-
-	directory.Set(t, tests.GenerateJWTToken())
-
-	_, err := client.CreateToken(ctx, &pbAuthenticationV1.CreateTokenRequest{
-		User: util.NewType("blocked"),
-	})
-	require.EqualError(t, err, "rpc error: code = Unknown desc = User blocked is not allowed")
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, i.authz)
 }
 
 func Test_Service_WithTTL(t *testing.T) {

--- a/pkg/integrations/authentication_v1.go
+++ b/pkg/integrations/authentication_v1.go
@@ -51,7 +51,6 @@ func (a *authenticationV1) Register(cmd *cobra.Command, fs FlagEnvHandler) error
 		fs.DurationVar(&a.config.Create.MinTTL, "token.ttl.min", pbImplAuthenticationV1.DefaultTokenMinTTL, "Min Token TTL"),
 		fs.DurationVar(&a.config.Create.MaxTTL, "token.ttl.max", pbImplAuthenticationV1.DefaultTokenMaxTTL, "Max Token TTL"),
 		fs.Uint16Var(&a.config.Create.MaxSize, "token.max-size", pbImplAuthenticationV1.DefaultMaxTokenSize, "Max Token max size in bytes"),
-		fs.StringSliceVar(&a.config.Create.AllowedUsers, "token.allowed", []string{}, "Allowed users for the Token"),
 	)
 }
 


### PR DESCRIPTION
## Summary

Replaces the optional static `token.allowed` allow-list on the authentication integration's `CreateToken` with a real IAM authorization check delegated to the authorization integration, active only where remote token validation is possible.

### Behaviour

Before signing, `CreateToken` evaluates the caller's identity against the authorization service for action `authentication:CreateToken` (resource = requested user). The check applies **only when both**:
- **central services are enabled** (`CENTRAL_INTEGRATION_SERVICE_ADDRESS`), and
- **asymmetric signing keys are in use** (`secret.PublicKey()` non-empty) — remote nodes can only validate a minted token with the public half of an asymmetric key, so the central-authorization / remote-validation flow is meaningful only there.

With symmetric keys, or without central services, token creation keeps its legacy unrestricted behaviour.

Following the `integrations/authorization/v1` idiom, authn keeps running **locally** (per-request `Validate` stays local — no hot-path regression) but delegates evaluation to the central AuthorizationPool service, SuperUser-wrapped.

### Removed
- `Token.AllowedUsers` config + validation and the `--token.allowed` flag (regenerated the CLI doc).

### Tests
Unit tests cover every gate branch: skipped without central, skipped with a symmetric key, enforced with central + asymmetric (unauthenticated caller rejected). Allow/deny-by-policy against a real central authorization service is covered by e2e tests in kube-arangodb-test (see linked PR).
