### PR TITLE
Document the harden feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Documentation) Document the `harden` feature (docs/features/harden.md) and the arangod arguments it appends
 - (Feature) Add the `harden` feature (requires `secured-containers`, disabled by default) that appends hardening arguments to the arangod server containers, and in cluster mode constrains replication for >=2 DBServers (default replication factor min(DBServers, 3), minimum replication factor 2, and write concern 2 when the default replication factor is 3)
 - (Feature) (Security) Gate authentication token creation behind the authorization integration (IAM) when central services are enabled and asymmetric signing keys are in use (the remote-validation prerequisite), and remove the static `token.allowed` allow-list
 - (Feature) Add the `enable-arango-deployment-status` feature (disabled by default); the chart ships the status subresource on the ArangoDeployment v1 CRD, the operator ensures it when the feature is enabled and, when disabled, leaves it as the chart ships it (neither adds nor removes it)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -11,7 +11,7 @@ title: List of all features
 | ArangoDeployment Status Subresource | 1.5.0 | 1.5.0 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.enable-arango-deployment-status | Ensures the status subresource on the ArangoDeployment v1 CRD when enabled; when disabled the operator leaves it as the chart ships it (neither adds nor removes it) |
 | Backup Policy Until Propagation | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | True | --deployment.feature.backup-policy-until-propagation | Sets Until field in the Backup based on next schedule time |
 | Central Services | 1.4.4 | 1.4.4 | >= 3.8.0 | Enterprise | Alpha | False | --deployment.feature.central-services | Enables Central Services |
-| Harden ArangoDB Server Containers | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.harden | Adds hardening arguments to the ArangoDB server containers |
+| [Harden ArangoDB Server Containers](harden.md) | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.harden | Adds hardening arguments to the ArangoDB server containers |
 | JWT Asymmetric Key | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.jwt-asymmetric-key | Uses Asymmetric Key as a default in ArangoDB |
 | Random Pod Names | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.random-pod-names | Enables generating random pod names |
 | Replace Migration | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | True | --deployment.feature.replace-migration | During member replacement shards are migrated directly to the new server |

--- a/docs/features/harden.md
+++ b/docs/features/harden.md
@@ -1,0 +1,62 @@
+---
+layout: page
+title: Harden ArangoDB Server Containers
+parent: List of all features
+---
+
+# Harden ArangoDB Server Containers
+
+## Overview
+
+When enabled, the operator appends a set of hardening arguments to the `arangod` command line of the
+server containers of every server group (Agents, DBServers, Coordinators, Single). The arguments lock
+down the JavaScript/Foxx runtime, restrict which process environment variables scripts can read, and
+require a JWT for the log and backup APIs.
+
+The feature is disabled by default and depends on the [Secured containers](secured_containers.md)
+feature - it only takes effect when `secured-containers` is enabled.
+
+## What is changed
+
+The following arguments are appended to the `arangod` containers of all server groups:
+
+| Argument | Effect |
+|:--- |:--- |
+| `--server.harden` | Restricts privileged server APIs to superusers |
+| `--javascript.harden` | Disables JavaScript functions that expose host/process information |
+| `--javascript.startup-options-denylist=.*` | Hides every startup option from JavaScript actions |
+| `--javascript.environment-variables-allowlist=^HOSTNAME$` | Allows JavaScript to read only the `HOSTNAME` environment variable... |
+| `--javascript.environment-variables-allowlist=^PATH$` | ...and the `PATH` environment variable (all others are hidden) |
+| `--log.api-enabled=jwt` | Requires a valid JWT (superuser) to access the log API |
+| `--backup.api-enabled=jwt` | Requires a valid JWT (superuser) to access the backup API |
+
+### Cluster replication constraints
+
+In cluster mode, once there are at least **2** DBServers, the following replication constraints are
+additionally appended (they are not applied in Single mode, nor while there is a single DBServer):
+
+| Argument | Value | Notes |
+|:--- |:--- |:--- |
+| `--cluster.default-replication-factor` | `min(DBServers, 3)` | Default replication factor for new collections |
+| `--cluster.min-replication-factor` | `2` | Collections must be replicated at least twice |
+| `--cluster.write-concern` | `2` | Only set when the default replication factor is `3` (i.e. 3 or more DBServers) |
+
+For example, with 2 DBServers the operator appends `--cluster.default-replication-factor=2` and
+`--cluster.min-replication-factor=2` (no write concern); with 3 or more DBServers it appends
+`--cluster.default-replication-factor=3`, `--cluster.min-replication-factor=2` and
+`--cluster.write-concern=2`.
+
+## Dependencies
+
+- [Secured containers](secured_containers.md) must be Enabled.
+
+## How to use
+
+To enable this feature use the `--deployment.feature.harden` arg, which needs to be passed to the
+operator (together with its dependency, `--deployment.feature.secured-containers`):
+
+```shell
+helm upgrade --install kube-arangodb \
+https://github.com/arangodb/kube-arangodb/releases/download/$VER/kube-arangodb-$VER.tgz \
+  --set "operator.args={--deployment.feature.secured-containers,--deployment.feature.harden}"
+```


### PR DESCRIPTION
Adds a dedicated documentation page for the `harden` feature (added in #2145) under `docs/features/`, and links it from the feature index.

`docs/features/harden.md` describes exactly what the feature changes when enabled:

- The hardening arguments appended to the `arangod` containers of every server group: `--server.harden`, `--javascript.harden`, `--javascript.startup-options-denylist=.*`, `--javascript.environment-variables-allowlist=^HOSTNAME$`, `--javascript.environment-variables-allowlist=^PATH$`, `--log.api-enabled=jwt`, `--backup.api-enabled=jwt`.
- The cluster-mode replication constraints applied once there are >= 2 DBServers: `--cluster.default-replication-factor=min(DBServers, 3)`, `--cluster.min-replication-factor=2`, and `--cluster.write-concern=2` (only when the default replication factor is 3).
- Its dependency on the `secured-containers` feature, and how to enable it via the operator helm args.

The `Harden ArangoDB Server Containers` row in `docs/features/README.md` now links to the new page (matching how other documented features link their pages). Documentation only - no functional change.
