### PR TITLE
Fix harden feature doc link so make ci-check passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ covers individual newer features separately.
 | ArangoDeployment Status Subresource | 1.5.0 | 1.5.0 | >= 3.8.0 | Community, Enterprise | Production | False | --deployment.feature.enable-arango-deployment-status | Ensures the status subresource on the ArangoDeployment v1 CRD when enabled; when disabled the operator leaves it as the chart ships it (neither adds nor removes it) |
 | Backup Policy Until Propagation | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | True | --deployment.feature.backup-policy-until-propagation | Sets Until field in the Backup based on next schedule time |
 | Central Services | 1.4.4 | 1.4.4 | >= 3.8.0 | Enterprise | Alpha | False | --deployment.feature.central-services | Enables Central Services |
-| Harden ArangoDB Server Containers | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.harden | Adds hardening arguments to the ArangoDB server containers |
+| [Harden ArangoDB Server Containers](docs/features/harden.md) | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.harden | Adds hardening arguments to the ArangoDB server containers |
 | JWT Asymmetric Key | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.jwt-asymmetric-key | Uses Asymmetric Key as a default in ArangoDB |
 | Random Pod Names | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | False | --deployment.feature.random-pod-names | Enables generating random pod names |
 | Replace Migration | 1.4.4 | 1.4.4 | >= 3.8.0 | Community, Enterprise | Alpha | True | --deployment.feature.replace-migration | During member replacement shards are migrated directly to the new server |

--- a/internal/features.yaml
+++ b/internal/features.yaml
@@ -277,6 +277,7 @@ features:
       - operatorVersion: 1.2.49
         state: Alpha
   - name: Harden ArangoDB Server Containers
+    doc: docs/features/harden.md
     flag: --deployment.feature.harden
     enabled: false
     remarks: Adds hardening arguments to the ArangoDB server containers


### PR DESCRIPTION
The merged #2150 added the `[Harden ArangoDB Server Containers](harden.md)` link directly to the generated `docs/features/README.md`, but the harden entry in `internal/features.yaml` (the generator source) was missing the `doc:` field. As a result `make ci-check` regenerates the feature list without the link and fails on the diff, breaking check-code for every branch based on master.

This adds `doc: docs/features/harden.md` to the harden entry (mirroring `Secured containers`), so the generated `docs/features/README.md` matches the committed file. Regenerated locally with no diff.