### PR TITLE
Add a README for the platform-storage chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
 - (Maintenance) Lint all Helm charts in CI via `make helm-lint`; fix the `platform-storage` passwords template document separator and add the missing `apiVersion` to the `kube-arangodb-crd` chart
+- (Documentation) Add a README for the `platform-storage` chart and reference it from `docs/helm.md`, the MinIO storage-integration docs and the main README
 - (Feature) Add the hidden `rbac-coredb` feature (requires `rbac-enforced` and `central-services`) that points the serving member's arangod at the local authorization integration sidecar via `--server.external-rbac-service`
 - (Feature) Allow an svc HTTP gateway to opt into plain HTTP, honoured only on a loopback address (a routable/0.0.0.0 listener is always served with TLS); the serving-member sidecar's HTTP gateway binds loopback and opts in, while its gRPC endpoint keeps TLS
 - (Feature) Mark the JWT/TLS/Encryption `*StatusUpdate` actions and `ArangoMemberUpdatePodStatus` as internal so a pure status/propagation write does not hold the deployment out of the `UpToDate` condition

--- a/README.md
+++ b/README.md
@@ -359,6 +359,12 @@ helm install --generate-name https://github.com/arangodb/kube-arangodb/releases/
 helm install --generate-name https://github.com/arangodb/kube-arangodb/releases/download/1.4.4/kube-arangodb-enterprise-1.4.4.tgz --set "operator.features.storage=true"
 ```
 
+#### Supporting charts
+
+Besides the operator chart, the repository ships the [`platform-storage`](chart/platform-storage/README.md)
+chart, which deploys an in-cluster S3-compatible object store (MinIO) and, optionally, an
+`ArangoPlatformStorage` backed by it. See [docs/helm.md](docs/helm.md#charts) for the full list.
+
 ### Upgrading the operator using Helm
 
 To upgrade the operator to the latest version with Helm, you have to run `helm upgrade` with the `--install` flag to enable CRD installation.

--- a/chart/platform-storage/README.md
+++ b/chart/platform-storage/README.md
@@ -1,0 +1,53 @@
+# platform-storage
+
+Deploys an in-cluster, S3-compatible object store ([MinIO](https://min.io/)) and, optionally, wires it
+to the ArangoDB Platform by rendering an
+[`ArangoPlatformStorage`](../../docs/api/ArangoPlatformStorage.V1Beta1.md) resource whose `s3` backend
+points at that MinIO Service. See also the [MinIO storage integration](../../docs/platform/storage/minio.md)
+docs.
+
+It is intended for self-hosted / development environments that need object storage for the ArangoDB
+Platform without an external S3, GCS or Azure Blob Storage account.
+
+## Prerequisites
+
+- The ArangoDB Kubernetes Operator installed with platform/storage support (the
+  `platform.arangodb.com/v1beta1` `ArangoPlatformStorage` CRD present).
+- A default `StorageClass`, or set `storage.class`.
+
+## Installing
+
+```sh
+# MinIO only
+helm install my-storage chart/platform-storage
+
+# MinIO + an ArangoPlatformStorage named "my-storage" pointing at it
+helm install my-storage chart/platform-storage --set deployment.name=my-storage
+```
+
+## What it deploys
+
+| Resource | Name | Notes |
+|---|---|---|
+| Deployment | `<release>` | single MinIO replica (`server /data`) |
+| Service | `<release>` | port `9000` |
+| PersistentVolumeClaim | `<release>` | `storage.size` on `storage.class` |
+| Secret | `<release>-root-credentials` | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` (password generated on first install, reused on upgrade) |
+| Secret | `<release>-credentials` | `accessKey` / `secretKey` consumed by the `ArangoPlatformStorage` |
+| ArangoPlatformStorage | `<deployment.name>` | only when `deployment.name` is set; `s3` backend → `http://<release>.<namespace>.svc:9000` |
+
+## Configuration
+
+| Key | Default | Description |
+|---|---|---|
+| `deployment.name` | `""` | Name of the `ArangoPlatformStorage` to render. Empty deploys MinIO only. |
+| `storage.class` | `""` | `StorageClass` for the MinIO PVC (empty = cluster default). |
+| `storage.size` | `5Gi` | Size of the MinIO PVC. |
+| `minio.image` | `minio/minio:latest` | MinIO container image. |
+| `minio.imagePullPolicy` | `IfNotPresent` | Image pull policy. |
+| `minio.imagePullSecrets` | `[]` | Image pull secrets. |
+| `minio.resources` | `250m` / `512Mi` (requests & limits) | MinIO container resources. |
+| `minio.nodeSelector` | `{}` | Node selector for the MinIO Pod. |
+| `minio.tolerations` | `[]` | Tolerations for the MinIO Pod. |
+
+See [`values.yaml`](values.yaml) for the full set of defaults.

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -20,6 +20,12 @@ For example you can install the operator in a namespace other than
 The ArangoDB Kubernetes Operator is contained in `helm` chart `kube-arangodb` which contains the operator for the
 `ArangoDeployment`, `ArangoLocalStorage` and `ArangoDeploymentReplication` resource types.
 
+The repository also ships supporting charts:
+
+- [`platform-storage`](../chart/platform-storage/README.md) — deploys an in-cluster, S3-compatible object
+  store (MinIO) and, optionally, an `ArangoPlatformStorage` backed by it, for self-hosted ArangoDB
+  Platform deployments without an external S3/GCS/Azure account.
+
 ## Configurable values for ArangoDB Kubernetes Operator
 
 The following values can be configured when installing the

--- a/docs/platform/storage/minio.md
+++ b/docs/platform/storage/minio.md
@@ -12,10 +12,11 @@ In order to connect to the MinIO, or any other S3 Compatible storage in the Aran
 
 ## Provided Helm Chart
 
-In order to create Storage Integration provided MinIO Chart can be used:
+The [`platform-storage`](../../../chart/platform-storage/README.md) chart deploys MinIO and the
+`ArangoPlatformStorage` in one step:
 
-```yaml
-helm- upgrade -i platform-storage-integration ./chart/platform-storage/ --set deployment.name=<ArangoDeployment Name>
+```sh
+helm upgrade -i platform-storage-integration ./chart/platform-storage/ --set deployment.name=<ArangoDeployment Name>
 ```
 
 ## Generic


### PR DESCRIPTION
## Summary

The `platform-storage` chart (in-cluster MinIO + optional `ArangoPlatformStorage`) was the only chart in the repo without a README. This adds one and links it from the existing docs.

## Changes

- **`chart/platform-storage/README.md`** (new) — what the chart deploys (MinIO Deployment/Service/PVC, root + S3 credential secrets, and — when `deployment.name` is set — an `ArangoPlatformStorage` with an `s3` backend pointing at the MinIO Service), install commands, and a values table.
- **`docs/helm.md`** — lists `platform-storage` under the Charts section.
- **`docs/platform/storage/minio.md`** — links the "Provided Helm Chart" section to the new README and fixes a `helm- upgrade` typo.
- **`README.md`** — adds a "Supporting charts" note under the Helm installation section.

Docs-only; no chart behaviour changes. (Note: `helm lint` flags a pre-existing YAML-separator quirk in `templates/passwords.yaml` — unrelated to this change; the chart renders correctly via `helm template`.)