### PR TITLE
Report INTEGRATION_AUTHORIZATION_MODE_COREDB as RBAC when rbac-coredb enforces it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - (Maintenance) Add a finalizer to gateway Pods that cleans up the member TLS keyfile secret when the gateway member is removed
 - (Maintenance) Lint all Helm charts in CI via `make helm-lint`; fix the `platform-storage` passwords template document separator and add the missing `apiVersion` to the `kube-arangodb-crd` chart
 - (Documentation) Add a README for the `platform-storage` chart and reference it from `docs/helm.md`, the MinIO storage-integration docs and the main README
+- (Bugfix) Report `INTEGRATION_AUTHORIZATION_MODE_COREDB` as `RBAC` when the `rbac-coredb` feature enables core-level RBAC enforcement (`--server.external-rbac-service`); it was always downgraded to `Native`
 - (Feature) Add the hidden `rbac-coredb` feature (requires `rbac-enforced` and `central-services`) that points the serving member's arangod at the local authorization integration sidecar via `--server.external-rbac-service`
 - (Feature) Allow an svc HTTP gateway to opt into plain HTTP, honoured only on a loopback address (a routable/0.0.0.0 listener is always served with TLS); the serving-member sidecar's HTTP gateway binds loopback and opts in, while its gRPC endpoint keeps TLS
 - (Feature) Mark the JWT/TLS/Encryption `*StatusUpdate` actions and `ArangoMemberUpdatePodStatus` as internal so a pure status/propagation write does not hold the deployment out of the `UpToDate` condition

--- a/pkg/integrations/sidecar/integration.go
+++ b/pkg/integrations/sidecar/integration.go
@@ -19,6 +19,7 @@ import (
 	schedulerPodApi "github.com/arangodb/kube-arangodb/pkg/apis/scheduler/v1beta1/pod"
 	schedulerPodResourcesApi "github.com/arangodb/kube-arangodb/pkg/apis/scheduler/v1beta1/pod/resources"
 	shared "github.com/arangodb/kube-arangodb/pkg/apis/shared"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
 	"github.com/arangodb/kube-arangodb/pkg/util"
 	utilConstants "github.com/arangodb/kube-arangodb/pkg/util/constants"
 	"github.com/arangodb/kube-arangodb/pkg/util/errors"
@@ -313,8 +314,9 @@ func NewIntegration(name string, spec api.DeploymentSpec, status api.DeploymentS
 }
 
 // securityModeEnvs returns env vars describing the deployment's authentication and authorization
-// modes. INTEGRATION_AUTHORIZATION_MODE_COREDB always reports None or Native - RBAC is enforced by the
-// platform gateway, not by the ArangoDB core.
+// modes. INTEGRATION_AUTHORIZATION_MODE_COREDB reports RBAC only when the rbac-coredb feature enables
+// core-level enforcement (arangod --server.external-rbac-service); otherwise the ArangoDB core does not
+// enforce RBAC (it is applied by the platform gateway) and it reports None or Native.
 func securityModeEnvs(spec api.DeploymentSpec, status api.DeploymentStatus) []core.EnvVar {
 	authentication := "None"
 	if spec.Gateway != nil && spec.Gateway.Authentication != nil {
@@ -331,7 +333,7 @@ func securityModeEnvs(spec api.DeploymentSpec, status api.DeploymentStatus) []co
 	}
 
 	authorizationCoreDB := authorization
-	if authorizationCoreDB == "RBAC" {
+	if authorizationCoreDB == "RBAC" && !features.RBACCoreDB().Enabled() {
 		authorizationCoreDB = "Native"
 	}
 

--- a/pkg/integrations/sidecar/integration_security_test.go
+++ b/pkg/integrations/sidecar/integration_security_test.go
@@ -26,8 +26,34 @@ import (
 	"github.com/stretchr/testify/require"
 
 	api "github.com/arangodb/kube-arangodb/pkg/apis/deployment/v1"
+	"github.com/arangodb/kube-arangodb/pkg/deployment/features"
 	"github.com/arangodb/kube-arangodb/pkg/util"
 )
+
+// enableFeatureWithDependencies enables f and all of its transitive dependencies for the duration of
+// the test, restoring the previous state afterwards.
+func enableFeatureWithDependencies(t *testing.T, f features.Feature) {
+	seen := map[string]bool{}
+
+	var enable func(x features.Feature)
+	enable = func(x features.Feature) {
+		if seen[x.Name()] {
+			return
+		}
+		seen[x.Name()] = true
+
+		p := x.EnabledPointer()
+		old := *p
+		*p = true
+		t.Cleanup(func() { *p = old })
+
+		for _, d := range x.Dependencies() {
+			enable(d)
+		}
+	}
+
+	enable(f)
+}
 
 func Test_securityModeEnvs(t *testing.T) {
 	modes := func(spec api.DeploymentSpec, status api.DeploymentStatus) map[string]string {
@@ -52,7 +78,7 @@ func Test_securityModeEnvs(t *testing.T) {
 		require.Equal(t, "Native", e["INTEGRATION_AUTHORIZATION_MODE_COREDB"])
 	})
 
-	t.Run("Platform RBAC, CoreDB Native", func(t *testing.T) {
+	t.Run("Platform RBAC, CoreDB Native (rbac-coredb disabled)", func(t *testing.T) {
 		var status api.DeploymentStatus
 		status.Conditions.Update(api.ConditionTypeGatewaySidecarEnabled, true, "", "")
 
@@ -60,5 +86,18 @@ func Test_securityModeEnvs(t *testing.T) {
 		require.Equal(t, "Native", e["INTEGRATION_AUTHENTICATION_MODE"])
 		require.Equal(t, "RBAC", e["INTEGRATION_AUTHORIZATION_MODE"])
 		require.Equal(t, "Native", e["INTEGRATION_AUTHORIZATION_MODE_COREDB"])
+	})
+
+	t.Run("Platform RBAC, CoreDB RBAC (rbac-coredb enabled)", func(t *testing.T) {
+		enableFeatureWithDependencies(t, features.RBACCoreDB())
+
+		var status api.DeploymentStatus
+		status.Conditions.Update(api.ConditionTypeGatewaySidecarEnabled, true, "", "")
+
+		e := modes(api.DeploymentSpec{}, status)
+		require.Equal(t, "Native", e["INTEGRATION_AUTHENTICATION_MODE"])
+		require.Equal(t, "RBAC", e["INTEGRATION_AUTHORIZATION_MODE"])
+		// The rbac-coredb feature wires --server.external-rbac-service, so the ArangoDB core enforces RBAC.
+		require.Equal(t, "RBAC", e["INTEGRATION_AUTHORIZATION_MODE_COREDB"])
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up to #2144 (rbac-coredb). `securityModeEnvs` (added in #2148) unconditionally downgraded the CoreDB authorization mode from `RBAC` to `Native`, with the assumption that *"RBAC is enforced by the platform gateway, not by the ArangoDB core."* That assumption no longer holds once the **`rbac-coredb`** feature is enabled: it wires `--server.external-rbac-service` so arangod's **core** enforces `db:*` RBAC. In that case `INTEGRATION_AUTHORIZATION_MODE_COREDB` should report `RBAC`, but it still reported `Native`.

## Change

`pkg/integrations/sidecar/integration.go` — only downgrade CoreDB to `Native` when the `rbac-coredb` feature is **not** enabled:

```go
authorizationCoreDB := authorization
if authorizationCoreDB == "RBAC" && !features.RBACCoreDB().Enabled() {
    authorizationCoreDB = "Native"
}
```

Resulting `INTEGRATION_AUTHORIZATION_MODE_COREDB`:

| authorization | rbac-coredb | before | after |
|---|---|---|---|
| None | – | None | None |
| Native | – | Native | Native |
| RBAC (gateway) | disabled | Native | Native |
| RBAC (gateway) | **enabled** | Native | **RBAC** |

Comment updated; added a `Test_securityModeEnvs` case covering the feature-enabled path (and renamed the existing one to make the feature-disabled case explicit).

## Verification

`go test -run Test_securityModeEnvs ./pkg/integrations/sidecar/` passes; build + goimports clean.