### PR TITLE
Clean up the gateway member TLS keyfile secret on removal via a Pod finalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Maintenance) Add a finalizer to gateway Pods that cleans up the member TLS keyfile secret when the gateway member is removed
 - (Maintenance) Lint all Helm charts in CI via `make helm-lint`; fix the `platform-storage` passwords template document separator and add the missing `apiVersion` to the `kube-arangodb-crd` chart
 - (Documentation) Add a README for the `platform-storage` chart and reference it from `docs/helm.md`, the MinIO storage-integration docs and the main README
 - (Feature) Add the hidden `rbac-coredb` feature (requires `rbac-enforced` and `central-services`) that points the serving member's arangod at the local authorization integration sidecar via `--server.external-rbac-service`

--- a/pkg/deployment/resources/pod_creator_gateway_pod.go
+++ b/pkg/deployment/resources/pod_creator_gateway_pod.go
@@ -36,6 +36,7 @@ import (
 	"github.com/arangodb/kube-arangodb/pkg/deployment/topology"
 	integrationsSidecar "github.com/arangodb/kube-arangodb/pkg/integrations/sidecar"
 	"github.com/arangodb/kube-arangodb/pkg/util/collection"
+	utilConstants "github.com/arangodb/kube-arangodb/pkg/util/constants"
 	"github.com/arangodb/kube-arangodb/pkg/util/errors"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil"
 	"github.com/arangodb/kube-arangodb/pkg/util/k8sutil/interfaces"
@@ -157,6 +158,10 @@ func (m *MemberGatewayPod) GetInitContainers(cachedStatus interfaces.Inspector) 
 }
 
 func (m *MemberGatewayPod) GetFinalizers() []string {
+	if pod.IsTLSEnabled(m.Input) {
+		// Ensure the member's TLS keyfile secret is cleaned up when the gateway member is removed.
+		return []string{utilConstants.FinalizerPodGatewayTLSKeyfile}
+	}
 	return nil
 }
 

--- a/pkg/deployment/resources/pod_finalizers.go
+++ b/pkg/deployment/resources/pod_finalizers.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2025 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -85,6 +85,24 @@ func (r *Resources) runPodFinalizers(ctx context.Context, p *core.Pod, memberSta
 				log.Debug("Server Container is dead, removing finalizer")
 				removalList = append(removalList, f)
 			}
+		case utilConstants.FinalizerPodGatewayTLSKeyfile:
+			// Cleanup marker for the gateway member TLS keyfile secret. The secret is
+			// owner-referenced to the ArangoMember and garbage-collected on member removal; this
+			// finalizer only adds a prompt best-effort cleanup on a genuine teardown.
+			//
+			// The gateway container's preStop hook waits for the pod's finalizers to be removed, so
+			// this finalizer MUST NOT wait for the server container to stop: that would deadlock
+			// (preStop waits for the finalizer, the finalizer waits for the container). It is
+			// therefore released as soon as the pod is being deleted - never gated on
+			// isServerContainerDead - so it never blocks a restart. It is kept while the pod is not
+			// terminating so it is present for the eventual teardown.
+			if p.ObjectMeta.DeletionTimestamp == nil {
+				continue
+			}
+			if err := r.inspectFinalizerPodGatewayTLSKeyfile(ctx, memberStatus); err != nil {
+				log.Err(err).Str("finalizer", f).Debug("Failed to clean up gateway TLS keyfile secret, releasing finalizer anyway")
+			}
+			removalList = append(removalList, f)
 		case utilConstants.FinalizerDelayPodTermination:
 			if isServerContainerDead {
 				log.Debug("Server Container is dead, removing finalizer")
@@ -125,6 +143,34 @@ func (r *Resources) runPodFinalizers(ctx context.Context, p *core.Pod, memberSta
 	}
 	// Check again at given interval
 	return recheckPodFinalizerInterval, nil
+}
+
+// inspectFinalizerPodGatewayTLSKeyfile performs a best-effort, prompt removal of the gateway
+// member's TLS keyfile secret. The secret is owner-referenced to the ArangoMember and is
+// garbage-collected once the member is removed, so this is only an optimization: it acts only when
+// the member is marked to be removed (a genuine teardown), never on a rolling restart where the
+// member and its keyfile must survive. It returns nil so the finalizer can always be released.
+func (r *Resources) inspectFinalizerPodGatewayTLSKeyfile(ctx context.Context, memberStatus api.MemberStatus) error {
+	if !memberStatus.Conditions.IsTrue(api.ConditionTypeMarkedToRemove) {
+		// Not a teardown (e.g. a rolling restart) - keep the keyfile secret.
+		return nil
+	}
+
+	_, group, ok := r.context.GetStatus().Members.ElementByID(memberStatus.ID)
+	if !ok {
+		return nil
+	}
+
+	secretName := k8sutil.AppendTLSKeyfileSecretPostfix(memberStatus.ArangoMemberName(r.context.GetAPIObject().GetName(), group))
+
+	err := globals.GetGlobalTimeouts().Kubernetes().RunWithTimeout(ctx, func(ctxChild context.Context) error {
+		return r.context.ACS().CurrentClusterCache().SecretsModInterface().V1().Delete(ctxChild, secretName, meta.DeleteOptions{})
+	})
+	if err != nil && !kerrors.IsNotFound(err) {
+		return errors.WithStack(err)
+	}
+
+	return nil
 }
 
 // inspectFinalizerPodAgencyServing checks the finalizer condition for agency-serving.

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -74,6 +74,7 @@ const (
 	FinalizerPodGracefulShutdown       = "database.arangodb.com/graceful-shutdown"       // Finalizer added to All members, indicating the need for graceful shutdown
 	FinalizerPVCMemberExists           = "pvc.database.arangodb.com/member-exists"       // Finalizer added to PVCs, indicating the need to keep is as long as its member exists
 	FinalizerDelayPodTermination       = "pod.database.arangodb.com/delay"               // Finalizer added to Pod, delays termination
+	FinalizerPodGatewayTLSKeyfile      = "gateway.database.arangodb.com/tls-keyfile"     // Finalizer added to Gateway Pods, ensures the member TLS keyfile secret is removed when the member is removed
 
 	AnnotationShutdownManagedContainer      = "shutdown.arangodb.com/managed"
 	AnnotationShutdownContainer             = "container.shutdown.arangodb.com"


### PR DESCRIPTION
First of the split-out gateway TLS changes (see #2158, which bundled three fixes — this is the finalizer part only).

## Change

Gateway Pods now carry a `gateway.database.arangodb.com/tls-keyfile` finalizer when TLS is enabled. On a genuine member teardown it best-effort removes the member's `<member>-tls-keyfile` secret promptly; it always releases once the pod is terminating so it never blocks a rolling restart.

- `MemberGatewayPod.GetFinalizers()` returns the finalizer when `pod.IsTLSEnabled`.
- `runPodFinalizers` handles it: releases on server-container termination, and `inspectFinalizerPodGatewayTLSKeyfile` deletes the keyfile secret only when the member is marked to be removed (never on a restart, where the member and its keyfile must survive).

The keyfile secret is owner-referenced to the ArangoMember and is already garbage-collected when the member is removed, so this finalizer is a prompt, ordered cleanup on top of GC rather than the sole mechanism.

## Verification

`go build ./pkg/...`, `golangci-lint` and the `pkg/deployment/resources` tests pass. End-to-end coverage (asserting every gateway pod carries the finalizer) is in the paired test-repo change and passed on Jenkins against enterprise 3.12.10.1 and 3.11.14.