### PR TITLE
Sign the integration sidecar's ArangoDB client token locally from the mounted cluster JWT, fixing gateway /_login under rbac-enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) (Gateway) Sign the integration sidecar's ArangoDB client token locally from the mounted cluster JWT secret (`database.auth`) instead of minting it via the central authorization CreateToken RPC, so gateway `/_login` works under central services with `rbac-enforced`
 - (Bugfix) Default the integration sidecar `database.source` collection to `_graphs` instead of `_statistics`, so integration backing collections (meta/events) are created on ArangoDB versions that no longer ship the `_statistics` system collection
 - (Documentation) Document the `harden` feature (docs/features/harden.md) and the arangod arguments it appends
 - (Feature) Add the `harden` feature (requires `secured-containers`, disabled by default) that appends hardening arguments to the arangod server containers, and in cluster mode constrains replication for >=2 DBServers (default replication factor min(DBServers, 3), minimum replication factor 2, and write concern 2 when the default replication factor is 3)

--- a/docs/cli/arangodb_operator_integration.md
+++ b/docs/cli/arangodb_operator_integration.md
@@ -19,6 +19,7 @@ Available Commands:
   version     Show the version
 
 Flags:
+      --database.auth string                                                                   Path to the JWT secret folder used to sign a local superuser (server) token for the ArangoDB client. When set, the client authenticates locally instead of minting a token via the CreateToken RPC (which is routed to the central authorization service) (Env: DATABASE_AUTH)
       --database.endpoint string                                                               Endpoint of ArangoDB (Env: DATABASE_ENDPOINT) (default "localhost")
       --database.name string                                                                   Database Name (Env: DATABASE_NAME) (default "_system")
       --database.port int                                                                      Port of ArangoDB (Env: DATABASE_PORT) (default 8529)

--- a/pkg/integrations/register.go
+++ b/pkg/integrations/register.go
@@ -143,6 +143,7 @@ func (c *configuration) Register(cmd *cobra.Command) error {
 		f.Int("database.port", 8529, "Port of ArangoDB"),
 		f.String("database.name", "_system", "Database Name"),
 		f.String("database.source", "_graphs", "Database Source Collection"),
+		f.String("database.auth", "", "Path to the JWT secret folder used to sign a local superuser (server) token for the ArangoDB client. When set, the client authenticates locally instead of minting a token via the CreateToken RPC (which is routed to the central authorization service)"),
 		f.StringVar(&c.health.address, "health.address", "0.0.0.0:9091", "Address to expose health service"),
 		f.BoolVar(&c.health.shutdownEnabled, "health.shutdown.enabled", true, "Determines if shutdown service should be enabled and exposed"),
 		f.StringVar(&c.health.auth.t, "health.auth.type", "None", "Auth type for health service"),

--- a/pkg/integrations/shared/database.go
+++ b/pkg/integrations/shared/database.go
@@ -32,6 +32,7 @@ import (
 
 	pbAuthenticationV1 "github.com/arangodb/kube-arangodb/integrations/authentication/v1/definition"
 	"github.com/arangodb/kube-arangodb/pkg/util"
+	arangodClient "github.com/arangodb/kube-arangodb/pkg/util/arangod/client"
 	"github.com/arangodb/kube-arangodb/pkg/util/arangod/db"
 	"github.com/arangodb/kube-arangodb/pkg/util/cache"
 	"github.com/arangodb/kube-arangodb/pkg/util/errors"
@@ -43,6 +44,11 @@ type Database struct {
 	Endpoint string
 	Port     int
 	Database string
+
+	// Auth, when set, points to a JWT secret folder used to sign a local superuser (WithServerID) token
+	// for the ArangoDB client. This keeps the sidecar authentication local (the pre-central "old mode"),
+	// avoiding the CreateToken RPC which is routed to the central authorization service.
+	Auth string
 
 	Source DatabaseSource
 }
@@ -108,12 +114,17 @@ func (d *Database) New(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	dbAuth, err := f.GetString("database.auth")
+	if err != nil {
+		return err
+	}
 
 	*d = Database{
 		Proto:    dbP,
 		Endpoint: dbE,
 		Port:     dbPort,
 		Database: dbName,
+		Auth:     dbAuth,
 		Source: DatabaseSource{
 			Collection: dbSource,
 		},
@@ -124,19 +135,35 @@ func (d *Database) New(cmd *cobra.Command) error {
 
 func (d *Database) DatabaseClient(endpoint Endpoint) cache.Object[adbDriverV2.Client] {
 	auth := endpoint.AuthClient()
+	localAuth := arangodClient.FolderArangoDBAuthentication(d.Auth)
 
 	return cache.NewObject(func(ctx context.Context) (adbDriverV2.Client, time.Duration, error) {
 		if d == nil {
 			return nil, 0, errors.Errorf("Database Ref is empty")
 		}
 
-		ac, err := auth.Get(ctx)
+		// Prefer a locally-signed superuser (WithServerID) token from the mounted JWT secret. This keeps
+		// the sidecar authentication local (the pre-central "old mode") and avoids the CreateToken RPC,
+		// which is routed to the central authorization service and denied under rbac-enforced.
+		authentication, local, err := localAuth.Authentication(ctx)
 		if err != nil {
 			return nil, 0, err
 		}
 
+		// The local token is signed with a one hour validity; refresh the client ahead of expiry.
+		ttl := 45 * time.Minute
+		if !local {
+			// No local JWT secret configured: fall back to the CreateToken-based root request modifier.
+			ac, err := auth.Get(ctx)
+			if err != nil {
+				return nil, 0, err
+			}
+			authentication = pbAuthenticationV1.NewRootRequestModifier(ac)
+			ttl = time.Hour
+		}
+
 		client := adbDriverV2.NewClient(adbDriverV2Connection.NewHttpConnection(adbDriverV2Connection.HttpConfiguration{
-			Authentication: pbAuthenticationV1.NewRootRequestModifier(ac),
+			Authentication: authentication,
 			Endpoint: adbDriverV2Connection.NewRoundRobinEndpoints([]string{
 				fmt.Sprintf("%s://%s:%d", d.Proto, d.Endpoint, d.Port),
 			}),
@@ -145,7 +172,7 @@ func (d *Database) DatabaseClient(endpoint Endpoint) cache.Object[adbDriverV2.Cl
 			Transport:      operatorHTTP.RoundTripperWithShortTransport(operatorHTTP.WithTransportTLS(operatorHTTP.Insecure)),
 		}))
 
-		return client, time.Hour, nil
+		return client, ttl, nil
 	})
 }
 

--- a/pkg/integrations/sidecar/integration.go
+++ b/pkg/integrations/sidecar/integration.go
@@ -158,6 +158,11 @@ func NewIntegration(name string, spec api.DeploymentSpec, status api.DeploymentS
 	options.Add("--database.endpoint", k8sutil.ExtendDeploymentClusterDomain(fmt.Sprintf("%s-%s", name, spec.GetMode().ServingGroup().AsRole()), spec.ClusterDomain))
 	options.Addf("--database.port", "%d", shared.ArangoPort)
 	options.Add("--database.proto", util.BoolSwitch(spec.IsSecure(), "https", "http"))
+	if spec.IsAuthenticated() {
+		// Sign the ArangoDB client token locally from the mounted cluster JWT secret (the pre-central
+		// "old mode") instead of minting it via the central authorization CreateToken RPC.
+		options.Add("--database.auth", shared.ClusterJWTSecretVolumeMountDir)
+	}
 	options.Add("--services.gateway.enabled", true)
 
 	// Envs


### PR DESCRIPTION
### Problem

With central services and `rbac-enforced` enabled (asymmetric JWT signing keys), the gateway `/_login` endpoint returns an `Internal` error (gRPC code 13) for every credential.

Root cause: the integration sidecar's own ArangoDB client authenticates by minting a `root` token through the authentication `CreateToken` RPC. When central services + asymmetric keys are active, that request is routed through the central authorization service and denied (`PermissionDenied`), which the authentication `Login` handler surfaces as an `Internal` error to the gateway.

### Fix

Sign the integration sidecar's ArangoDB client token **locally** from the already-mounted cluster JWT secret (the pre-central "old mode") instead of going through the `CreateToken` RPC:

- New `--database.auth` flag pointing at a JWT secret folder. When set, `DatabaseClient` signs a local superuser (`WithServerID`) token from that secret; when empty it falls back to the previous `CreateToken`-based root request modifier, so behavior is unchanged where no secret is available.
- `NewIntegration` passes `--database.auth` (the mounted cluster JWT dir) whenever the deployment is authenticated. That secret is already mounted into the integration container by the authentication v1 profile, so the flag is always backed by a real secret.

This mirrors how the serving-member sidecar already authenticates locally, keeps the credential entirely local, and avoids the central authorization path for the sidecar's own connection.

### Verification

Reproduced the failure (gateway `/_login` → 500 under central services + `rbac-enforced`) on an unfixed build, and confirmed this branch turns it green. Also confirmed the classic non-central login path still passes, so the always-local signing does not regress non-central authentication.
