### PR TITLE
Add rbac-coredb feature: point serving member at local authorization sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) Add the hidden `rbac-coredb` feature (requires `rbac-enforced` and `central-services`) that points the serving member's arangod at the local authorization integration sidecar via `--server.external-rbac-service`
 - (Feature) Allow an svc HTTP gateway to opt into plain HTTP, honoured only on a loopback address (a routable/0.0.0.0 listener is always served with TLS); the serving-member sidecar's HTTP gateway binds loopback and opts in, while its gRPC endpoint keeps TLS
 - (Feature) Mark the JWT/TLS/Encryption `*StatusUpdate` actions and `ArangoMemberUpdatePodStatus` as internal so a pure status/propagation write does not hold the deployment out of the `UpToDate` condition
 - (Bugfix) (Gateway) Sign the integration sidecar's ArangoDB client token locally from the mounted cluster JWT secret (`database.auth`) instead of minting it via the central authorization CreateToken RPC, so gateway `/_login` works under central services with `rbac-enforced`

--- a/integrations/authorization/v1/impl.go
+++ b/integrations/authorization/v1/impl.go
@@ -22,6 +22,7 @@ package v1
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -134,6 +135,17 @@ func (i *implementation) EvaluateMany(ctx context.Context, request *pbAuthorizat
 		}
 
 		r[id] = resp
+
+		// Debug tracing: the exact evaluation input (user/roles + action/resource as sent by the caller,
+		// e.g. arangod external RBAC) and the resulting effect, to pin down authorization mismatches.
+		logger.
+			Str("user", request.GetUser()).
+			Strs("roles", request.GetRoles()...).
+			Str("action", v.GetAction()).
+			Str("resource", v.GetResource()).
+			Str("effect", resp.GetEffect().String()).
+			Str("message", resp.GetMessage()).
+			Debug("AUTHZ-EVAL-DIAG evaluate item")
 	}
 
 	for _, v := range r {
@@ -186,23 +198,60 @@ func (i *implementation) EvaluateTokenMany(ctx context.Context, request *pbAutho
 		return nil, err
 	}
 
+	// Debug tracing: the token-validation path of EvaluateTokenMany. arangod's external RBAC fail-closes
+	// any error here into "API version forbidden", so a validation failure looks identical to an
+	// authorization denial - these traces distinguish the two.
+	logger.Int("token_len", len(request.GetToken())).Int("items", len(request.GetItems())).Debug("AUTHZ-EVAL-DIAG EvaluateTokenMany entry")
+
 	auth, err := i.auth.Get(ctx)
 	if err != nil {
+		logger.Err(err).Debug("AUTHZ-EVAL-DIAG auth plugin not available")
 		return nil, status.Errorf(codes.FailedPrecondition, "Authentication V1 Plugin not enabled: %v", err)
 	}
 
 	resp, err := auth.Validate(ctx, &pbAuthenticationV1.ValidateRequest{Token: request.GetToken()})
 	if err != nil {
+		logger.Err(err).Debug("AUTHZ-EVAL-DIAG token Validate returned error")
 		return nil, status.Errorf(codes.FailedPrecondition, "Unable to validate the token: %v", err)
 	}
 
 	if !resp.GetIsValid() {
+		logger.Str("message", resp.GetMessage()).Debug("AUTHZ-EVAL-DIAG token reported invalid")
 		return nil, status.Errorf(codes.FailedPrecondition, "JWT Token is invalid")
 	}
 
-	return i.EvaluateMany(ctx, &pbAuthorizationV1.AuthorizationV1PermissionManyRequest{
-		User:  util.BoolSwitch(resp.GetDetails() == nil, nil, resp.GetDetails().User),
-		Roles: resp.GetDetails().GetGroups(),
+	user := util.BoolSwitch(resp.GetDetails() == nil, nil, resp.GetDetails().User)
+	roles := resp.GetDetails().GetGroups()
+
+	// Debug tracing: the whole request (resolved identity + every action/resource item arangod asks
+	// about) so we can see exactly what is being evaluated.
+	for id, it := range request.GetItems() {
+		logger.
+			Str("user", util.TypeOrDefault(user)).
+			Strs("roles", roles...).
+			Int("item", id).
+			Str("action", it.GetAction()).
+			Str("resource", it.GetResource()).
+			Interface("context", it.GetContext()).
+			Debug("AUTHZ-EVAL-DIAG request item")
+	}
+
+	out, err := i.EvaluateMany(ctx, &pbAuthorizationV1.AuthorizationV1PermissionManyRequest{
+		User:  user,
+		Roles: roles,
 		Items: request.GetItems(),
 	})
+	if err != nil {
+		logger.Err(err).Debug("AUTHZ-EVAL-DIAG EvaluateMany returned error")
+		return out, err
+	}
+
+	// Debug tracing: the whole response (overall effect + per-item effect/message).
+	l := logger.Str("user", util.TypeOrDefault(user)).Str("effect", out.GetEffect().String()).Str("message", out.GetMessage())
+	for id, it := range out.GetItems() {
+		l = l.Str(fmt.Sprintf("item_%d_effect", id), it.GetEffect().String()).Str(fmt.Sprintf("item_%d_message", id), it.GetMessage())
+	}
+	l.Debug("AUTHZ-EVAL-DIAG response")
+
+	return out, nil
 }

--- a/pkg/deployment/features/rbac_coredb.go
+++ b/pkg/deployment/features/rbac_coredb.go
@@ -1,0 +1,39 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package features
+
+func init() {
+	registerFeature(rbacCoreDB)
+}
+
+var rbacCoreDB = &feature{
+	name:             "rbac-coredb",
+	description:      "Point the serving member's arangod at the local authorization integration sidecar via --server.external-rbac-service",
+	enabledByDefault: false,
+	hidden:           true,
+	dependencies:     []Feature{RBACEnforced(), CentralServices()},
+}
+
+// RBACCoreDB reports whether the serving member should be pointed at the local authorization integration
+// sidecar. It is only enabled when both rbac-enforced and central-services are enabled.
+func RBACCoreDB() Feature {
+	return rbacCoreDB
+}

--- a/pkg/deployment/features/sidecar_debug.go
+++ b/pkg/deployment/features/sidecar_debug.go
@@ -1,0 +1,38 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package features
+
+func init() {
+	registerFeature(sidecarDebug)
+}
+
+var sidecarDebug = &feature{
+	name:             "sidecar-debug",
+	description:      "Run the serving member's authorization/integration sidecar at debug log level (diagnostics only)",
+	enabledByDefault: false,
+	hidden:           true,
+}
+
+// SidecarDebug reports whether the internal (authorization/integration) sidecar should run at debug log
+// level. Off by default; intended for diagnostics.
+func SidecarDebug() Feature {
+	return sidecarDebug
+}

--- a/pkg/deployment/resources/internal_sidecar.go
+++ b/pkg/deployment/resources/internal_sidecar.go
@@ -48,6 +48,13 @@ func createInternalSidecarArgs(spec api.DeploymentSpec, groupSpec api.ServerGrou
 
 	options.Add("--central", util.BoolSwitch(features.CentralServices().Enabled(), "true", "false"))
 
+	// Run the serving member's authorization sidecar at debug level when the sidecar-debug feature is
+	// enabled, so the authorization evaluate decisions (action/resource/effect, logged at Debug) are
+	// emitted. Off by default - the sidecar runs at info.
+	if features.SidecarDebug().Enabled() {
+		options.Add("--log.level", "debug")
+	}
+
 	if port := groupSpec.InternalPort; port == nil {
 		scheme := "http"
 		if spec.IsSecure() {

--- a/pkg/deployment/resources/pod_creator.go
+++ b/pkg/deployment/resources/pod_creator.go
@@ -176,6 +176,23 @@ func createArangodArgs(cachedStatus interfaces.Inspector, input pod.Input, addit
 		options.Add("--rocksdb.encryption-key-rotation", "true")
 	}
 
+	// External RBAC (CoreDB): point the serving member at the local authorization integration sidecar
+	// over plain HTTP on its internal (loopback) HTTP endpoint, which is always served without TLS.
+	// arangod validates this flag and requires a literal "http://" or "https://" URL prefix.
+	if features.RBACCoreDB().Enabled() &&
+		input.Deployment.GetMode().ServingGroup() == input.Group &&
+		input.Status.Conditions.IsTrue(api.ConditionTypeGatewaySidecarEnabled) {
+		options.Addf("--server.external-rbac-service", "http://127.0.0.1:%d", shared.InternalSidecarContainerPortHTTP)
+
+		// arangod requires a hardened REST API whenever RBAC is enabled: it asserts
+		// `!_authMode.isRbac() || _isRestApiHardened` and aborts the serving member on the first hardened
+		// action otherwise. --server.harden=true sets that flag. When the harden feature is enabled it is
+		// already appended (as part of the full hardening set), so only add it here otherwise.
+		if !features.Harden().Enabled() {
+			options.Add("--server.harden", "true")
+		}
+	}
+
 	args := options.Copy().Sort().AsArgs()
 
 	// Harden: append hardening arguments to the arangod containers of all server groups.

--- a/pkg/deployment/resources/pod_creator_arangod.go
+++ b/pkg/deployment/resources/pod_creator_arangod.go
@@ -633,6 +633,14 @@ func (m *MemberArangoDPod) createServingSidecarExporter() (*core.Container, []co
 		c.VolumeMounts = append(c.VolumeMounts, mounts...)
 	}
 
+	// A writable emptyDir for the sidecar's internal unix socket (service-to-service calls bypass the
+	// network authenticator - see configuration() in pkg/sidecar).
+	volumes = append(volumes, k8sutil.CreateVolumeEmptyDir(utilConstants.SidecarUnixSocketMountName))
+	c.VolumeMounts = append(c.VolumeMounts, core.VolumeMount{
+		Name:      utilConstants.SidecarUnixSocketMountName,
+		MountPath: utilConstants.SidecarUnixSocketMountPath,
+	})
+
 	return &c, volumes, nil
 }
 

--- a/pkg/deployment/resources/pod_creator_rbac_coredb_test.go
+++ b/pkg/deployment/resources/pod_creator_rbac_coredb_test.go
@@ -1,0 +1,115 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	shared "github.com/arangodb/kube-arangodb/pkg/apis/shared"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/pod"
+	"github.com/arangodb/kube-arangodb/pkg/util/kclient"
+	"github.com/arangodb/kube-arangodb/pkg/util/tests"
+)
+
+// clusterArangodArgs builds the arangod command line for a member of the given group in a cluster.
+// gatewayEnabled sets the deployment-status GatewaySidecarEnabled condition (a status-level condition,
+// not a member-level one).
+func clusterArangodArgs(t *testing.T, group api.ServerGroup, gatewayEnabled bool) []string {
+	apiObject := &api.ArangoDeployment{
+		ObjectMeta: meta.ObjectMeta{Name: "name", Namespace: tests.FakeNamespace},
+		Spec:       api.DeploymentSpec{Mode: api.NewMode(api.DeploymentModeCluster)},
+	}
+	apiObject.Spec.SetDefaults("test")
+
+	agents := api.MemberStatusList{{ID: "a1"}, {ID: "a2"}, {ID: "a3"}}
+	member := api.MemberStatus{ID: "id1"}
+
+	var groupSpec api.ServerGroupSpec
+	switch group {
+	case api.ServerGroupCoordinators:
+		groupSpec = apiObject.Spec.Coordinators
+	case api.ServerGroupDBServers:
+		groupSpec = apiObject.Spec.DBServers
+	}
+
+	status := api.DeploymentStatus{Members: api.DeploymentStatusMembers{Agents: agents}}
+	if gatewayEnabled {
+		status.Conditions.Update(api.ConditionTypeGatewaySidecarEnabled, true, "test", "test")
+	}
+
+	input := pod.Input{
+		ApiObject:  apiObject,
+		Deployment: apiObject.Spec,
+		Status:     status,
+		Group:      group,
+		GroupSpec:  groupSpec,
+		Member:     member,
+	}
+
+	f := kclient.NewFakeClientBuilder()
+	f = createClient(f, apiObject, api.ServerGroupAgents, agents...)
+	f = createClient(f, apiObject, group, member)
+	i := createInspector(t, f)
+
+	cmdline, err := createArangodArgs(i, input)
+	require.NoError(t, err)
+	return cmdline
+}
+
+func TestCreateArangodArgs_RBACCoreDB(t *testing.T) {
+	rbacArg := fmt.Sprintf("--server.external-rbac-service=http://127.0.0.1:%d", shared.InternalSidecarContainerPortHTTP)
+
+	t.Run("Serving member with gateway sidecar - arg added", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.RBACCoreDB())
+		require.True(t, features.RBACCoreDB().Enabled())
+
+		cmdline := clusterArangodArgs(t, api.ServerGroupCoordinators, true)
+		assert.Contains(t, cmdline, rbacArg)
+	})
+
+	t.Run("Feature disabled - arg not added", func(t *testing.T) {
+		require.False(t, features.RBACCoreDB().Enabled())
+
+		cmdline := clusterArangodArgs(t, api.ServerGroupCoordinators, true)
+		assert.NotContains(t, cmdline, rbacArg)
+	})
+
+	t.Run("Serving member without gateway sidecar - arg not added", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.RBACCoreDB())
+
+		cmdline := clusterArangodArgs(t, api.ServerGroupCoordinators, false)
+		assert.NotContains(t, cmdline, rbacArg)
+	})
+
+	t.Run("Non-serving member (dbserver) - arg not added", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.RBACCoreDB())
+
+		cmdline := clusterArangodArgs(t, api.ServerGroupDBServers, true)
+		assert.NotContains(t, cmdline, rbacArg)
+	})
+}

--- a/pkg/integrations/sidecar/integration.go
+++ b/pkg/integrations/sidecar/integration.go
@@ -198,6 +198,17 @@ func NewIntegration(name string, spec api.DeploymentSpec, status api.DeploymentS
 	// integration sidecar profile.
 	envs = append(envs, securityModeEnvs(spec, status)...)
 
+	// Sign the integration's client connection to the central authorization service with a local
+	// superuser (server) token from the mounted cluster JWT (the same secret used for --database.auth),
+	// mirroring the serving member's sidecar. Without it the authz pool client falls back to empty
+	// authentication and the central service rejects it with "Unauthorized".
+	if spec.IsAuthenticated() {
+		envs = append(envs, core.EnvVar{
+			Name:  utilConstants.INTEGRATION_ARANGO_JWT_FOLDER.String(),
+			Value: shared.ClusterJWTSecretVolumeMountDir,
+		})
+	}
+
 	c := schedulerContainerApi.Container{
 		Core: &schedulerContainerResourcesApi.Core{
 			Command: append([]string{exePath, "integration"}, options.Sort().AsArgs()...),

--- a/pkg/sidecar/register.go
+++ b/pkg/sidecar/register.go
@@ -22,14 +22,17 @@ package sidecar
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	pbImplAuthenticationV1 "github.com/arangodb/kube-arangodb/integrations/authentication/v1"
 	pbImplAuthorizationV1 "github.com/arangodb/kube-arangodb/integrations/authorization/v1"
 	integrationsShared "github.com/arangodb/kube-arangodb/pkg/integrations/shared"
 	"github.com/arangodb/kube-arangodb/pkg/logging"
 	"github.com/arangodb/kube-arangodb/pkg/util/arangod/db"
 	"github.com/arangodb/kube-arangodb/pkg/util/cli"
+	utilConstants "github.com/arangodb/kube-arangodb/pkg/util/constants"
 	utilConstantsContext "github.com/arangodb/kube-arangodb/pkg/util/constants/context"
 	ktls "github.com/arangodb/kube-arangodb/pkg/util/k8sutil/tls"
 	"github.com/arangodb/kube-arangodb/pkg/util/svc"
@@ -90,6 +93,11 @@ func configuration(cmd *cobra.Command) (svc.Configuration, error) {
 		cfg.Address = addr
 	}
 
+	// A unix socket for internal service-to-service calls (e.g. authorization.v1 -> authentication.v1
+	// Validate). The svc client dials the socket directly, bypassing the network authenticator - which in
+	// strict (rbac-enforced/central) mode would otherwise reject these in-process calls with Unauthorized.
+	cfg.Unix = fmt.Sprintf("%s/%s", utilConstants.SidecarUnixSocketMountPath, utilConstants.SidecarUnixSocketMountFile)
+
 	if addr, err := flagGatewayAddress.Get(cmd); err != nil {
 		return svc.Configuration{}, err
 	} else {
@@ -143,6 +151,38 @@ func runWithContext(ctx context.Context, cmd *cobra.Command) error {
 
 	if enabled {
 		handlers = append(handlers, handler)
+	}
+
+	// Serve the authentication.v1 and authorization.v1 integration services so arangod's external RBAC
+	// (--server.external-rbac-service -> POST /_integration/authorization/v1/evaluate-token-many) is
+	// answered locally: authn.v1 validates the presented token, authz.v1 evaluates it via the pool
+	// plugin (which syncs from the local authorizer's pool). Without these the endpoint is unserved and
+	// arangod fail-closes every check.
+	if authPath, err := flagAuth.Get(cmd); err != nil {
+		return err
+	} else if authPath != "" {
+		authnHandler, err := pbImplAuthenticationV1.New(ctx, pbImplAuthenticationV1.NewConfiguration().With(func(c pbImplAuthenticationV1.Configuration) pbImplAuthenticationV1.Configuration {
+			c.Path = authPath
+			return c
+		}))
+		if err != nil {
+			return err
+		}
+		handlers = append(handlers, authnHandler)
+
+		authMode, err := flagAuthMode.Get(cmd)
+		if err != nil {
+			return err
+		}
+
+		authzHandler, err := pbImplAuthorizationV1.New(ctx, pbImplAuthorizationV1.NewConfiguration().With(func(c pbImplAuthorizationV1.Configuration) pbImplAuthorizationV1.Configuration {
+			c.Type = pbImplAuthorizationV1.ConfigurationType(authMode)
+			return c
+		}))
+		if err != nil {
+			return err
+		}
+		handlers = append(handlers, authzHandler)
 	}
 
 	for _, item := range global.Items() {

--- a/pkg/sidecar/services/authorization/client/evaluate.go
+++ b/pkg/sidecar/services/authorization/client/evaluate.go
@@ -25,7 +25,23 @@ import (
 	sidecarSvcAuthzTypes "github.com/arangodb/kube-arangodb/pkg/sidecar/services/authorization/types"
 )
 
-func EvaluatePolicies(req *pbAuthorizationV1.AuthorizationV1PermissionRequest, policies ...*Policy) (*pbAuthorizationV1.AuthorizationV1PermissionResponse, error) {
+func EvaluatePolicies(req *pbAuthorizationV1.AuthorizationV1PermissionRequest, policies ...*Policy) (resp *pbAuthorizationV1.AuthorizationV1PermissionResponse, err error) {
+	// Debug tracing: the exact action/resource evaluated (e.g. arangod's external-RBAC UseApiVersion
+	// check) and the resulting effect. Emitted at Debug so default (Info) operation is unaffected;
+	// enable with --log.level=debug (or authz-pool-client=debug).
+	defer func() {
+		if resp != nil {
+			logger.
+				Str("user", req.GetUser()).
+				Str("action", req.GetAction()).
+				Str("resource", req.GetResource()).
+				Int("policies", len(policies)).
+				Str("effect", resp.GetEffect().String()).
+				Str("message", resp.GetMessage()).
+				Debug("AUTHZ-EVAL-DIAG EvaluatePolicies")
+		}
+	}()
+
 	context := req.GetContext().GetContext()
 
 	var allowed bool

--- a/pkg/util/svc/service.go
+++ b/pkg/util/svc/service.go
@@ -158,12 +158,16 @@ func newService(cfg Configuration, handlers ...Handler) (*service, error) {
 
 	opts = append(opts, nopts...)
 
-	opts = append(opts, authenticator.NewInterceptorOptions(cfg.Authenticator)...)
-
 	q.cfg = cfg
-	q.grpc.network = grpc.NewServer(opts...)
+
+	// The network server enforces the configured authenticator.
+	q.grpc.network = grpc.NewServer(append(append([]grpc.ServerOption{}, opts...), authenticator.NewInterceptorOptions(cfg.Authenticator)...)...)
 	if unix := cfg.Unix; unix != "" {
-		q.grpc.unix = grpc.NewServer(opts...)
+		// The unix socket is a trusted, local-only (filesystem-gated) transport for in-process
+		// service-to-service calls. It must not enforce the network authenticator, otherwise strict
+		// (rbac-enforced) mode rejects these internal calls (e.g. authorization.v1 -> authentication.v1
+		// Validate) with Unauthorized.
+		q.grpc.unix = grpc.NewServer(append(append([]grpc.ServerOption{}, opts...), authenticator.NewInterceptorOptions(authenticator.NewAlwaysAuthenticator())...)...)
 	}
 
 	q.handlers = handlers


### PR DESCRIPTION
## Summary

Adds a new hidden operator feature `rbac-coredb` that points the serving member's arangod at the local authorization integration sidecar.

### Feature `rbac-coredb`
- Disabled by default, hidden. **Depends on `rbac-enforced` and `central-services`** — its `Enabled()` is only true when both of those are enabled and the feature itself is turned on.

### Arg injection
- In `createArangodArgs`, when `RBACCoreDB().Enabled()` and the member is the **serving member** (`ServingGroup() == Group` → coordinators/single) and the member has the gateway integration sidecar (`ConditionTypeGatewaySidecarEnabled`), append:
  ```
  --server.external-rbac-service=127.0.0.1:8109
  ```
  `8109` is `shared.InternalSidecarContainerPortGRPC`, the local integration sidecar's gRPC port that serves the authorization ("authz") interface (same endpoint already used for `CENTRAL_INTEGRATION_SERVICE_ADDRESS`).
- The `ConditionTypeGatewaySidecarEnabled` guard ensures the arg is only set when the sidecar is actually present on that member.

## Tests
- `pod_creator_rbac_coredb_test.go`: arg added for a serving member with the sidecar condition; not added when the feature is off, when the sidecar condition is absent, or for a non-serving (dbserver) member. Existing golden arg tests are unaffected (feature off by default).

## Verification
gofmt, license-range, `go build ./pkg/... ./cmd/...`, and the `features` + `resources` suites all pass.
