### PR TITLE
Add harden feature: append arangod hardening arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) Add the `harden` feature (requires `secured-containers`, disabled by default) that appends hardening arguments to the arangod server containers, and in cluster mode constrains replication for >=2 DBServers (default replication factor min(DBServers, 3), minimum replication factor 2, and write concern 2 when the default replication factor is 3)
 - (Feature) (Security) Gate authentication token creation behind the authorization integration (IAM) when central services are enabled and asymmetric signing keys are in use (the remote-validation prerequisite), and remove the static `token.allowed` allow-list
 - (Bugfix) (Gateway) Fix Envoy auth: keep hashing the auth response side-effect free (do not sort the shared groups slice in place) and preserve headers added by earlier handlers when stripping the cookie on cookie authentication
 - (Feature) (Gateway) Allow WebSocket upgrades over HTTP/2 by enabling RFC 8441 Extended CONNECT (allowConnect) on the gateway downstream listener, gated behind the hidden `gateway-websockets` feature (enabled by default) and a destination declaring a websocket upgrade

--- a/README.md
+++ b/README.md
@@ -87,9 +87,18 @@ covers individual newer features separately.
 
 | Feature | Operator Version | Introduced | ArangoDB Version | ArangoDB Edition | State | Enabled | Flag | Remarks |
 |:--- |:--- |:--- |:--- |:--- |:--- |:--- |:--- |:--- |
+| Backup Policy Until Propagation | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | True | --deployment.feature.backup-policy-until-propagation | Sets Until field in the Backup based on next schedule time |
+| Central Services | 1.4.4 | 1.4.4 | >= 3.8.0 | Enterprise | Alpha | False | --deployment.feature.central-services | Enables Central Services |
+| Harden ArangoDB Server Containers | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.harden | Adds hardening arguments to the ArangoDB server containers |
+| JWT Asymmetric Key | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.jwt-asymmetric-key | Uses Asymmetric Key as a default in ArangoDB |
+| Random Pod Names | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.random-pod-names | Enables generating random pod names |
+| Replace Migration | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | True | --deployment.feature.replace-migration | During member replacement shards are migrated directly to the new server |
+| Sensitive Information Protection | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.sensitive-information-protection | Hide sensitive information from metrics and logs |
+| Gateway Sidecar | 1.4.2 | 1.4.2 | >= 3.8.0 | Enterprise | Production | False | --deployment.feature.gateway-sidecar | Enables Gateway Integration |
 | ArangoPlatform OpenID SSO | 1.2.49 | 1.2.49 | >= 3.8.0 | Community, Enterprise | Beta | True | N/A | Support for ArangoPlatform SSO with OpenID |
 | ArangoPlatform OpenID SSO Refresh | 1.2.49 | 1.2.49 | >= 3.8.0 | Community, Enterprise | Alpha | True | N/A | Support for ArangoPlatform SSO with OpenID Refresh |
 | ArangoPlatform | 1.2.49 | 1.2.43 | >= 3.8.0 | Community, Enterprise | Beta | True | N/A | ArangoPlatform Solution with support for ArangoDeployment Gateway Group |
+| Gateway | 1.2.43 | 1.2.43 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.gateway | Defines if gateway extension is enabled |
 | Cleanup Imported Backups | 1.2.41 | 1.2.41 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.backup-cleanup | Cleanup backups created outside of the Operator and imported into Kubernetes ArangoBackup |
 | Upscale resources spec in init containers | 1.2.36 | 1.2.36 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.init-containers-upscale-resources | Upscale resources spec to built-in init containers if they are not specified or lower |
 | Create backups asynchronously | 1.2.35 | 1.2.41 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.async-backup-creation | Create backups asynchronously to avoid blocking the operator and reaching the timeout |
@@ -97,13 +106,18 @@ covers individual newer features separately.
 | Copy resources spec to init containers | 1.2.33 | 1.2.33 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.init-containers-copy-resources | Copy resources spec to built-in init containers if they are not specified |
 | [Rebalancer V2](docs/features/rebalancer_v2.md) | 1.2.31 | 1.2.31 | >= 3.10.0 | Community, Enterprise | Alpha | False | --deployment.feature.rebalancer-v2 | N/A |
 | [Secured containers](docs/features/secured_containers.md) | 1.2.31 | 1.2.31 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.secured-containers | If set to True Operator will run containers in secure mode |
-| Version Check V2 | 1.2.31 | 1.2.31 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.upgrade-version-check-V2 | N/A |
+| Version Check V2 | 1.2.31 | 1.2.31 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.upgrade-version-check-v2 | Enable initContainer with pre version check based by Operator |
 | [Operator Ephemeral Volumes](docs/features/ephemeral_volumes.md) | 1.2.31 | 1.2.2 | >= 3.8.0 | Community, Enterprise | Beta | False | --deployment.feature.ephemeral-volumes | N/A |
+| Agency Poll | 1.2.30 | 1.2.30 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.agency-poll | Enable Agency Poll for Enterprise deployments |
+| Local Volume Replacement Check | 1.2.28 | 1.2.28 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.local-volume-replacement-check | Replace volume for local-storage if volume is unschedulable (ex. node is gone) |
 | [Force Rebuild Out Synced Shards](docs/features/rebuild_out_synced_shards.md) | 1.2.27 | 1.2.27 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.force-rebuild-out-synced-shards | It should be used only if user is aware of the risks. |
 | [Spec Default Restore](docs/features/deployment_spec_defaults.md) | 1.2.25 | 1.2.21 | >= 3.8.0 | Community, Enterprise | Beta | True | --deployment.feature.deployment-spec-defaults-restore | If set to False Operator will not change ArangoDeployment Spec |
 | Version Check | 1.2.23 | 1.1.4 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.upgrade-version-check | N/A |
+| Timezone Management | 1.2.16 | 1.2.16 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.timezone-management | Enable timezone management for pods |
+| Restart Policy Always | 1.2.14 | 1.2.14 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.restart-policy-always | Allow to restart containers with always restart policy |
 | [Failover Leader service](docs/features/failover_leader_service.md) | 1.2.13 | 1.2.13 | < 3.12.0 | Community, Enterprise | Production | False | --deployment.feature.failover-leadership | N/A |
 | Graceful Restart | 1.2.5 | 1.0.7 | >= 3.8.0 | Community, Enterprise | Production | True | ---deployment.feature.graceful-shutdown | N/A |
+| Short Pod Names | 1.2.4 | 1.2.4 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.short-pod-names | Enable Short Pod Names |
 | Optional Graceful Restart | 1.2.0 | 1.2.5 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.optional-graceful-shutdown | N/A |
 | Operator Internal Metrics Exporter | 1.2.0 | 1.2.0 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.metrics-exporter | N/A |
 | Operator Maintenance Management Support | 1.2.0 | 1.0.7 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.maintenance | N/A |
@@ -171,6 +185,7 @@ Flags:
       --deployment.feature.failover-leadership                 Support for leadership in fail-over mode - Required ArangoDB >= 3.8.0, < 3.12
       --deployment.feature.gateway                             Defines if gateway extension is enabled - Required ArangoDB >= 3.8.0 (default true)
       --deployment.feature.gateway-sidecar                     Enables Gateway Integration - Required ArangoDB EE >= 3.8.0
+      --deployment.feature.harden                              Adds hardening arguments to the ArangoDB server containers - Required ArangoDB >= 3.8.0
       --deployment.feature.init-containers-copy-resources      Copy resources spec to built-in init containers if they are not specified - Required ArangoDB >= 3.8.0 (default true)
       --deployment.feature.init-containers-upscale-resources   Copy resources spec to built-in init containers if they are not specified or lower - Required ArangoDB >= 3.8.0 (default true)
       --deployment.feature.jwt-asymmetric-key                  Uses Asymmetric Key as a default in ArangoDB - Required ArangoDB >= 3.12.8

--- a/docs/cli/arangodb_operator.md
+++ b/docs/cli/arangodb_operator.md
@@ -55,6 +55,7 @@ Flags:
       --deployment.feature.failover-leadership                 Support for leadership in fail-over mode - Required ArangoDB >= 3.8.0, < 3.12
       --deployment.feature.gateway                             Defines if gateway extension is enabled - Required ArangoDB >= 3.8.0 (default true)
       --deployment.feature.gateway-sidecar                     Enables Gateway Integration - Required ArangoDB EE >= 3.8.0
+      --deployment.feature.harden                              Adds hardening arguments to the ArangoDB server containers - Required ArangoDB >= 3.8.0
       --deployment.feature.init-containers-copy-resources      Copy resources spec to built-in init containers if they are not specified - Required ArangoDB >= 3.8.0 (default true)
       --deployment.feature.init-containers-upscale-resources   Copy resources spec to built-in init containers if they are not specified or lower - Required ArangoDB >= 3.8.0 (default true)
       --deployment.feature.jwt-asymmetric-key                  Uses Asymmetric Key as a default in ArangoDB - Required ArangoDB >= 3.12.8

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -8,9 +8,18 @@ title: List of all features
 
 | Feature | Operator Version | Introduced | ArangoDB Version | ArangoDB Edition | State | Enabled | Flag | Remarks |
 |:--- |:--- |:--- |:--- |:--- |:--- |:--- |:--- |:--- |
+| Backup Policy Until Propagation | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | True | --deployment.feature.backup-policy-until-propagation | Sets Until field in the Backup based on next schedule time |
+| Central Services | 1.4.4 | 1.4.4 | >= 3.8.0 | Enterprise | Alpha | False | --deployment.feature.central-services | Enables Central Services |
+| Harden ArangoDB Server Containers | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.harden | Adds hardening arguments to the ArangoDB server containers |
+| JWT Asymmetric Key | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.jwt-asymmetric-key | Uses Asymmetric Key as a default in ArangoDB |
+| Random Pod Names | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.random-pod-names | Enables generating random pod names |
+| Replace Migration | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | True | --deployment.feature.replace-migration | During member replacement shards are migrated directly to the new server |
+| Sensitive Information Protection | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.sensitive-information-protection | Hide sensitive information from metrics and logs |
+| Gateway Sidecar | 1.4.2 | 1.4.2 | >= 3.8.0 | Enterprise | Production | False | --deployment.feature.gateway-sidecar | Enables Gateway Integration |
 | ArangoPlatform OpenID SSO | 1.2.49 | 1.2.49 | >= 3.8.0 | Community, Enterprise | Beta | True | N/A | Support for ArangoPlatform SSO with OpenID |
 | ArangoPlatform OpenID SSO Refresh | 1.2.49 | 1.2.49 | >= 3.8.0 | Community, Enterprise | Alpha | True | N/A | Support for ArangoPlatform SSO with OpenID Refresh |
 | ArangoPlatform | 1.2.49 | 1.2.43 | >= 3.8.0 | Community, Enterprise | Beta | True | N/A | ArangoPlatform Solution with support for ArangoDeployment Gateway Group |
+| Gateway | 1.2.43 | 1.2.43 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.gateway | Defines if gateway extension is enabled |
 | Cleanup Imported Backups | 1.2.41 | 1.2.41 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.backup-cleanup | Cleanup backups created outside of the Operator and imported into Kubernetes ArangoBackup |
 | Upscale resources spec in init containers | 1.2.36 | 1.2.36 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.init-containers-upscale-resources | Upscale resources spec to built-in init containers if they are not specified or lower |
 | Create backups asynchronously | 1.2.35 | 1.2.41 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.async-backup-creation | Create backups asynchronously to avoid blocking the operator and reaching the timeout |
@@ -18,13 +27,18 @@ title: List of all features
 | Copy resources spec to init containers | 1.2.33 | 1.2.33 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.init-containers-copy-resources | Copy resources spec to built-in init containers if they are not specified |
 | [Rebalancer V2](rebalancer_v2.md) | 1.2.31 | 1.2.31 | >= 3.10.0 | Community, Enterprise | Alpha | False | --deployment.feature.rebalancer-v2 | N/A |
 | [Secured containers](secured_containers.md) | 1.2.31 | 1.2.31 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.secured-containers | If set to True Operator will run containers in secure mode |
-| Version Check V2 | 1.2.31 | 1.2.31 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.upgrade-version-check-V2 | N/A |
+| Version Check V2 | 1.2.31 | 1.2.31 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.upgrade-version-check-v2 | Enable initContainer with pre version check based by Operator |
 | [Operator Ephemeral Volumes](ephemeral_volumes.md) | 1.2.31 | 1.2.2 | >= 3.8.0 | Community, Enterprise | Beta | False | --deployment.feature.ephemeral-volumes | N/A |
+| Agency Poll | 1.2.30 | 1.2.30 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.agency-poll | Enable Agency Poll for Enterprise deployments |
+| Local Volume Replacement Check | 1.2.28 | 1.2.28 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.local-volume-replacement-check | Replace volume for local-storage if volume is unschedulable (ex. node is gone) |
 | [Force Rebuild Out Synced Shards](rebuild_out_synced_shards.md) | 1.2.27 | 1.2.27 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.force-rebuild-out-synced-shards | It should be used only if user is aware of the risks. |
 | [Spec Default Restore](deployment_spec_defaults.md) | 1.2.25 | 1.2.21 | >= 3.8.0 | Community, Enterprise | Beta | True | --deployment.feature.deployment-spec-defaults-restore | If set to False Operator will not change ArangoDeployment Spec |
 | Version Check | 1.2.23 | 1.1.4 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.upgrade-version-check | N/A |
+| Timezone Management | 1.2.16 | 1.2.16 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.timezone-management | Enable timezone management for pods |
+| Restart Policy Always | 1.2.14 | 1.2.14 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.restart-policy-always | Allow to restart containers with always restart policy |
 | [Failover Leader service](failover_leader_service.md) | 1.2.13 | 1.2.13 | < 3.12.0 | Community, Enterprise | Production | False | --deployment.feature.failover-leadership | N/A |
 | Graceful Restart | 1.2.5 | 1.0.7 | >= 3.8.0 | Community, Enterprise | Production | True | ---deployment.feature.graceful-shutdown | N/A |
+| Short Pod Names | 1.2.4 | 1.2.4 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.short-pod-names | Enable Short Pod Names |
 | Optional Graceful Restart | 1.2.0 | 1.2.5 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.optional-graceful-shutdown | N/A |
 | Operator Internal Metrics Exporter | 1.2.0 | 1.2.0 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.metrics-exporter | N/A |
 | Operator Maintenance Management Support | 1.2.0 | 1.0.7 | >= 3.8.0 | Community, Enterprise | Production | True | --deployment.feature.maintenance | N/A |

--- a/internal/features.yaml
+++ b/internal/features.yaml
@@ -92,8 +92,9 @@ features:
       - operatorVersion: 1.2.23
         state: Production
   - name: Version Check V2
-    flag: --deployment.feature.upgrade-version-check-V2
+    flag: --deployment.feature.upgrade-version-check-v2
     enabled: false
+    remarks: Enable initContainer with pre version check based by Operator
     releases:
       - operatorVersion: 1.2.31
         state: Alpha
@@ -275,3 +276,103 @@ features:
     releases:
       - operatorVersion: 1.2.49
         state: Alpha
+  - name: Harden ArangoDB Server Containers
+    flag: --deployment.feature.harden
+    enabled: false
+    remarks: Adds hardening arguments to the ArangoDB server containers
+    releases:
+      - operatorVersion: 1.4.4
+        state: Alpha
+  - name: Agency Poll
+    flag: --deployment.feature.agency-poll
+    enabled: true
+    remarks: Enable Agency Poll for Enterprise deployments
+    releases:
+      - operatorVersion: 1.2.30
+        state: Production
+  - name: Backup Policy Until Propagation
+    flag: --deployment.feature.backup-policy-until-propagation
+    enabled: true
+    remarks: Sets Until field in the Backup based on next schedule time
+    releases:
+      - operatorVersion: 1.4.4
+        state: Alpha
+  - name: Central Services
+    arangoDBEditions: Enterprise
+    flag: --deployment.feature.central-services
+    enabled: false
+    remarks: Enables Central Services
+    releases:
+      - operatorVersion: 1.4.4
+        state: Alpha
+  - name: Gateway
+    flag: --deployment.feature.gateway
+    enabled: true
+    remarks: Defines if gateway extension is enabled
+    releases:
+      - operatorVersion: 1.2.43
+        state: Production
+  - name: Gateway Sidecar
+    arangoDBEditions: Enterprise
+    flag: --deployment.feature.gateway-sidecar
+    enabled: false
+    remarks: Enables Gateway Integration
+    releases:
+      - operatorVersion: 1.4.2
+        state: Production
+  - name: JWT Asymmetric Key
+    flag: --deployment.feature.jwt-asymmetric-key
+    enabled: false
+    remarks: Uses Asymmetric Key as a default in ArangoDB
+    releases:
+      - operatorVersion: 1.4.4
+        state: Alpha
+  - name: Local Volume Replacement Check
+    flag: --deployment.feature.local-volume-replacement-check
+    enabled: false
+    remarks: Replace volume for local-storage if volume is unschedulable (ex. node is gone)
+    releases:
+      - operatorVersion: 1.2.28
+        state: Production
+  - name: Random Pod Names
+    flag: --deployment.feature.random-pod-names
+    enabled: false
+    remarks: Enables generating random pod names
+    releases:
+      - operatorVersion: 1.4.4
+        state: Alpha
+  - name: Replace Migration
+    flag: --deployment.feature.replace-migration
+    enabled: true
+    remarks: During member replacement shards are migrated directly to the new server
+    releases:
+      - operatorVersion: 1.4.4
+        state: Alpha
+  - name: Restart Policy Always
+    flag: --deployment.feature.restart-policy-always
+    enabled: false
+    remarks: Allow to restart containers with always restart policy
+    releases:
+      - operatorVersion: 1.2.14
+        state: Production
+  - name: Sensitive Information Protection
+    flag: --deployment.feature.sensitive-information-protection
+    enabled: false
+    remarks: Hide sensitive information from metrics and logs
+    releases:
+      - operatorVersion: 1.4.4
+        state: Alpha
+  - name: Short Pod Names
+    flag: --deployment.feature.short-pod-names
+    enabled: false
+    remarks: Enable Short Pod Names
+    releases:
+      - operatorVersion: 1.2.4
+        state: Production
+  - name: Timezone Management
+    flag: --deployment.feature.timezone-management
+    enabled: false
+    remarks: Enable timezone management for pods
+    releases:
+      - operatorVersion: 1.2.16
+        state: Production

--- a/pkg/deployment/features/harden.go
+++ b/pkg/deployment/features/harden.go
@@ -1,0 +1,39 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package features
+
+func init() {
+	registerFeature(harden)
+}
+
+var harden = &feature{
+	name:               "harden",
+	description:        "Adds hardening arguments to the ArangoDB server containers",
+	enterpriseRequired: false,
+	enabledByDefault:   false,
+	dependencies:       []Feature{SecuredContainers()},
+}
+
+// Harden returns the harden feature. When enabled it appends hardening arguments to the arangod
+// containers of all server groups. It is only enabled when the secured-containers feature is enabled.
+func Harden() Feature {
+	return harden
+}

--- a/pkg/deployment/resources/pod_creator.go
+++ b/pkg/deployment/resources/pod_creator.go
@@ -178,6 +178,11 @@ func createArangodArgs(cachedStatus interfaces.Inspector, input pod.Input, addit
 
 	args := options.Copy().Sort().AsArgs()
 
+	// Harden: append hardening arguments to the arangod containers of all server groups.
+	if features.Harden().Enabled() {
+		args = append(args, hardenArangodArgs(input)...)
+	}
+
 	if a := input.GroupSpec.Args; len(a) > 0 {
 		args = append(args, a...)
 	}

--- a/pkg/deployment/resources/pod_creator_harden.go
+++ b/pkg/deployment/resources/pod_creator_harden.go
@@ -1,0 +1,66 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package resources
+
+import (
+	"fmt"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/pod"
+)
+
+// hardenArangodArgs returns the hardening arguments appended to the arangod containers when the harden
+// feature is enabled.
+func hardenArangodArgs(input pod.Input) []string {
+	args := []string{
+		"--server.harden",
+		"--javascript.harden",
+		"--javascript.startup-options-denylist=.*",
+		"--javascript.environment-variables-allowlist=^HOSTNAME$",
+		"--javascript.environment-variables-allowlist=^PATH$",
+		"--log.api-enabled=jwt",
+		"--backup.api-enabled=jwt",
+	}
+
+	// In cluster mode also constrain replication based on the number of DBServers (only once there are at
+	// least 2): a default replication factor of min(DBServers, 3), a minimum replication factor of 2, and
+	// a write concern of 2 when the default replication factor is 3.
+	if input.Deployment.GetMode() == api.DeploymentModeCluster {
+		if count := input.Deployment.DBServers.GetCount(); count >= 2 {
+			rf := count
+			if rf > 3 {
+				rf = 3
+			}
+
+			args = append(args,
+				fmt.Sprintf("--cluster.default-replication-factor=%d", rf),
+				"--cluster.min-replication-factor=2",
+			)
+
+			// Write concern is set only when the default replication factor is 3.
+			if rf >= 3 {
+				args = append(args, "--cluster.write-concern=2")
+			}
+		}
+	}
+
+	return args
+}

--- a/pkg/deployment/resources/pod_creator_harden_test.go
+++ b/pkg/deployment/resources/pod_creator_harden_test.go
@@ -1,0 +1,179 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/pod"
+	"github.com/arangodb/kube-arangodb/pkg/util"
+	"github.com/arangodb/kube-arangodb/pkg/util/kclient"
+	"github.com/arangodb/kube-arangodb/pkg/util/tests"
+)
+
+// enableFeatureWithDependencies enables f and all of its transitive dependencies for the duration of the
+// test, restoring the previous state afterwards.
+func enableFeatureWithDependencies(t *testing.T, f features.Feature) {
+	seen := map[string]bool{}
+
+	var enable func(x features.Feature)
+	enable = func(x features.Feature) {
+		if seen[x.Name()] {
+			return
+		}
+		seen[x.Name()] = true
+
+		p := x.EnabledPointer()
+		old := *p
+		*p = true
+		t.Cleanup(func() { *p = old })
+
+		for _, d := range x.Dependencies() {
+			enable(d)
+		}
+	}
+
+	enable(f)
+}
+
+var hardenBaseArgs = []string{
+	"--server.harden",
+	"--javascript.harden",
+	"--javascript.startup-options-denylist=.*",
+	"--javascript.environment-variables-allowlist=^HOSTNAME$",
+	"--javascript.environment-variables-allowlist=^PATH$",
+	"--log.api-enabled=jwt",
+	"--backup.api-enabled=jwt",
+}
+
+func hardenArangodArgsFor(t *testing.T, mode api.DeploymentMode, group api.ServerGroup, dbServers int) []string {
+	apiObject := &api.ArangoDeployment{
+		ObjectMeta: meta.ObjectMeta{Name: "name", Namespace: tests.FakeNamespace},
+		Spec:       api.DeploymentSpec{Mode: api.NewMode(mode)},
+	}
+	apiObject.Spec.SetDefaults("test")
+	if mode == api.DeploymentModeCluster {
+		apiObject.Spec.DBServers.Count = util.NewType(dbServers)
+	}
+
+	agents := api.MemberStatusList{{ID: "a1"}, {ID: "a2"}, {ID: "a3"}}
+
+	var groupSpec api.ServerGroupSpec
+	switch group {
+	case api.ServerGroupCoordinators:
+		groupSpec = apiObject.Spec.Coordinators
+	case api.ServerGroupDBServers:
+		groupSpec = apiObject.Spec.DBServers
+	case api.ServerGroupSingle:
+		groupSpec = apiObject.Spec.Single
+	}
+
+	input := pod.Input{
+		ApiObject:  apiObject,
+		Deployment: apiObject.Spec,
+		Status:     api.DeploymentStatus{Members: api.DeploymentStatusMembers{Agents: agents}},
+		Group:      group,
+		GroupSpec:  groupSpec,
+		Member:     api.MemberStatus{ID: "id1"},
+	}
+
+	f := kclient.NewFakeClientBuilder()
+	f = createClient(f, apiObject, api.ServerGroupAgents, agents...)
+	f = createClient(f, apiObject, group, input.Member)
+	i := createInspector(t, f)
+
+	cmdline, err := createArangodArgs(i, input)
+	require.NoError(t, err)
+	return cmdline
+}
+
+func TestCreateArangodArgs_Harden(t *testing.T) {
+	t.Run("Disabled - no harden args", func(t *testing.T) {
+		require.False(t, features.Harden().Enabled())
+
+		cmdline := hardenArangodArgsFor(t, api.DeploymentModeSingle, api.ServerGroupSingle, 0)
+		for _, a := range hardenBaseArgs {
+			assert.NotContains(t, cmdline, a)
+		}
+	})
+
+	t.Run("Enabled single - harden flags, no cluster flags", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.Harden())
+		require.True(t, features.Harden().Enabled())
+
+		cmdline := hardenArangodArgsFor(t, api.DeploymentModeSingle, api.ServerGroupSingle, 0)
+		for _, a := range hardenBaseArgs {
+			assert.Contains(t, cmdline, a)
+		}
+		for _, a := range cmdline {
+			assert.NotContains(t, a, "--cluster.default-replication-factor")
+			assert.NotContains(t, a, "--cluster.min-replication-factor")
+		}
+	})
+
+	t.Run("Enabled cluster 3 dbservers - default-rf=3, min-rf=2", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.Harden())
+
+		cmdline := hardenArangodArgsFor(t, api.DeploymentModeCluster, api.ServerGroupCoordinators, 3)
+		for _, a := range hardenBaseArgs {
+			assert.Contains(t, cmdline, a)
+		}
+		assert.Contains(t, cmdline, "--cluster.default-replication-factor=3")
+		assert.Contains(t, cmdline, "--cluster.min-replication-factor=2")
+		assert.Contains(t, cmdline, "--cluster.write-concern=2")
+	})
+
+	t.Run("Enabled cluster 5 dbservers - default-rf=3, min-rf=2, wc=2", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.Harden())
+
+		cmdline := hardenArangodArgsFor(t, api.DeploymentModeCluster, api.ServerGroupDBServers, 5)
+		assert.Contains(t, cmdline, "--cluster.default-replication-factor=3")
+		assert.Contains(t, cmdline, "--cluster.min-replication-factor=2")
+		assert.Contains(t, cmdline, "--cluster.write-concern=2")
+	})
+
+	t.Run("Enabled cluster 2 dbservers - default-rf=2, min-rf=2, no wc", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.Harden())
+
+		cmdline := hardenArangodArgsFor(t, api.DeploymentModeCluster, api.ServerGroupCoordinators, 2)
+		assert.Contains(t, cmdline, "--cluster.default-replication-factor=2")
+		assert.Contains(t, cmdline, "--cluster.min-replication-factor=2")
+		for _, a := range cmdline {
+			assert.NotContains(t, a, "--cluster.write-concern")
+		}
+	})
+
+	t.Run("Enabled cluster 1 dbserver - no replication flags", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.Harden())
+
+		cmdline := hardenArangodArgsFor(t, api.DeploymentModeCluster, api.ServerGroupCoordinators, 1)
+		for _, a := range cmdline {
+			assert.NotContains(t, a, "--cluster.default-replication-factor")
+			assert.NotContains(t, a, "--cluster.min-replication-factor")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a new hidden operator feature `harden` that appends hardening arguments to the arangod server containers.

### Feature `harden`
- Hidden, **disabled by default**. **Depends on `secured-containers`** (→ `ephemeral-volumes`), so `Harden().Enabled()` is only true when the whole chain is enabled.

### Args (all arangod server groups)
```
--server.harden
--javascript.harden
--javascript.startup-options-denylist=.*
--javascript.environment-variables-allowlist=^HOSTNAME$
--javascript.environment-variables-allowlist=^PATH$
--log.api-enabled=jwt
--backup.api-enabled=jwt
```

### Cluster replication (cluster mode only, by DBServer count)
```
>=3 DBServers -> --cluster.default-replication-factor=3  --cluster.write-concern=2
>=2 DBServers -> --cluster.min-replication-factor=2
```
(write concern is only set when the default replication factor is 3)

The arg builder lives in `pkg/deployment/resources/pod_creator_harden.go`.

## Tests
- `pod_creator_harden_test.go`: args added when enabled (single + cluster); replication flags by count (3/5 → default-rf=3 + min-rf=2 + wc=2; 2 → min-rf=2 only; 1 → none); none added when disabled. Existing golden arg tests unaffected (feature off by default).

## Verification
gofmt, license-range, `go build ./pkg/... ./cmd/...`, `features` + `resources` suites all pass.