### PR TITLE
Add a dedicated License Manager API timeout and raise the reconciliation default to 2m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) Add a dedicated `--timeout.license-manager` (default 30s) for the ArangoDB License Manager API call (license generation), so a slow License Manager does not fail licensing within the general 5s ArangoDB request timeout
+- (Maintenance) Raise the default reconciliation timeout (`--timeout.reconciliation`) from 1 to 2 minutes
 - (Feature) Validate gateway serving certificates (endpoint verification, expiry margin and alt-name match) like arangod members and trigger keyfile renewal + restart when required
 - (Feature) Deliver the gateway's TLS certificates (internal and SNI) to Envoy via filesystem SDS with a watched directory, so a rotated certificate is reloaded in place without restarting the gateway
 - (Maintenance) Add a finalizer to gateway Pods that cleans up the member TLS keyfile secret when the gateway member is removed

--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ Flags:
       --timeout.backup-upload duration                         The request timeout to the ArangoDB during uploading files (default 5m0s)
       --timeout.force-delete-pod-grace-period duration         Default period when ArangoDB Pod should be forcefully removed after all containers were stopped - set to 0 to disable forceful removals (default 15m0s)
       --timeout.k8s duration                                   The request timeout to the kubernetes (default 2s)
+      --timeout.license-manager duration                       The request timeout for the ArangoDB License Manager API calls (default 30s)
       --timeout.pod-scheduling-grace-period duration           Default period when ArangoDB Pod should be deleted in case of scheduling info change - set to 0 to disable (default 15s)
-      --timeout.reconciliation duration                        The reconciliation timeout to the ArangoDB CR (default 1m0s)
+      --timeout.reconciliation duration                        The reconciliation timeout to the ArangoDB CR (default 2m0s)
       --timeout.shard-rebuild duration                         Timeout after which particular out-synced shard is considered as failed and rebuild is triggered (default 1h0m0s)
       --timeout.shard-rebuild-retry duration                   Timeout after which rebuild shards retry flow is triggered (default 4h0m0s)
       --webhook.enabled                                        Enable integrated webhook server

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -152,6 +152,7 @@ var (
 	operatorTimeouts struct {
 		k8s                         time.Duration
 		arangoD                     time.Duration
+		licenseManager              time.Duration
 		arangoDCheck                time.Duration
 		reconciliation              time.Duration
 		agency                      time.Duration
@@ -236,6 +237,7 @@ func initE() error {
 	f.String("scope", "", "Define scope on which Operator works. Legacy - pre 1.1.0 scope with limited cluster access")
 	f.DurationVar(&operatorTimeouts.k8s, "timeout.k8s", globals.DefaultKubernetesTimeout, "The request timeout to the kubernetes")
 	f.DurationVar(&operatorTimeouts.arangoD, "timeout.arangod", globals.DefaultArangoDTimeout, "The request timeout to the ArangoDB")
+	f.DurationVar(&operatorTimeouts.licenseManager, "timeout.license-manager", globals.DefaultLicenseManagerTimeout, "The request timeout for the ArangoDB License Manager API calls")
 	f.DurationVar(&operatorTimeouts.arangoDCheck, "timeout.arangod-check", globals.DefaultArangoDCheckTimeout, "The version check request timeout to the ArangoDB")
 	f.DurationVar(&operatorTimeouts.agency, "timeout.agency", globals.DefaultArangoDAgencyTimeout, "The Agency read timeout")
 	f.DurationVar(&operatorTimeouts.reconciliation, "timeout.reconciliation", globals.DefaultReconciliationTimeout, "The reconciliation timeout to the ArangoDB CR")
@@ -350,6 +352,7 @@ func executeMain(cmd *cobra.Command, args []string) {
 
 	globals.GetGlobalTimeouts().Kubernetes().Set(operatorTimeouts.k8s)
 	globals.GetGlobalTimeouts().ArangoD().Set(operatorTimeouts.arangoD)
+	globals.GetGlobalTimeouts().LicenseManager().Set(operatorTimeouts.licenseManager)
 	globals.GetGlobalTimeouts().Agency().Set(operatorTimeouts.agency)
 	globals.GetGlobalTimeouts().ArangoDCheck().Set(operatorTimeouts.arangoDCheck)
 	globals.GetGlobalTimeouts().Reconciliation().Set(operatorTimeouts.reconciliation)

--- a/docs/cli/arangodb_operator.md
+++ b/docs/cli/arangodb_operator.md
@@ -115,8 +115,9 @@ Flags:
       --timeout.backup-upload duration                         The request timeout to the ArangoDB during uploading files (default 5m0s)
       --timeout.force-delete-pod-grace-period duration         Default period when ArangoDB Pod should be forcefully removed after all containers were stopped - set to 0 to disable forceful removals (default 15m0s)
       --timeout.k8s duration                                   The request timeout to the kubernetes (default 2s)
+      --timeout.license-manager duration                       The request timeout for the ArangoDB License Manager API calls (default 30s)
       --timeout.pod-scheduling-grace-period duration           Default period when ArangoDB Pod should be deleted in case of scheduling info change - set to 0 to disable (default 15s)
-      --timeout.reconciliation duration                        The reconciliation timeout to the ArangoDB CR (default 1m0s)
+      --timeout.reconciliation duration                        The reconciliation timeout to the ArangoDB CR (default 2m0s)
       --timeout.shard-rebuild duration                         Timeout after which particular out-synced shard is considered as failed and rebuild is triggered (default 1h0m0s)
       --timeout.shard-rebuild-retry duration                   Timeout after which rebuild shards retry flow is triggered (default 4h0m0s)
       --webhook.enabled                                        Enable integrated webhook server

--- a/pkg/deployment/reconcile/action_license_generate.go
+++ b/pkg/deployment/reconcile/action_license_generate.go
@@ -60,8 +60,6 @@ type actionLicenseGenerate struct {
 }
 
 func (a *actionLicenseGenerate) Start(ctx context.Context) (bool, error) {
-	ctxChild, cancel := globals.GetGlobals().Timeouts().ArangoD().WithTimeout(ctx)
-	defer cancel()
 	spec := a.actionCtx.GetSpec()
 	if !spec.License.HasSecretName() {
 		a.log.Error("License is not set")
@@ -119,7 +117,10 @@ func (a *actionLicenseGenerate) Start(ctx context.Context) (bool, error) {
 
 	lm := lmanager.NewClient(lmanager.ArangoLicenseManagerEndpoint, l.API.ClientID, l.API.ClientSecret)
 
-	generatedLicense, err := lm.License(ctx, req)
+	generatedLicense, err := globals.RunWithTimeoutE(ctx, globals.GetGlobals().Timeouts().LicenseManager(),
+		func(ctxChild context.Context) (lmanager.LicenseResponse, error) {
+			return lm.License(ctxChild, req)
+		})
 	if err != nil {
 		a.log.Err(err).Error("Unable to create license")
 		a.actionCtx.CreateEvent(&k8sutil.Event{
@@ -132,14 +133,18 @@ func (a *actionLicenseGenerate) Start(ctx context.Context) (bool, error) {
 	}
 	a.log.Str("id", generatedLicense.ID).Info("License Generated")
 
-	client := client.NewClient(c.Connection())
+	dbClient := client.NewClient(c.Connection())
 
-	if err := client.SetLicense(ctxChild, generatedLicense.License, true); err != nil {
+	if err := globals.GetGlobals().Timeouts().ArangoD().RunWithTimeout(ctx, func(ctxChild context.Context) error {
+		return dbClient.SetLicense(ctxChild, generatedLicense.License, true)
+	}); err != nil {
 		a.log.Err(err).Error("Unable to set license")
 		return true, nil
 	}
 
-	license, err := client.GetLicense(ctxChild)
+	license, err := globals.RunWithTimeoutE(ctx, globals.GetGlobals().Timeouts().ArangoD(), func(ctxChild context.Context) (client.License, error) {
+		return dbClient.GetLicense(ctxChild)
+	})
 	if err != nil {
 		a.log.Err(err).Error("Unable to get license")
 		return true, nil

--- a/pkg/deployment/reconcile/action_license_set.go
+++ b/pkg/deployment/reconcile/action_license_set.go
@@ -46,8 +46,6 @@ type actionLicenseSet struct {
 }
 
 func (a *actionLicenseSet) Start(ctx context.Context) (bool, error) {
-	ctxChild, cancel := globals.GetGlobals().Timeouts().ArangoD().WithTimeout(ctx)
-	defer cancel()
 	spec := a.actionCtx.GetSpec()
 	if !spec.License.HasSecretName() {
 		a.log.Error("License is not set")
@@ -75,21 +73,27 @@ func (a *actionLicenseSet) Start(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
-	client := client.NewClient(c.Connection())
+	dbClient := client.NewClient(c.Connection())
 
-	if license, err := client.GetLicense(ctxChild); err != nil {
+	if current, err := globals.RunWithTimeoutE(ctx, globals.GetGlobals().Timeouts().ArangoD(), func(ctxChild context.Context) (client.License, error) {
+		return dbClient.GetLicense(ctxChild)
+	}); err != nil {
 		a.log.Err(err).Error("Unable to get license")
 		return true, nil
-	} else if license.Hash != l.V2.V2Hash() {
-		if err := client.SetLicense(ctxChild, string(l.V2), true); err != nil {
+	} else if current.Hash != l.V2.V2Hash() {
+		if err := globals.GetGlobals().Timeouts().ArangoD().RunWithTimeout(ctx, func(ctxChild context.Context) error {
+			return dbClient.SetLicense(ctxChild, string(l.V2), true)
+		}); err != nil {
 			a.log.Err(err).Error("Unable to set license")
 			return true, nil
 		}
 	} else {
-		a.log.Str("hash", license.Hash).Info("License already set")
+		a.log.Str("hash", current.Hash).Info("License already set")
 	}
 
-	license, err := client.GetLicense(ctxChild)
+	license, err := globals.RunWithTimeoutE(ctx, globals.GetGlobals().Timeouts().ArangoD(), func(ctxChild context.Context) (client.License, error) {
+		return dbClient.GetLicense(ctxChild)
+	})
 	if err != nil {
 		a.log.Err(err).Error("Unable to get license")
 		return true, nil

--- a/pkg/util/globals/global.go
+++ b/pkg/util/globals/global.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ import "time"
 const (
 	DefaultKubernetesTimeout                  = 2 * time.Second
 	DefaultArangoDTimeout                     = time.Second * 5
+	DefaultLicenseManagerTimeout              = time.Second * 30
 	DefaultArangoDAgencyTimeout               = time.Second * 10
 	DefaultArangoDCheckTimeout                = time.Second * 2
-	DefaultReconciliationTimeout              = time.Minute
+	DefaultReconciliationTimeout              = time.Minute * 2
 	DefaultForcePodDeletionGracePeriodTimeout = 15 * time.Minute
 	DefaultPodSchedulingGracePeriod           = 15 * time.Second
 
@@ -54,6 +55,7 @@ var globalObj = &globals{
 	timeouts: &globalTimeouts{
 		requests:                           NewTimeout(DefaultKubernetesTimeout),
 		arangod:                            NewTimeout(DefaultArangoDTimeout),
+		licenseManager:                     NewTimeout(DefaultLicenseManagerTimeout),
 		arangodCheck:                       NewTimeout(DefaultArangoDCheckTimeout),
 		reconciliation:                     NewTimeout(DefaultReconciliationTimeout),
 		agency:                             NewTimeout(DefaultArangoDAgencyTimeout),
@@ -145,6 +147,7 @@ type GlobalTimeouts interface {
 
 	Kubernetes() Timeout
 	ArangoD() Timeout
+	LicenseManager() Timeout
 	ArangoDCheck() Timeout
 	Agency() Timeout
 
@@ -156,10 +159,10 @@ type GlobalTimeouts interface {
 }
 
 type globalTimeouts struct {
-	requests, arangod, reconciliation, arangodCheck, agency, shardRebuild, shardRebuildRetry Timeout
-	backupArangoClientTimeout                                                                Timeout
-	backupArangoClientUploadTimeout                                                          Timeout
-	forcePodDeletionGracePeriodTimeout, podSchedulingGracePeriod                             Timeout
+	requests, arangod, licenseManager, reconciliation, arangodCheck, agency, shardRebuild, shardRebuildRetry Timeout
+	backupArangoClientTimeout                                                                                Timeout
+	backupArangoClientUploadTimeout                                                                          Timeout
+	forcePodDeletionGracePeriodTimeout, podSchedulingGracePeriod                                             Timeout
 }
 
 func (g *globalTimeouts) ForcePodDeletionGracePeriodTimeout() Timeout {
@@ -192,6 +195,10 @@ func (g *globalTimeouts) ShardRebuildRetry() Timeout {
 
 func (g *globalTimeouts) ArangoD() Timeout {
 	return g.arangod
+}
+
+func (g *globalTimeouts) LicenseManager() Timeout {
+	return g.licenseManager
 }
 
 func (g *globalTimeouts) Kubernetes() Timeout {

--- a/pkg/util/globals/timeout.go
+++ b/pkg/util/globals/timeout.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2016-2022 ArangoDB GmbH, Cologne, Germany
+// Copyright 2016-2026 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,6 +68,15 @@ func (t *timeout) Run(run TimeoutRunFunc) error {
 }
 
 func (t *timeout) RunWithTimeout(ctx context.Context, run TimeoutRunFunc) error {
+	newCtx, c := t.WithTimeout(ctx)
+	defer c()
+	return run(newCtx)
+}
+
+// RunWithTimeoutE runs run within a child context bounded by the given Timeout and returns its
+// result. It is the generic, value-returning counterpart of Timeout.RunWithTimeout - it removes the
+// WithTimeout/cancel/defer boilerplate for calls that return a value and an error.
+func RunWithTimeoutE[T any](ctx context.Context, t Timeout, run func(ctxChild context.Context) (T, error)) (T, error) {
 	newCtx, c := t.WithTimeout(ctx)
 	defer c()
 	return run(newCtx)


### PR DESCRIPTION
## Why

Under heavy load (full smoke runs), `LicenseGenerate` was failing with `Unable to create license … context deadline exceeded`: the operator's call to the **ArangoDB License Manager** (`lm.License`) inherited the general action context deadline, and the reconciliation timeout was tight, so a slow License Manager (or a throttled cluster) failed licensing.

## Changes

- **New `--timeout.license-manager` (default 30s)** applied **only** to the License Manager API call (`lm.License` in the `LicenseGenerate` action). The arangod license *set* calls keep the general `--timeout.arangod` (5s). Plumbed through `globals` (`LicenseManager()` timeout).
- **Generic `globals.RunWithTimeoutE[T]` helper** — the value-returning counterpart of `Timeout.RunWithTimeout`: `RunWithTimeoutE(ctx, timeout, func(ctx) (T, error)) (T, error)`. Removes the `WithTimeout`/`cancel`/`defer` boilerplate for value-returning calls; the License Manager call is the first user.
- **Raise the default reconciliation timeout** (`--timeout.reconciliation`) from 1 to 2 minutes.

## Verification

`go build ./...`, `pkg/util/globals` tests, gofmt/goimports clean.