### PR TITLE
Document authentication v1 token creation and IAM gating

### DIFF
--- a/docs/integration/authentication.v1.md
+++ b/docs/integration/authentication.v1.md
@@ -115,3 +115,20 @@ curl -sk "https://<coordinator>:8529/_api/version" \
 
 When central services are enabled the caller of `createToken` must itself be
 authorized (by the authorization service) to mint a token for `root`.
+
+## Pod environment variables
+
+When the authentication integration sidecar is present, the deployment's
+authentication and authorization modes are exposed as environment variables to
+**every container in the pod** (not just the integration sidecar), so the
+ArangoDB server containers can discover how the deployment is secured:
+
+| Env var | Values | Description |
+|---|---|---|
+| `INTEGRATION_AUTHENTICATION_MODE` | `None` / `Native` / `SSO` | Authentication mode: `SSO` (Gateway OpenID), `Native` (ArangoDB JWT) or `None` (disabled) |
+| `INTEGRATION_AUTHORIZATION_MODE` | `None` / `Native` / `RBAC` | Effective authorization mode (`RBAC` when enforced by the platform gateway) |
+| `INTEGRATION_AUTHORIZATION_MODE_COREDB` | `None` / `Native` | Authorization enforced by the ArangoDB core itself — always `Native` when authenticated, since RBAC is enforced upstream at the gateway, not by the DB core |
+
+The sidecar's own configuration variables (`INTEGRATION_AUTHENTICATION_V1`,
+`INTEGRATION_AUTHENTICATION_V1_ENABLED`, `INTEGRATION_AUTHENTICATION_V1_PATH`)
+stay on the integration sidecar container only.

--- a/docs/integration/authentication.v1.md
+++ b/docs/integration/authentication.v1.md
@@ -7,6 +7,85 @@ parent: Integration Sidecars
 
 # Authentication V1
 
-Definitions:
+The Authentication V1 integration service validates ArangoDB JWT tokens and
+issues new ones on behalf of the deployment. It is used by services (and by
+legacy, JWT-based clients) that need a valid ArangoDB token without having
+direct access to the deployment JWT secret.
 
-- [Service](https://github.com/arangodb/kube-arangodb/blob/1.4.4/integrations/authentication/v1/definition/definition.proto)
+## Service Definition
+
+- [Proto](https://github.com/arangodb/kube-arangodb/blob/1.4.4/integrations/authentication/v1/definition/definition.proto)
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/_integration/authn/v1/validate` | Validate a token and return its identity |
+| `POST` | `/_integration/authn/v1/createToken` | Create a new signed token |
+| `GET`  | `/_integration/authn/v1/identity` | Return the identity of the caller |
+| `POST` | `/_integration/authn/v1/login` | Exchange credentials for a token |
+| `GET`  | `/_integration/authn/v1/logout` | Invalidate the current session |
+
+## Token creation
+
+`CreateToken` signs a new token with the deployment JWT secret. The request
+accepts:
+
+- `user` — the user the token is issued for. Defaults to
+  `--integration.authentication.v1.token.user` (`root`).
+- `lifetime` — the token lifetime, clamped to
+  `--integration.authentication.v1.token.ttl.min` /
+  `--integration.authentication.v1.token.ttl.max`
+  (default `--integration.authentication.v1.token.ttl.default`, 1h).
+- `groups` — optional groups assigned to the token.
+
+### Authorization gating
+
+Token creation is gated by the [Authorization V1](authorization.v1.md) (IAM)
+service when central services are enabled (that is, when asymmetric signing
+keys and remote validation are in use). In that mode the authentication service
+keeps running locally — so per-request `Validate` stays local — but delegates
+the `CreateToken` decision to the central authorization service (SuperUser
+wrapped). If the caller is not authorized to mint a token for the requested
+`user`, the request is rejected.
+
+When central services are not enabled, `CreateToken` is served locally.
+
+> The previous static allow-list (`--integration.authentication.v1.token.allowed`)
+> has been removed; who may create a token is now governed by the authorization
+> service instead of a fixed list.
+
+## Example: obtain a `root` token
+
+This is the typical way for a service (or a legacy, JWT-based client) to get a
+usable ArangoDB token without reading the deployment JWT secret. Call the
+integration sidecar's `createToken` endpoint:
+
+```bash
+# Request a root token valid for 1 hour.
+curl -sk -X POST \
+  "https://<integration-sidecar>:<port>/_integration/authn/v1/createToken" \
+  -H "Content-Type: application/json" \
+  -d '{"user": "root", "lifetime": "1h"}'
+```
+
+Response:
+
+```json
+{
+  "lifetime": "3600s",
+  "user": "root",
+  "token": "<JWT>",
+  "groups": []
+}
+```
+
+Use the returned `token` as the ArangoDB bearer token:
+
+```bash
+curl -sk "https://<coordinator>:8529/_api/version" \
+  -H "Authorization: bearer <JWT>"
+```
+
+When central services are enabled the caller of `createToken` must itself be
+authorized (by the authorization service) to mint a token for `root`.

--- a/docs/integration/authentication.v1.md
+++ b/docs/integration/authentication.v1.md
@@ -118,17 +118,14 @@ authorized (by the authorization service) to mint a token for `root`.
 
 ## Pod environment variables
 
-When the authentication integration sidecar is present, the deployment's
-authentication and authorization modes are exposed as environment variables to
-**every container in the pod** (not just the integration sidecar), so the
-ArangoDB server containers can discover how the deployment is secured:
+The deployment-wide authentication and authorization *modes* are exposed by the
+integration sidecar profile:
 
 | Env var | Values | Description |
 |---|---|---|
 | `INTEGRATION_AUTHENTICATION_MODE` | `None` / `Native` / `SSO` | Authentication mode: `SSO` (Gateway OpenID), `Native` (ArangoDB JWT) or `None` (disabled) |
 | `INTEGRATION_AUTHORIZATION_MODE` | `None` / `Native` / `RBAC` | Effective authorization mode (`RBAC` when enforced by the platform gateway) |
-| `INTEGRATION_AUTHORIZATION_MODE_COREDB` | `None` / `Native` | Authorization enforced by the ArangoDB core itself — always `Native` when authenticated, since RBAC is enforced upstream at the gateway, not by the DB core |
+| `INTEGRATION_AUTHORIZATION_MODE_COREDB` | `None` / `Native` | Authorization enforced by the ArangoDB core (RBAC reported as `Native`, since it is enforced upstream at the gateway) |
 
-The sidecar's own configuration variables (`INTEGRATION_AUTHENTICATION_V1`,
-`INTEGRATION_AUTHENTICATION_V1_ENABLED`, `INTEGRATION_AUTHENTICATION_V1_PATH`)
-stay on the integration sidecar container only.
+See [Integration Sidecars](../integration-sidecar.md#envs) for the full list of
+integration sidecar environment variables.

--- a/docs/integration/authentication.v1.md
+++ b/docs/integration/authentication.v1.md
@@ -55,6 +55,32 @@ When central services are not enabled, `CreateToken` is served locally.
 > has been removed; who may create a token is now governed by the authorization
 > service instead of a fixed list.
 
+### Required RBAC permission
+
+When the gate applies (central services enabled **and** an asymmetric signing key
+in use), the caller of `createToken` must be granted the following permission via
+an [`ArangoPermissionPolicy`](../platform/rbac/policies.md) bound to their role:
+
+| Action | Resource |
+|---|---|
+| `authentication:CreateToken` | the user the token is minted for (e.g. `root`, or `*` for any user) |
+
+Example policy statement allowing a subject to mint tokens for `root`:
+
+```yaml
+statements:
+  - effect: Allow
+    actions:
+      - "authentication:CreateToken"
+    resources:
+      - "root"
+```
+
+A mint request without an explicit `user` is a privileged default mint and is
+allowed by the SuperUser wrapper (no policy required). With symmetric keys, or
+when central services are not enabled, no permission is required and
+`createToken` behaves as before.
+
 ## Example: obtain a `root` token
 
 This is the typical way for a service (or a legacy, JWT-based client) to get a


### PR DESCRIPTION
Expands the Authentication V1 integration documentation (previously a stub) to reflect #2142.

- Documents the endpoints (`validate`, `createToken`, `identity`, `login`, `logout`).
- Documents token creation (`user` / `lifetime` / `groups`, and the `token.*` flags).
- **Authorization gating** (from #2142): `CreateToken` is delegated to the Authorization V1 (IAM) service, SuperUser-wrapped, when central services are enabled (asymmetric signing keys / remote validation); served locally otherwise. The static `--integration.authentication.v1.token.allowed` allow-list has been removed.
- Adds an example showing how a service (or a legacy JWT client) obtains a `root` token via the `createToken` endpoint and uses it as an ArangoDB bearer token.
