### PR TITLE
Reload gateway TLS certificates in place via Envoy SDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
 - (Feature) Validate gateway serving certificates (endpoint verification, expiry margin and alt-name match) like arangod members and trigger keyfile renewal + restart when required
+- (Feature) Deliver the gateway's TLS certificates (internal and SNI) to Envoy via filesystem SDS with a watched directory, so a rotated certificate is reloaded in place without restarting the gateway
 - (Maintenance) Add a finalizer to gateway Pods that cleans up the member TLS keyfile secret when the gateway member is removed
 - (Maintenance) Lint all Helm charts in CI via `make helm-lint`; fix the `platform-storage` passwords template document separator and add the missing `apiVersion` to the `kube-arangodb-crd` chart
 - (Documentation) Add a README for the `platform-storage` chart and reference it from `docs/helm.md`, the MinIO storage-integration docs and the main README

--- a/pkg/deployment/resources/config_map_gateway.go
+++ b/pkg/deployment/resources/config_map_gateway.go
@@ -209,6 +209,11 @@ func (r *Resources) ensureGatewayConfig(ctx context.Context, cachedStatus inspec
 		return errors.WithStack(errors.Wrapf(err, "Failed to render gateway lds config"))
 	}
 
+	gatewaySDSFiles, err := cfg.RenderSDS()
+	if err != nil {
+		return errors.WithStack(errors.Wrapf(err, "Failed to render gateway sds config"))
+	}
+
 	inventory.Configuration = &pbInventoryV1.InventoryConfiguration{
 		Hash: gatewayCfgYamlChecksum,
 	}
@@ -241,6 +246,15 @@ func (r *Resources) ensureGatewayConfig(ctx context.Context, cachedStatus inspec
 		utilConstants.GatewayConfigChecksum: gatewayCfgYamlChecksum,
 	}); err != nil {
 		return err
+	}
+
+	// SDS secret definitions are only rendered when TLS is enabled. The gateway pod mounts the
+	// resulting ConfigMap only in that case (see createGatewayVolumes), so skip it otherwise to
+	// avoid managing (and repeatedly patching) an empty ConfigMap.
+	if len(gatewaySDSFiles) > 0 {
+		if err := r.ensureGatewayConfigMap(ctx, cachedStatus, configMaps, GetGatewayConfigMapName(r.context.GetAPIObject().GetName(), "sds"), gatewaySDSFiles); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -379,11 +393,15 @@ func (r *Resources) renderGatewayConfig(cachedStatus inspectorInterface.Inspecto
 	}
 
 	if spec.TLS.IsSecure() {
-		// Enabled TLS, add config
+		// Enabled TLS, add config. Certificates are delivered to Envoy via filesystem SDS so a
+		// rotated keyfile is reloaded in place; WatchDir points at the mounted secret directory.
 		keyPath := filepath.Join(shared.TLSKeyfileVolumeMountDir, utilConstants.SecretTLSKeyfile)
 		cfg.DefaultTLS = &gateway.ConfigTLS{
+			Name:            utilConstants.GatewaySDSInternalName,
 			CertificatePath: keyPath,
 			PrivateKeyPath:  keyPath,
+			WatchDir:        shared.TLSKeyfileVolumeMountDir,
+			SDSPath:         path.Join(utilConstants.GatewaySDSVolumeMountDir, gateway.SDSFileName(utilConstants.GatewaySDSInternalName)),
 		}
 		cfg.DefaultDestination.Type = util.NewType(gateway.ConfigDestinationTypeHTTPS)
 
@@ -395,11 +413,17 @@ func (r *Resources) renderGatewayConfig(cachedStatus inspectorInterface.Inspecto
 					continue
 				}
 
+				name := fmt.Sprintf("sni-%s", volume)
+				watchDir := path.Join(shared.TLSSNIKeyfileVolumeMountDir, volume)
+				f := path.Join(watchDir, utilConstants.SecretTLSKeyfile)
+
 				var s gateway.ConfigSNI
-				f := path.Join(shared.TLSSNIKeyfileVolumeMountDir, volume, utilConstants.SecretTLSKeyfile)
 				s.ConfigTLS = gateway.ConfigTLS{
+					Name:            name,
 					CertificatePath: f,
 					PrivateKeyPath:  f,
+					WatchDir:        watchDir,
+					SDSPath:         path.Join(utilConstants.GatewaySDSVolumeMountDir, gateway.SDSFileName(name)),
 				}
 				s.ServerNames = servers
 				cfg.SNI = append(cfg.SNI, s)

--- a/pkg/deployment/resources/gateway/gateway_config_sds.go
+++ b/pkg/deployment/resources/gateway/gateway_config_sds.go
@@ -1,0 +1,77 @@
+//
+// DISCLAIMER
+//
+// Copyright 2024-2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package gateway
+
+import (
+	"fmt"
+
+	ugrpc "github.com/arangodb/kube-arangodb/pkg/util/grpc"
+)
+
+// SDSFileName returns the filesystem SDS definition file name (also the ConfigMap key) for the
+// given SDS secret name.
+func SDSFileName(name string) string {
+	return fmt.Sprintf("%s.yaml", name)
+}
+
+// tlsCertificates returns every certificate served by the gateway that is delivered to Envoy via
+// SDS: the default (internal) serving certificate plus one per SNI mapping.
+func (c Config) tlsCertificates() []*ConfigTLS {
+	var r []*ConfigTLS
+
+	if c.DefaultTLS != nil {
+		r = append(r, c.DefaultTLS)
+	}
+
+	for id := range c.SNI {
+		r = append(r, &c.SNI[id].ConfigTLS)
+	}
+
+	return r
+}
+
+// RenderSDS renders the filesystem SDS secret definition files (keyed by file name) backing the
+// listener's tls_certificate_sds_secret_configs. Each file is a discovery response holding a single
+// Secret whose certificate/key are referenced by path; Envoy watches the corresponding mounted
+// secret directory and hot-reloads the certificate on rotation.
+func (c Config) RenderSDS() (map[string]string, error) {
+	files := map[string]string{}
+
+	for _, tls := range c.tlsCertificates() {
+		if tls.Name == "" {
+			continue
+		}
+
+		resp, err := DynamicConfigResponse(tls.RenderSDSSecret())
+		if err != nil {
+			return nil, err
+		}
+
+		data, err := ugrpc.MarshalYAML(resp, ugrpc.WithUseProtoNames(true))
+		if err != nil {
+			return nil, err
+		}
+
+		files[SDSFileName(tls.Name)] = string(data)
+	}
+
+	return files, nil
+}

--- a/pkg/deployment/resources/gateway/gateway_config_sds_test.go
+++ b/pkg/deployment/resources/gateway/gateway_config_sds_test.go
@@ -1,0 +1,105 @@
+//
+// DISCLAIMER
+//
+// Copyright 2024-2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package gateway
+
+import (
+	"testing"
+
+	tlsApi "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arangodb/kube-arangodb/pkg/util"
+)
+
+func Test_GatewaySDS(t *testing.T) {
+	cfg := Config{
+		DefaultDestination: ConfigDestination{
+			Targets: []ConfigDestinationTarget{
+				ConfigDestinationTargetEndpoint{Host: "127.0.0.1", Port: 8529},
+			},
+			Type: util.NewType(ConfigDestinationTypeHTTPS),
+		},
+		DefaultTLS: &ConfigTLS{
+			Name:            "internal",
+			CertificatePath: "/secrets/tls/tls.keyfile",
+			PrivateKeyPath:  "/secrets/tls/tls.keyfile",
+			WatchDir:        "/secrets/tls",
+			SDSPath:         "/etc/gateway/sds/internal.yaml",
+		},
+		SNI: ConfigSNIList{
+			{
+				ConfigTLS: ConfigTLS{
+					Name:            "sni-example",
+					CertificatePath: "/secrets/sni/example/tls.keyfile",
+					PrivateKeyPath:  "/secrets/sni/example/tls.keyfile",
+					WatchDir:        "/secrets/sni/example",
+					SDSPath:         "/etc/gateway/sds/sni-example.yaml",
+				},
+				ServerNames: []string{"example.com"},
+			},
+		},
+	}
+
+	t.Run("RenderSDS renders one file per certificate", func(t *testing.T) {
+		files, err := cfg.RenderSDS()
+		require.NoError(t, err)
+		require.Len(t, files, 2)
+
+		require.Contains(t, files, "internal.yaml")
+		require.Contains(t, files, "sni-example.yaml")
+
+		// Each SDS definition references the mounted keyfile by path (stable across rotations).
+		require.Contains(t, files["internal.yaml"], "/secrets/tls/tls.keyfile")
+		require.Contains(t, files["sni-example.yaml"], "/secrets/sni/example/tls.keyfile")
+	})
+
+	// The listener must deliver certificates via SDS (not inline) and watch the mounted secret
+	// directory, so a rotated keyfile is reloaded in place without a restart.
+	assertSDS := func(t *testing.T, tls *ConfigTLS) {
+		t.Helper()
+
+		ts, err := tls.RenderListenerTransportSocket()
+		require.NoError(t, err)
+		require.NotNil(t, ts)
+
+		var dtc tlsApi.DownstreamTlsContext
+		require.NoError(t, ts.GetTypedConfig().UnmarshalTo(&dtc))
+
+		require.Empty(t, dtc.GetCommonTlsContext().GetTlsCertificates(), "certificate must not be inlined")
+
+		sds := dtc.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()
+		require.Len(t, sds, 1)
+		require.Equal(t, tls.Name, sds[0].GetName())
+
+		pcs := sds[0].GetSdsConfig().GetPathConfigSource()
+		require.NotNil(t, pcs)
+		require.Equal(t, tls.SDSPath, pcs.GetPath())
+		require.Equal(t, tls.WatchDir, pcs.GetWatchedDirectory().GetPath())
+	}
+
+	t.Run("Internal listener transport socket uses SDS", func(t *testing.T) {
+		assertSDS(t, cfg.DefaultTLS)
+	})
+
+	t.Run("SNI listener transport socket uses SDS", func(t *testing.T) {
+		assertSDS(t, &cfg.SNI[0].ConfigTLS)
+	})
+}

--- a/pkg/deployment/resources/gateway/gateway_config_tls.go
+++ b/pkg/deployment/resources/gateway/gateway_config_tls.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2024-2025 ArangoDB GmbH, Cologne, Germany
+// Copyright 2024-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,10 +29,23 @@ import (
 )
 
 type ConfigTLS struct {
+	// Name is the unique SDS secret name used to reference this certificate from the listener.
+	Name string `json:"name,omitempty"`
+
 	CertificatePath string `json:"certificatePath,omitempty"`
 	PrivateKeyPath  string `json:"privateKeyPath,omitempty"`
+
+	// WatchDir is the directory Envoy watches for atomic changes - the mounted Kubernetes secret
+	// directory. When the secret rotates, Envoy reloads the SDS secret in place (no pod restart).
+	WatchDir string `json:"watchDir,omitempty"`
+
+	// SDSPath is the filesystem path of the SDS secret definition file that Envoy sources.
+	SDSPath string `json:"sdsPath,omitempty"`
 }
 
+// RenderListenerTransportSocket renders the downstream TLS transport socket. The certificate is
+// delivered via filesystem SDS (Secret Discovery Service) rather than inlined so that Envoy can
+// hot-reload a rotated certificate in place, without churning the listener or restarting the pod.
 func (c *ConfigTLS) RenderListenerTransportSocket() (*pbEnvoyCoreV3.TransportSocket, error) {
 	if c == nil {
 		return nil, nil
@@ -40,18 +53,10 @@ func (c *ConfigTLS) RenderListenerTransportSocket() (*pbEnvoyCoreV3.TransportSoc
 
 	tlsContext, err := anypb.New(&tlsApi.DownstreamTlsContext{
 		CommonTlsContext: &tlsApi.CommonTlsContext{
-			TlsCertificates: []*tlsApi.TlsCertificate{
+			TlsCertificateSdsSecretConfigs: []*tlsApi.SdsSecretConfig{
 				{
-					CertificateChain: &pbEnvoyCoreV3.DataSource{
-						Specifier: &pbEnvoyCoreV3.DataSource_Filename{
-							Filename: c.CertificatePath,
-						},
-					},
-					PrivateKey: &pbEnvoyCoreV3.DataSource{
-						Specifier: &pbEnvoyCoreV3.DataSource_Filename{
-							Filename: c.PrivateKeyPath,
-						},
-					},
+					Name:      c.Name,
+					SdsConfig: c.renderSDSConfigSource(),
 				},
 			},
 			AlpnProtocols: []string{(ALPNProtocolHTTP2 | ALPNProtocolHTTP1).String()},
@@ -67,4 +72,52 @@ func (c *ConfigTLS) RenderListenerTransportSocket() (*pbEnvoyCoreV3.TransportSoc
 			TypedConfig: tlsContext,
 		},
 	}, nil
+}
+
+// renderSDSConfigSource builds a filesystem SDS config source: Envoy sources the secret definition
+// from SDSPath and reloads it whenever a file is moved into WatchDir (the mounted Kubernetes secret
+// directory, which is updated by an atomic symlink swap on rotation). This lets a rotated
+// certificate be picked up in place without restarting the gateway.
+func (c *ConfigTLS) renderSDSConfigSource() *pbEnvoyCoreV3.ConfigSource {
+	src := &pbEnvoyCoreV3.PathConfigSource{
+		Path: c.SDSPath,
+	}
+	if c.WatchDir != "" {
+		src.WatchedDirectory = &pbEnvoyCoreV3.WatchedDirectory{
+			Path: c.WatchDir,
+		}
+	}
+
+	return &pbEnvoyCoreV3.ConfigSource{
+		ResourceApiVersion: pbEnvoyCoreV3.ApiVersion_V3,
+		ConfigSourceSpecifier: &pbEnvoyCoreV3.ConfigSource_PathConfigSource{
+			PathConfigSource: src,
+		},
+	}
+}
+
+// RenderSDSSecret builds the Envoy SDS Secret that points at the mounted certificate keyfile. The
+// referenced file path is stable across rotations; Envoy re-reads its contents when WatchDir changes.
+func (c *ConfigTLS) RenderSDSSecret() *tlsApi.Secret {
+	if c == nil {
+		return nil
+	}
+
+	return &tlsApi.Secret{
+		Name: c.Name,
+		Type: &tlsApi.Secret_TlsCertificate{
+			TlsCertificate: &tlsApi.TlsCertificate{
+				CertificateChain: &pbEnvoyCoreV3.DataSource{
+					Specifier: &pbEnvoyCoreV3.DataSource_Filename{
+						Filename: c.CertificatePath,
+					},
+				},
+				PrivateKey: &pbEnvoyCoreV3.DataSource{
+					Specifier: &pbEnvoyCoreV3.DataSource_Filename{
+						Filename: c.PrivateKeyPath,
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/deployment/resources/pod_creator_gateway.go
+++ b/pkg/deployment/resources/pod_creator_gateway.go
@@ -71,6 +71,17 @@ func createGatewayVolumes(input pod.Input) pod.Volumes {
 		ReadOnly:  true,
 	})
 
+	// SDS secret definitions, referenced by the listener's tls_certificate_sds_secret_configs.
+	// Only mounted when TLS is enabled (the ConfigMap is only rendered in that case).
+	if pod.IsTLSEnabled(input) {
+		volumes.AddVolume(k8sutil.CreateVolumeWithConfigMap(utilConstants.GatewaySDSVolumeName, GetGatewayConfigMapName(input.ApiObject.GetName(), "sds")))
+		volumes.AddVolumeMount(core.VolumeMount{
+			Name:      utilConstants.GatewaySDSVolumeName,
+			MountPath: utilConstants.GatewaySDSVolumeMountDir,
+			ReadOnly:  true,
+		})
+	}
+
 	// TLS
 	volumes.Append(pod.TLS(), input)
 

--- a/pkg/util/constants/gateway.go
+++ b/pkg/util/constants/gateway.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2025 ArangoDB GmbH, Cologne, Germany
+// Copyright 2025-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,6 +48,12 @@ const (
 
 	GatewayCDSVolumeMountDir = "/etc/gateway/cds/"
 	GatewayCDSVolumeName     = "gateway-cds"
+
+	GatewaySDSVolumeMountDir = "/etc/gateway/sds/"
+	GatewaySDSVolumeName     = "gateway-sds"
+
+	// GatewaySDSInternalName is the SDS secret name of the gateway's own (internal) serving certificate.
+	GatewaySDSInternalName = "internal"
 
 	MemberConfigVolumeMountDir = "/etc/gateway/member/"
 	MemberConfigVolumeName     = "member-config"


### PR DESCRIPTION
Split out of #2158 (which bundled SDS + cert-validation + the finalizer that already merged as #2159). This is the **SDS** part only.

## Change

The gateway listener previously referenced the internal serving keyfile and each SNI keyfile as inline `DataSource_Filename` paths. The gateway config checksum is computed over the rendered YAML, which references certs only by path — so rotating a secret's contents changed neither the LDS listener nor the checksum, and a rotated cert was silently missed (static gateways never restarted, dynamic ones never got an LDS change).

Now each certificate (internal + one per SNI) is delivered via filesystem **SDS**: the listener uses `tls_certificate_sds_secret_configs` → `PathConfigSource{ Path, WatchedDirectory }`, where `WatchedDirectory` is the mounted secret directory (`/secrets/tls`, `/secrets/sni/<secret>`). Envoy hot-reloads the certificate in place on rotation — no listener churn, no pod restart. The SDS `Secret` definitions are rendered into a new `<depl>-gateway-sds` ConfigMap, mounted at `/etc/gateway/sds/` when TLS is enabled.

## Verification

`Test_GatewaySDS` asserts the listener delivers certs via SDS (not inline) with the correct watched directory, and that one SDS definition file is rendered per certificate. Build, `golangci-lint`, and the gateway suite pass. The end-to-end reload (rotate → served cert changes with no pod restart) is covered by the paired test-repo change and passed on Jenkins.