### PR TITLE
Lint Helm charts in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Maintenance) Lint all Helm charts in CI via `make helm-lint`; fix the `platform-storage` passwords template document separator and add the missing `apiVersion` to the `kube-arangodb-crd` chart
 - (Feature) Add the hidden `rbac-coredb` feature (requires `rbac-enforced` and `central-services`) that points the serving member's arangod at the local authorization integration sidecar via `--server.external-rbac-service`
 - (Feature) Allow an svc HTTP gateway to opt into plain HTTP, honoured only on a loopback address (a routable/0.0.0.0 listener is always served with TLS); the serving-member sidecar's HTTP gateway binds loopback and opts in, while its gRPC endpoint keeps TLS
 - (Feature) Mark the JWT/TLS/Encryption `*StatusUpdate` actions and `ArangoMemberUpdatePodStatus` as internal so a pure status/propagation write does not hold the deployment out of the `UpToDate` condition

--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,16 @@ yamlfmt-verify:
 	@echo ">> Verifying style of yaml files"
 	@$(GOPATH)/bin/yamlfmt -lint -quiet $(YAMLS)
 
+.PHONY: helm-lint
+helm-lint:
+	@echo ">> Linting Helm charts"
+	@for chart in $(ROOTDIR)/chart/*/; do \
+		if [ -f "$${chart}Chart.yaml" ]; then \
+			echo ">> Linting $${chart}"; \
+			$(GOPATH)/bin/helm lint "$${chart}" || exit 1; \
+		fi; \
+	done
+
 .PHONY: license
 license:
 	@echo ">> Ensuring license of files"
@@ -808,6 +818,8 @@ tools-min: update-vendor
 	@GOBIN=$(GOPATH)/bin go install github.com/google/yamlfmt/cmd/yamlfmt@v0.20.0
 	@echo ">> Fetching protolinter"
 	@GOBIN=$(GOPATH)/bin go install github.com/yoheimuta/protolint/cmd/protolint@v0.56.4
+	@echo ">> Fetching helm"
+	@GOBIN=$(GOPATH)/bin go install helm.sh/helm/v3/cmd/helm@v3.13.0
 
 .PHONY: tools
 tools: tools-min
@@ -957,7 +969,7 @@ sync-charts:
 sync: sync-charts
 
 ci-check:
-	@$(MAKE) tidy vendor generate update-generated synchronize-v2alpha1-with-v1 sync fmt yamlfmt license protolint
+	@$(MAKE) tidy vendor generate update-generated synchronize-v2alpha1-with-v1 sync fmt yamlfmt license protolint helm-lint
 	@git checkout -- go.sum # ignore changes in go.sum
 	@if [ ! -z "$$(git status --porcelain)" ]; then echo "There are uncommited changes!"; git status; git diff; exit 1; fi
 

--- a/chart/kube-arangodb-crd/Chart.yaml
+++ b/chart/kube-arangodb-crd/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: kube-arangodb-crd
 version: 1.4.4
 description: "ArangoDB Kubernetes Custom Resource Definitions (Deprecated)"

--- a/chart/platform-storage/templates/passwords.yaml
+++ b/chart/platform-storage/templates/passwords.yaml
@@ -1,4 +1,3 @@
----
 {{- $secretName := printf "%s-root-credentials" (include "platform-storage.releaseName" .) -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 


### PR DESCRIPTION
## Summary

Adds `helm lint` for every chart as part of `make ci-check` (already run by the `check-code` "everything generated is committed" step), and fixes the two charts that didn't pass so the gate is green. No CircleCI config change.

## Changes

- **`Makefile`**:
  - `tools-min` installs Helm via `go install helm.sh/helm/v3/cmd/helm@v3.13.0` (into `$(GOPATH)/bin`, alongside golangci-lint / yamlfmt / goimports / …).
  - new `helm-lint` target — `$(GOPATH)/bin/helm lint` over each `chart/*/`, fails on the first error.
  - `ci-check` now runs `helm-lint` (after `sync`, so it lints the synced charts).
- **`chart/platform-storage/templates/passwords.yaml`**: drop the leading `---`. Under `helm lint` (no injected `# Source:` comment) the `{{- … -}}` chomping glued `---` onto `apiVersion` → `---apiVersion: v1` (invalid separator). The file already has a mid-file separator between its two Secrets. Render output unchanged.
- **`chart/kube-arangodb-crd/Chart.yaml`**: add the required `apiVersion: v1` (only chart missing it).

## Verification

`make helm-lint` → 6 charts linted, 0 failed (exit 0). `go install helm.sh/helm/v3/cmd/helm@v3.13.0` builds a working helm v3.13. `helm template` for both fixed charts is unchanged.