### PR TITLE
Default integration database.source to _graphs instead of _statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-- (Bugfix) Default the integration sidecar `database.source` collection to `_users` instead of `_statistics`, so integration backing collections (meta/events) are created on ArangoDB versions that no longer ship the `_statistics` system collection
+- (Bugfix) Default the integration sidecar `database.source` collection to `_graphs` instead of `_statistics`, so integration backing collections (meta/events) are created on ArangoDB versions that no longer ship the `_statistics` system collection
 - (Documentation) Document the `harden` feature (docs/features/harden.md) and the arangod arguments it appends
 - (Feature) Add the `harden` feature (requires `secured-containers`, disabled by default) that appends hardening arguments to the arangod server containers, and in cluster mode constrains replication for >=2 DBServers (default replication factor min(DBServers, 3), minimum replication factor 2, and write concern 2 when the default replication factor is 3)
 - (Feature) (Security) Gate authentication token creation behind the authorization integration (IAM) when central services are enabled and asymmetric signing keys are in use (the remote-validation prerequisite), and remove the static `token.allowed` allow-list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) Default the integration sidecar `database.source` collection to `_users` instead of `_statistics`, so integration backing collections (meta/events) are created on ArangoDB versions that no longer ship the `_statistics` system collection
 - (Documentation) Document the `harden` feature (docs/features/harden.md) and the arangod arguments it appends
 - (Feature) Add the `harden` feature (requires `secured-containers`, disabled by default) that appends hardening arguments to the arangod server containers, and in cluster mode constrains replication for >=2 DBServers (default replication factor min(DBServers, 3), minimum replication factor 2, and write concern 2 when the default replication factor is 3)
 - (Feature) (Security) Gate authentication token creation behind the authorization integration (IAM) when central services are enabled and asymmetric signing keys are in use (the remote-validation prerequisite), and remove the static `token.allowed` allow-list

--- a/docs/cli/arangodb_operator_integration.md
+++ b/docs/cli/arangodb_operator_integration.md
@@ -23,7 +23,7 @@ Flags:
       --database.name string                                                                   Database Name (Env: DATABASE_NAME) (default "_system")
       --database.port int                                                                      Port of ArangoDB (Env: DATABASE_PORT) (default 8529)
       --database.proto string                                                                  Proto of the ArangoDB endpoint (Env: DATABASE_PROTO) (default "http")
-      --database.source string                                                                 Database Source Collection (Env: DATABASE_SOURCE) (default "_statistics")
+      --database.source string                                                                 Database Source Collection (Env: DATABASE_SOURCE) (default "_graphs")
       --health.address string                                                                  Address to expose health service (Env: HEALTH_ADDRESS) (default "0.0.0.0:9091")
       --health.auth.token string                                                               Token for health service (when auth service is token) (Env: HEALTH_AUTH_TOKEN)
       --health.auth.type string                                                                Auth type for health service (Env: HEALTH_AUTH_TYPE) (default "None")

--- a/pkg/integrations/register.go
+++ b/pkg/integrations/register.go
@@ -142,7 +142,7 @@ func (c *configuration) Register(cmd *cobra.Command) error {
 		f.String("database.proto", "http", "Proto of the ArangoDB endpoint"),
 		f.Int("database.port", 8529, "Port of ArangoDB"),
 		f.String("database.name", "_system", "Database Name"),
-		f.String("database.source", "_users", "Database Source Collection"),
+		f.String("database.source", "_graphs", "Database Source Collection"),
 		f.StringVar(&c.health.address, "health.address", "0.0.0.0:9091", "Address to expose health service"),
 		f.BoolVar(&c.health.shutdownEnabled, "health.shutdown.enabled", true, "Determines if shutdown service should be enabled and exposed"),
 		f.StringVar(&c.health.auth.t, "health.auth.type", "None", "Auth type for health service"),

--- a/pkg/integrations/register.go
+++ b/pkg/integrations/register.go
@@ -142,7 +142,7 @@ func (c *configuration) Register(cmd *cobra.Command) error {
 		f.String("database.proto", "http", "Proto of the ArangoDB endpoint"),
 		f.Int("database.port", 8529, "Port of ArangoDB"),
 		f.String("database.name", "_system", "Database Name"),
-		f.String("database.source", "_statistics", "Database Source Collection"),
+		f.String("database.source", "_users", "Database Source Collection"),
 		f.StringVar(&c.health.address, "health.address", "0.0.0.0:9091", "Address to expose health service"),
 		f.BoolVar(&c.health.shutdownEnabled, "health.shutdown.enabled", true, "Determines if shutdown service should be enabled and exposed"),
 		f.StringVar(&c.health.auth.t, "health.auth.type", "None", "Auth type for health service"),


### PR DESCRIPTION
Defaults the integration sidecar `database.source` collection to `_graphs` instead of `_statistics`.

The per-pod integration sidecars (meta, events) create their backing collection by cloning the replication/sharding properties of a "source" system collection via `SourceCollectionProps` (`GetCollection(name)` + `Properties()`). The default source was `_statistics`.

On ArangoDB builds that no longer ship `_statistics` (e.g. 4.0), `Properties()` returns `collection or view not found`, so the source-props callback errors and the backing collection is never created - every subsequent integration op then fails with `collection not found`. This broke the `Meta_V1_*` and `Events_V1_*` integration tests against the ArangoDB 4.0 image.

`_graphs` is a system collection that is present across these versions and, unlike `_users` (which is access-restricted and denied to the scoped/distributed integration user), is readable by the integration in every mode. Verified on the ArangoDB 4.0-nightly image: the meta/events integration tests pass in both Central and Distributed integration modes with `_graphs` as the source.

The operator does not override `--database.source`, so the flag default is the effective value. Includes the regenerated `docs/cli/arangodb_operator_integration.md`.