### PR TITLE
Mark status-only propagation actions as internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) Mark the JWT/TLS/Encryption `*StatusUpdate` actions and `ArangoMemberUpdatePodStatus` as internal so a pure status/propagation write does not hold the deployment out of the `UpToDate` condition
 - (Bugfix) (Gateway) Sign the integration sidecar's ArangoDB client token locally from the mounted cluster JWT secret (`database.auth`) instead of minting it via the central authorization CreateToken RPC, so gateway `/_login` works under central services with `rbac-enforced`
 - (Bugfix) Default the integration sidecar `database.source` collection to `_graphs` instead of `_statistics`, so integration backing collections (meta/events) are created on ArangoDB versions that no longer ship the `_statistics` system collection
 - (Documentation) Document the `harden` feature (docs/features/harden.md) and the arangod arguments it appends

--- a/docs/generated/actions.md
+++ b/docs/generated/actions.md
@@ -15,7 +15,7 @@ nav_order: 11
 | AddMember | no | 10m0s | no | Community & Enterprise | Adds new member to the Member list |
 | AppendTLSCACertificate | no | 30m0s | no | Enterprise Only | Append Certificate into CA TrustStore |
 | ArangoMemberUpdatePodSpec | no | 10m0s | no | Community & Enterprise | Propagate Member Pod spec (requested) |
-| ArangoMemberUpdatePodStatus | no | 10m0s | no | Community & Enterprise | Propagate Member Pod status (current) |
+| ArangoMemberUpdatePodStatus | yes | 10m0s | no | Community & Enterprise | Propagate Member Pod status (current) |
 | BackupRestore | no | 15m0s | no | Enterprise Only | Restore selected Backup |
 | BackupRestoreClean | no | 15m0s | no | Enterprise Only | Clean restore status in case of restore spec change |
 | BootstrapSetPassword | no | 10m0s | no | Community & Enterprise | Change password during bootstrap procedure |
@@ -37,7 +37,7 @@ nav_order: 11
 | EncryptionKeyPropagated | yes | 10m0s | no | Enterprise Only | Update condition of encryption propagation |
 | EncryptionKeyRefresh | no | 10m0s | no | Enterprise Only | Refresh the encryption keys on member |
 | EncryptionKeyRemove | no | 10m0s | no | Enterprise Only | Remove the encryption key to the pool |
-| EncryptionKeyStatusUpdate | no | 10m0s | no | Enterprise Only | Update status of encryption propagation |
+| EncryptionKeyStatusUpdate | yes | 10m0s | no | Enterprise Only | Update status of encryption propagation |
 | EnforceResignLeadership | no | 45m0s | yes | Community & Enterprise | Run the ResignLeadership job on DBServer and checks data compatibility after |
 | Idle | no | 10m0s | no | Community & Enterprise | Define idle operation in case if preconditions are not meet |
 | JWTAdd | no | 10m0s | no | Enterprise Only | Adds new JWT to the pool |
@@ -45,7 +45,7 @@ nav_order: 11
 | JWTPropagated | yes | 10m0s | no | Enterprise Only | Update condition of JWT propagation |
 | JWTRefresh | no | 10m0s | no | Enterprise Only | Refresh current JWT secrets on the member |
 | JWTSetActive | no | 10m0s | no | Enterprise Only | Change active JWT key on the cluster |
-| JWTStatusUpdate | no | 10m0s | no | Enterprise Only | Update status of JWT propagation |
+| JWTStatusUpdate | yes | 10m0s | no | Enterprise Only | Update status of JWT propagation |
 | KillMemberPod | no | 10m0s | no | Community & Enterprise | Execute Delete on Pod (put pod in Terminating state) |
 | LicenseClean | no | 10m0s | no | Community & Enterprise | Removes the License reference from the status |
 | LicenseGenerate | no | 10m0s | no | Community & Enterprise | Generates License using ArangoDB LicenseManager Endpoint |
@@ -88,7 +88,7 @@ nav_order: 11
 | SetMemberCurrentImage | no | 10m0s | no | Community & Enterprise | Update Member current image |
 | ShutdownMember | no | 30m0s | no | Community & Enterprise | Sends Shutdown requests and waits for container to be stopped |
 | SyncRBACPermissions | no | 10m0s | no | Community & Enterprise | Sync the operator managed predefined RBAC roles into the authorization sidecar (super-admin ships an Allow-all policy bound to the root user; other roles are created empty) |
-| TLSKeyStatusUpdate | no | 10m0s | no | Enterprise Only | Update Status of TLS propagation process |
+| TLSKeyStatusUpdate | yes | 10m0s | no | Enterprise Only | Update Status of TLS propagation process |
 | TLSPropagated | yes | 10m0s | no | Enterprise Only | Update TLS propagation condition |
 | TimezoneSecretSet | no | 30m0s | no | Community & Enterprise | Set timezone details in cluster |
 | TopologyDisable | no | 10m0s | no | Enterprise Only | Disable TopologyAwareness |

--- a/internal/actions.yaml
+++ b/internal/actions.yaml
@@ -110,6 +110,7 @@ actions:
   TLSKeyStatusUpdate:
     enterprise: true
     description: Update Status of TLS propagation process
+    isInternal: true
   TLSPropagated:
     enterprise: true
     description: Update TLS propagation condition
@@ -162,6 +163,7 @@ actions:
   EncryptionKeyStatusUpdate:
     enterprise: true
     description: Update status of encryption propagation
+    isInternal: true
   EncryptionKeyPropagated:
     enterprise: true
     description: Update condition of encryption propagation
@@ -169,6 +171,7 @@ actions:
   JWTStatusUpdate:
     enterprise: true
     description: Update status of JWT propagation
+    isInternal: true
   JWTSetActive:
     enterprise: true
     description: Change active JWT key on the cluster
@@ -248,6 +251,7 @@ actions:
       - High
   ArangoMemberUpdatePodStatus:
     description: Propagate Member Pod status (current)
+    isInternal: true
     scopes:
       - High
   LicenseSet:

--- a/pkg/apis/deployment/v1/actions.generated.go
+++ b/pkg/apis/deployment/v1/actions.generated.go
@@ -947,9 +947,15 @@ func (a ActionType) Priority() ActionPriority {
 // Internal returns true if action is considered to be internal
 func (a ActionType) Internal() bool {
 	switch a {
+	case ActionTypeArangoMemberUpdatePodStatus:
+		return true
 	case ActionTypeEncryptionKeyPropagated:
 		return true
+	case ActionTypeEncryptionKeyStatusUpdate:
+		return true
 	case ActionTypeJWTPropagated:
+		return true
+	case ActionTypeJWTStatusUpdate:
 		return true
 	case ActionTypeRebalancerGenerateV2:
 		return true
@@ -960,6 +966,8 @@ func (a ActionType) Internal() bool {
 	case ActionTypeSetMaintenanceCondition:
 		return true
 	case ActionTypeSetMemberConditionV2:
+		return true
+	case ActionTypeTLSKeyStatusUpdate:
 		return true
 	case ActionTypeTLSPropagated:
 		return true

--- a/pkg/apis/deployment/v2alpha1/actions.generated.go
+++ b/pkg/apis/deployment/v2alpha1/actions.generated.go
@@ -947,9 +947,15 @@ func (a ActionType) Priority() ActionPriority {
 // Internal returns true if action is considered to be internal
 func (a ActionType) Internal() bool {
 	switch a {
+	case ActionTypeArangoMemberUpdatePodStatus:
+		return true
 	case ActionTypeEncryptionKeyPropagated:
 		return true
+	case ActionTypeEncryptionKeyStatusUpdate:
+		return true
 	case ActionTypeJWTPropagated:
+		return true
+	case ActionTypeJWTStatusUpdate:
 		return true
 	case ActionTypeRebalancerGenerateV2:
 		return true
@@ -960,6 +966,8 @@ func (a ActionType) Internal() bool {
 	case ActionTypeSetMaintenanceCondition:
 		return true
 	case ActionTypeSetMemberConditionV2:
+		return true
+	case ActionTypeTLSKeyStatusUpdate:
 		return true
 	case ActionTypeTLSPropagated:
 		return true

--- a/pkg/deployment/reconcile/action.register.generated_test.go
+++ b/pkg/deployment/reconcile/action.register.generated_test.go
@@ -63,7 +63,7 @@ func Test_Actions(t *testing.T) {
 	t.Run("ArangoMemberUpdatePodStatus", func(t *testing.T) {
 		ActionsExistence(t, api.ActionTypeArangoMemberUpdatePodStatus)
 		t.Run("Internal", func(t *testing.T) {
-			require.False(t, api.ActionTypeArangoMemberUpdatePodStatus.Internal())
+			require.True(t, api.ActionTypeArangoMemberUpdatePodStatus.Internal())
 		})
 		t.Run("Optional", func(t *testing.T) {
 			require.False(t, api.ActionTypeArangoMemberUpdatePodStatus.Optional())
@@ -289,7 +289,7 @@ func Test_Actions(t *testing.T) {
 	t.Run("EncryptionKeyStatusUpdate", func(t *testing.T) {
 		ActionsExistence(t, api.ActionTypeEncryptionKeyStatusUpdate)
 		t.Run("Internal", func(t *testing.T) {
-			require.False(t, api.ActionTypeEncryptionKeyStatusUpdate.Internal())
+			require.True(t, api.ActionTypeEncryptionKeyStatusUpdate.Internal())
 		})
 		t.Run("Optional", func(t *testing.T) {
 			require.False(t, api.ActionTypeEncryptionKeyStatusUpdate.Optional())
@@ -369,7 +369,7 @@ func Test_Actions(t *testing.T) {
 	t.Run("JWTStatusUpdate", func(t *testing.T) {
 		ActionsExistence(t, api.ActionTypeJWTStatusUpdate)
 		t.Run("Internal", func(t *testing.T) {
-			require.False(t, api.ActionTypeJWTStatusUpdate.Internal())
+			require.True(t, api.ActionTypeJWTStatusUpdate.Internal())
 		})
 		t.Run("Optional", func(t *testing.T) {
 			require.False(t, api.ActionTypeJWTStatusUpdate.Optional())
@@ -811,7 +811,7 @@ func Test_Actions(t *testing.T) {
 	t.Run("TLSKeyStatusUpdate", func(t *testing.T) {
 		ActionsExistence(t, api.ActionTypeTLSKeyStatusUpdate)
 		t.Run("Internal", func(t *testing.T) {
-			require.False(t, api.ActionTypeTLSKeyStatusUpdate.Internal())
+			require.True(t, api.ActionTypeTLSKeyStatusUpdate.Internal())
 		})
 		t.Run("Optional", func(t *testing.T) {
 			require.False(t, api.ActionTypeTLSKeyStatusUpdate.Optional())


### PR DESCRIPTION
## Summary

Mark four status-only reconcile actions as internal so a pure status/propagation write does not hold the deployment out of the `UpToDate` condition.

`ActionType.Internal()` feeds `Plan.NonInternalActions()`, which is the sole input to `isUpToDateStatus()` (`deployment_inspector.go`): a plan containing only internal actions still lets the deployment report up-to-date. The three `*Propagated` condition actions are already internal, but their paired `*StatusUpdate` bookkeeping actions were not — so a lone "Update status" write currently flaps the deployment out of `UpToDate`.

## Actions marked internal

| Action | Why |
|---|---|
| `JWTStatusUpdate` | Planned together with the internal `JWTPropagated` (`addJWTPropagatedPlanAction`), so it was the only non-internal action in that plan |
| `TLSKeyStatusUpdate` | Sole action in its plan (`plan_builder_tls.go`); sibling of internal `TLSPropagated` |
| `EncryptionKeyStatusUpdate` | Sole action in its plan (`plan_builder_encryption.go`); sibling of internal `EncryptionKeyPropagated` |
| `ArangoMemberUpdatePodStatus` | `status.Template ← spec.Template` propagation; the sole action in the SilentRotation path (no restart) |

All four are pure status writes with no member-lifecycle or external effect.

## Changes

- `internal/actions.yaml`: add `isInternal: true` to the four actions (source of truth).
- Regenerated: `actions.generated.go` (v1 + v2alpha1) `Internal()`, `action.register.generated_test.go` assertions, `docs/generated/actions.md`.