### PR TITLE
Set the Envoy node identity in the static gateway bootstrap so SDS-served TLS initializes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) Set the Envoy node identity in the static gateway bootstrap so SDS-served TLS initializes (a static-config gateway otherwise crashed with `TlsCertificateSdsApi: node 'id' and 'cluster' are required`)
 - (Feature) Add a dedicated `--timeout.license-manager` (default 30s) for the ArangoDB License Manager API call (license generation), so a slow License Manager does not fail licensing within the general 5s ArangoDB request timeout
 - (Maintenance) Raise the default reconciliation timeout (`--timeout.reconciliation`) from 1 to 2 minutes
 - (Feature) Validate gateway serving certificates (endpoint verification, expiry margin and alt-name match) like arangod members and trigger keyfile renewal + restart when required

--- a/pkg/deployment/resources/gateway/gateway_config.go
+++ b/pkg/deployment/resources/gateway/gateway_config.go
@@ -48,6 +48,13 @@ import (
 	ugrpc "github.com/arangodb/kube-arangodb/pkg/util/grpc"
 )
 
+const (
+	// NodeCluster and NodeID identify the gateway's Envoy node. Envoy requires a node identity
+	// whenever the config uses SDS; the values only need to be non-empty.
+	NodeCluster = "arangodb"
+	NodeID      = "arangodb"
+)
+
 type Config struct {
 	DefaultDestination ConfigDestination `json:"defaultDestination,omitempty"`
 
@@ -152,6 +159,14 @@ func (c Config) Render() (*pbEnvoyBootstrapV3.Bootstrap, error) {
 	}
 
 	return &pbEnvoyBootstrapV3.Bootstrap{
+		// Node identity is required by Envoy whenever the config uses SDS (the listener's
+		// tls_certificate_sds_secret_configs); without it Envoy fails to initialize with
+		// "TlsCertificateSdsApi: node 'id' and 'cluster' are required". The static bootstrap serves a
+		// single gateway instance, so constant values suffice.
+		Node: &pbEnvoyCoreV3.Node{
+			Id:      NodeID,
+			Cluster: NodeCluster,
+		},
 		Admin: &pbEnvoyBootstrapV3.Admin{
 			Address: &pbEnvoyCoreV3.Address{
 				Address: &pbEnvoyCoreV3.Address_SocketAddress{

--- a/pkg/deployment/resources/gateway/gateway_config_test.go
+++ b/pkg/deployment/resources/gateway/gateway_config_test.go
@@ -559,3 +559,38 @@ func Test_GatewayConfig(t *testing.T) {
 		}
 	})
 }
+
+// Test_GatewayConfig_SDSRequiresNode is a regression guard: whenever the static bootstrap serves TLS
+// via SDS, Envoy requires a node identity, otherwise it aborts with
+// "TlsCertificateSdsApi: node 'id' and 'cluster' are required". The static bootstrap must therefore
+// always set Node.Id and Node.Cluster.
+func Test_GatewayConfig_SDSRequiresNode(t *testing.T) {
+	cfg := Config{
+		DefaultDestination: ConfigDestination{
+			Targets: []ConfigDestinationTarget{
+				ConfigDestinationTargetEndpoint{
+					Host: "127.0.0.1",
+					Port: 12345,
+				},
+			},
+		},
+		DefaultTLS: &ConfigTLS{
+			Name:            "internal",
+			CertificatePath: "/etc/gateway/tls/tls.crt",
+			PrivateKeyPath:  "/etc/gateway/tls/tls.key",
+			WatchDir:        "/etc/gateway/tls",
+			SDSPath:         "/etc/gateway/sds/internal.yaml",
+		},
+	}
+
+	// The listener must actually reference SDS for this test to be meaningful.
+	sds, err := cfg.RenderSDS()
+	require.NoError(t, err)
+	require.NotEmpty(t, sds, "expected the config to render SDS secret files")
+
+	b, err := cfg.Render()
+	require.NoError(t, err)
+	require.NotNil(t, b.Node, "static bootstrap must set Node when SDS is used")
+	require.NotEmpty(t, b.Node.Id, "Envoy requires node.id when SDS is used")
+	require.NotEmpty(t, b.Node.Cluster, "Envoy requires node.cluster when SDS is used")
+}


### PR DESCRIPTION
## Summary

Fixes a regression where a gateway using the **static** Envoy config crashes on startup and the deployment never becomes Ready.

## Root cause

The SDS change (#2161) delivers the gateway's serving certificate to Envoy via `tls_certificate_sds_secret_configs` (filesystem SDS). Envoy requires a node identity (`node.id` / `node.cluster`) whenever the config uses SDS — otherwise it aborts initialization with:

```
critical: TlsCertificateSdsApi: node 'id' and 'cluster' are required.
```

The dynamic gateway path (`NodeDynamicConfig`) sets `Node`, but the **static** bootstrap built by `Config.Render()` (`gateway_config.go`) did not. So a gateway rendered from the static config crashes the Envoy `server` container (exit 1), the gateway member never reaches `Serving`, and the ArangoDeployment stays `Ready: False` with `GatewayConfig: Gateway Config Not Propagated`.

## Fix

Set `Node{Id, Cluster}` in the static bootstrap. The static config serves a single gateway instance, so constant values suffice (matching the `"arangodb"` cluster used by the dynamic path).

Added `Test_GatewayConfig_SDSRequiresNode` as a regression guard: it renders a TLS/SDS-backed static config and asserts the bootstrap carries a non-empty `Node.Id` and `Node.Cluster`.