### PR TITLE
Serve the svc HTTP gateway without TLS only on loopback addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) Allow an svc HTTP gateway to opt into plain HTTP, honoured only on a loopback address (a routable/0.0.0.0 listener is always served with TLS); the serving-member sidecar's HTTP gateway binds loopback and opts in, while its gRPC endpoint keeps TLS
 - (Feature) Mark the JWT/TLS/Encryption `*StatusUpdate` actions and `ArangoMemberUpdatePodStatus` as internal so a pure status/propagation write does not hold the deployment out of the `UpToDate` condition
 - (Bugfix) (Gateway) Sign the integration sidecar's ArangoDB client token locally from the mounted cluster JWT secret (`database.auth`) instead of minting it via the central authorization CreateToken RPC, so gateway `/_login` works under central services with `rbac-enforced`
 - (Bugfix) Default the integration sidecar `database.source` collection to `_graphs` instead of `_statistics`, so integration backing collections (meta/events) are created on ArangoDB versions that no longer ship the `_statistics` system collection

--- a/pkg/sidecar/flags.go
+++ b/pkg/sidecar/flags.go
@@ -36,9 +36,11 @@ var (
 		Default:     fmt.Sprintf("0.0.0.0:%d", shared.InternalSidecarContainerPortGRPC),
 	}
 	flagGatewayAddress = cli.Flag[string]{
-		Name:        "sidecar.gateway.address",
-		Description: "Address of the http gateway server",
-		Default:     fmt.Sprintf("0.0.0.0:%d", shared.InternalSidecarContainerPortHTTP),
+		Name: "sidecar.gateway.address",
+		Description: "Address of the http gateway server. Defaults to a loopback address: the endpoint is " +
+			"consumed only in-Pod (e.g. by arangod), so it is served plain HTTP; bind a routable address to " +
+			"have it served over TLS.",
+		Default: fmt.Sprintf("127.0.0.1:%d", shared.InternalSidecarContainerPortHTTP),
 	}
 	flagHealthAddress = cli.Flag[string]{
 		Name:        "sidecar.health.address",

--- a/pkg/sidecar/register.go
+++ b/pkg/sidecar/register.go
@@ -93,7 +93,9 @@ func configuration(cmd *cobra.Command) (svc.Configuration, error) {
 	if addr, err := flagGatewayAddress.Get(cmd); err != nil {
 		return svc.Configuration{}, err
 	} else {
-		cfg.Gateway = &svc.ConfigurationGateway{Address: addr}
+		// The sidecar's HTTP gateway is an in-Pod endpoint (default loopback address), so it opts into
+		// plain HTTP. If it is bound to a routable address instead, the svc still serves it over TLS.
+		cfg.Gateway = &svc.ConfigurationGateway{Address: addr, Insecure: true}
 	}
 
 	if keyfile, err := flagKeyfile.Get(cmd); err != nil {

--- a/pkg/sidecar/suite_test.go
+++ b/pkg/sidecar/suite_test.go
@@ -152,7 +152,10 @@ func Test_Protocol(t *testing.T) {
 				require.Error(t, err)
 			})
 	})
-	t.Run("HTTPS", func(t *testing.T) {
+	t.Run("HTTP with TLS keyfile on loopback", func(t *testing.T) {
+		// The default gateway address is loopback, so the HTTP gateway is served plain even when a keyfile
+		// is provided (only the gRPC endpoint, bound to a routable address, is secured) - it behaves
+		// exactly like the plain HTTP case.
 		runSidecar(t).
 			evaluateArgs(renderTLSKeyfileCertificate).
 			run("HTTP Client", func(t *testing.T) {
@@ -164,7 +167,7 @@ func Test_Protocol(t *testing.T) {
 				resp, err := executeHttpRequest(t, c, req)
 				// Expect Response
 				require.NoError(t, err)
-				require.Equal(t, goHttp.StatusBadRequest, resp.StatusCode)
+				require.Equal(t, goHttp.StatusNotFound, resp.StatusCode)
 			}).
 			run("HTTPS Client", func(t *testing.T) {
 				req, err := goHttp.NewRequest(goHttp.MethodGet, "https://127.0.0.1:8108/unknown", nil)
@@ -172,10 +175,38 @@ func Test_Protocol(t *testing.T) {
 
 				c := http.NewHTTPClient(http.WithTransport(http.WithTransportTLS(http.Insecure)))
 
+				_, err = executeHttpRequest(t, c, req)
+				// The HTTP gateway is plain, so a TLS handshake fails.
+				require.Error(t, err)
+			})
+	})
+	t.Run("HTTP with TLS keyfile on routable address", func(t *testing.T) {
+		// A gateway bound to a routable (non-loopback) address IS served over TLS when a keyfile is
+		// provided, so it is reachable over HTTPS and rejects plain HTTP.
+		runSidecar(t).
+			addArgs("--sidecar.gateway.address", "0.0.0.0:8108").
+			evaluateArgs(renderTLSKeyfileCertificate).
+			run("HTTPS Client", func(t *testing.T) {
+				req, err := goHttp.NewRequest(goHttp.MethodGet, "https://127.0.0.1:8108/unknown", nil)
+				require.NoError(t, err)
+
+				c := http.NewHTTPClient(http.WithTransport(http.WithTransportTLS(http.Insecure)))
+
 				resp, err := executeHttpRequest(t, c, req)
-				// Expect Response
+				// Expect Response over TLS
 				require.NoError(t, err)
 				require.Equal(t, goHttp.StatusNotFound, resp.StatusCode)
+			}).
+			run("HTTP Client", func(t *testing.T) {
+				req, err := goHttp.NewRequest(goHttp.MethodGet, "http://127.0.0.1:8108/unknown", nil)
+				require.NoError(t, err)
+
+				c := http.NewHTTPClient()
+
+				resp, err := executeHttpRequest(t, c, req)
+				// Plain HTTP against a TLS listener is answered with Bad Request.
+				require.NoError(t, err)
+				require.Equal(t, goHttp.StatusBadRequest, resp.StatusCode)
 			})
 	})
 

--- a/pkg/util/svc/configuration.go
+++ b/pkg/util/svc/configuration.go
@@ -78,6 +78,11 @@ type ConfigurationGateway struct {
 	Address string
 	Unix    string
 
+	// Insecure requests that the HTTP gateway be served without TLS. It is honoured only when Address is a
+	// loopback address (127.0.0.1/localhost/::1); a gateway bound to a routable address (e.g. 0.0.0.0) is
+	// always served with TLS when the service has TLS options. The gRPC endpoint keeps its TLS regardless.
+	Insecure bool
+
 	MuxExtensions []runtime.ServeMuxOption
 }
 

--- a/pkg/util/svc/service.go
+++ b/pkg/util/svc/service.go
@@ -177,8 +177,18 @@ func newService(cfg Configuration, handlers ...Handler) (*service, error) {
 
 	if gateway := cfg.Gateway; gateway != nil {
 		var http serviceHTTP
+
+		// The HTTP gateway may be served without TLS (gateway.Insecure), but only when it is bound to a
+		// loopback address - reachable solely from within the Pod. A gateway that opts into plain HTTP
+		// while bound to a routable address (e.g. 0.0.0.0) is still served with TLS, so an endpoint exposed
+		// on the network is never served plain. The gRPC endpoint always honours the service TLS options.
+		httpTLS := tls
+		if gateway.Insecure && isLoopbackListenAddress(gateway.Address) {
+			httpTLS = nil
+		}
+
 		http.network = &goHttp.Server{
-			TLSConfig: tls,
+			TLSConfig: httpTLS,
 		}
 
 		if gateway.Unix != "" {
@@ -189,6 +199,29 @@ func newService(cfg Configuration, handlers ...Handler) (*service, error) {
 	}
 
 	return &q, nil
+}
+
+// isLoopbackListenAddress reports whether addr (a "host:port" listen address) binds only to the loopback
+// interface - i.e. the host is "localhost" or a loopback IP (127.0.0.0/8, ::1). An empty host, "0.0.0.0"
+// or "::" binds to all interfaces and is therefore not loopback.
+func isLoopbackListenAddress(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+
+	switch host {
+	case "":
+		return false
+	case "localhost":
+		return true
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+
+	return false
 }
 
 func (p *service) GetHandler(name string) (Handler, bool) {

--- a/pkg/util/svc/starter.go
+++ b/pkg/util/svc/starter.go
@@ -142,7 +142,9 @@ func (s *serviceStarter) runE(ctx context.Context, health Health, grpcListener, 
 			s.service.http.network.Close()
 		}()
 
-		if s.service.tls {
+		// Serve the HTTP gateway over TLS only when the HTTP server has a TLS configuration. This is
+		// decoupled from the gRPC TLS flag so an Insecure gateway can stay plain while gRPC keeps TLS.
+		if s.service.http.network.TLSConfig != nil {
 			if err := s.service.http.network.ServeTLS(httpListener, "", ""); !errors.AnyOf(err, goHttp.ErrServerClosed) {
 				return err
 			}


### PR DESCRIPTION
## Summary

Decide the svc **HTTP gateway's** TLS from its **bind address** instead of an unconditional opt-out:

- A **loopback** listener (`127.0.0.1` / `localhost` / `::1`) is reachable only from within the Pod, so it is served **plain** even when the service has TLS options.
- A listener on **`0.0.0.0`** (or any routable address) keeps **TLS**.
- The **gRPC** endpoint is unaffected and always honours the service TLS options.

The serving-member sidecar's HTTP gateway now defaults to a **loopback** address (`127.0.0.1:8108`). Its HTTP endpoint is only consumed in-Pod (e.g. by arangod's `--server.external-rbac-service`) — cross-pod traffic uses the gRPC port — so binding loopback both serves it plain and stops exposing a plain HTTP listener on `0.0.0.0`. The gRPC endpoint stays on `0.0.0.0` with TLS.

This supersedes the earlier `ConfigurationGateway.Insecure` approach, which would have served plain HTTP on the network.

## Changes

- `pkg/util/svc`: `service.go` derives the HTTP gateway's `TLSConfig` from `isLoopbackListenAddress(gateway.Address)`; `starter.go` serves TLS iff the HTTP server has a `TLSConfig`. No `Insecure` flag.
- `pkg/sidecar/flags.go`: `--sidecar.gateway.address` defaults to `127.0.0.1:8108` (loopback); override with a routable address to have it served over TLS.
- `pkg/sidecar/suite_test.go`: covers both loopback→plain and routable→TLS.

Split out of the rbac-coredb branch so it can be reviewed and merged independently.