### PR TITLE
Platform chart: derive the release image list only from each chart's root images map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
 - (Bugfix) Set the Envoy node identity in the static gateway bootstrap so SDS-served TLS initializes (a static-config gateway otherwise crashed with `TlsCertificateSdsApi: node 'id' and 'cluster' are required`)
+- (Bugfix) Build the platform release chart's aggregated image list only from each chart's root `images` map (not its `images.yaml`), so unowned upstream dependency images (e.g. busybox, curl, grafana-image-renderer) stay out
 - (Feature) Add a dedicated `--timeout.license-manager` (default 30s) for the ArangoDB License Manager API call (license generation), so a slow License Manager does not fail licensing within the general 5s ArangoDB request timeout
 - (Maintenance) Raise the default reconciliation timeout (`--timeout.reconciliation`) from 1 to 2 minutes
 - (Feature) Validate gateway serving certificates (endpoint verification, expiry margin and alt-name match) like arangod members and trigger keyfile renewal + restart when required

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -325,17 +325,12 @@ func packageChartChart(ctx context.Context, reg *regclient.RegClient, endpoint s
 		return nil, errors.Wrapf(err, "invalid values.schema.json in chart %s", name)
 	}
 
-	// A chart that ships an unparsable images.yaml is a chart bug; fail packaging rather than
-	// silently dropping images from the air-gapped list (same policy as values.schema.json).
-	images, err := extractChartImages(chart)
-	if err != nil {
-		return nil, errors.Wrapf(err, "invalid images.yaml in chart %s", name)
-	}
-
-	// When a chart does not ship an explicit images.yaml, derive its images from values.yaml.
-	if images == nil {
-		images = imagesFromValues(defaults)
-	}
+	// Derive the chart's owned images strictly from the root `images` map in values.yaml (path
+	// `images.<name>`) - the single source of truth for images this release pins, scans and mirrors.
+	// A chart's images.yaml is intentionally NOT scanned: forked upstream charts carry unowned image
+	// specs at arbitrary paths (sidecars, test hooks, init containers - e.g. busybox/curl/bats in a
+	// Grafana fork), and scanning the whole file would leak them into the published list.
+	images := imagesFromValues(defaults)
 
 	return &packageChartRenderInputChart{
 		Name:             name,
@@ -408,65 +403,58 @@ func extractChartValues(chartData []byte) (map[string]interface{}, error) {
 	return values, nil
 }
 
-// extractChartImages reads images.yaml from a gzipped tar chart archive and returns the container
-// images the chart declares. Returns nil when the chart ships no images.yaml.
-func extractChartImages(chartData []byte) ([]packageChartRenderInputImage, error) {
-	data, err := extractChartFile(chartData, "images.yaml")
-	if err != nil {
-		return nil, err
-	}
-
-	if data == nil {
-		return nil, nil
-	}
-
-	var doc struct {
-		Images []packageChartRenderInputImage `json:"images"`
-	}
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil, err
-	}
-
-	return doc.Images, nil
-}
-
-// imagesFromValues derives container image references from a chart's values by walking them and
-// recognising image-spec maps: a map carrying an "image" or "repository" string, optionally combined
-// with a sibling "registry" and "tag". It is the fallback source when a chart ships no explicit
-// images.yaml, so the air-gapped list reflects what the chart actually references.
+// imagesFromValues derives container image references from a chart's values. It is the single source
+// for the aggregated image list.
+//
+// The rule is deliberately narrow: ONLY the image specs declared under the root `images` map are
+// recognised, one per key, following the ArangoDB chart convention `images.<name>`. That map is a
+// declaration of ownership - an image the chart is built or copied around, and therefore one the
+// owning repository pins, scans and mirrors.
+//
+// An image referenced from anywhere else in values.yaml is NOT derived. Upstream chart forks carry
+// image specs for optional components all over their values (sidecars, init containers, test hooks),
+// and those are inherited upstream defaults that no one has taken ownership of; publishing them here
+// would state that this release ships them. A chart that needs an image in the list therefore has to
+// declare it under this root `images` map - the chart's own images.yaml is not scanned.
 func imagesFromValues(values map[string]interface{}) []packageChartRenderInputImage {
+	root, ok := values["images"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Iterate in key order so the generated list is reproducible regardless of map iteration order.
+	names := make([]string, 0, len(root))
+	for name := range root {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	seen := map[string]struct{}{}
 	var out []packageChartRenderInputImage
 
-	collectImagesFromValues(values, "", &out, seen)
+	for _, name := range names {
+		spec, ok := root[name].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// The dotted values path of this image spec, e.g. "images.application".
+		path := joinPath("images", name)
+
+		ref := imageRefFromMap(spec)
+		if ref == "" || imageIsTest(path, ref) {
+			continue
+		}
+
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+
+		out = append(out, packageChartRenderInputImage{OverridePath: path, Image: ref})
+	}
 
 	return out
-}
-
-func collectImagesFromValues(node interface{}, path string, out *[]packageChartRenderInputImage, seen map[string]struct{}) {
-	switch v := node.(type) {
-	case map[string]interface{}:
-		if ref := imageRefFromMap(v); ref != "" && !imageIsTest(path, ref) {
-			if _, ok := seen[ref]; !ok {
-				seen[ref] = struct{}{}
-				// path is the dotted values path of this image-spec map, e.g. "images.application".
-				*out = append(*out, packageChartRenderInputImage{OverridePath: path, Image: ref})
-			}
-		}
-
-		keys := make([]string, 0, len(v))
-		for k := range v {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			collectImagesFromValues(v[k], joinPath(path, k), out, seen)
-		}
-	case []interface{}:
-		for i, e := range v {
-			collectImagesFromValues(e, fmt.Sprintf("%s[%d]", path, i), out, seen)
-		}
-	}
 }
 
 // joinPath appends a key to a dotted values path.

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -463,88 +463,156 @@ func Test_packageChartTemplateValues_EmptySections(t *testing.T) {
 	}
 }
 
-// Test_extractChartImages ensures images.yaml is read from the chart's own root (not a subchart's)
-// and that a missing file is not an error while a malformed one is surfaced.
-func Test_extractChartImages(t *testing.T) {
-	t.Run("reads own images.yaml, ignores subcharts", func(t *testing.T) {
-		files := map[string]string{
-			"mychart/charts/sub/images.yaml": "images:\n  - overridePath: sub\n    image: sub/img:1\n",
-			"mychart/images.yaml":            "images:\n  - overridePath: images.operator\n    image: arangodb/kube-arangodb:1.4.4\n  - overridePath: images.db\n    image: arangodb/arangodb-enterprise:3.12.5\n",
-		}
-		order := []string{"mychart/charts/sub/images.yaml", "mychart/images.yaml"}
-
-		imgs, err := extractChartImages(newTestChart(t, files, order))
-		require.NoError(t, err)
-		require.Equal(t, []packageChartRenderInputImage{
-			{OverridePath: "images.operator", Image: "arangodb/kube-arangodb:1.4.4"},
-			{OverridePath: "images.db", Image: "arangodb/arangodb-enterprise:3.12.5"},
-		}, imgs)
-	})
-
-	t.Run("missing images.yaml returns nil", func(t *testing.T) {
-		imgs, err := extractChartImages(newTestChart(t, map[string]string{"mychart/Chart.yaml": "name: mychart\n"}, []string{"mychart/Chart.yaml"}))
-		require.NoError(t, err)
-		require.Nil(t, imgs)
-	})
-
-	t.Run("malformed images.yaml is an error", func(t *testing.T) {
-		_, err := extractChartImages(newTestChart(t, map[string]string{"mychart/images.yaml": "images: [not: valid"}, []string{"mychart/images.yaml"}))
-		require.Error(t, err)
-	})
-}
-
-// Test_imagesFromValues ensures container images are derived from a chart's values by composing
-// registry/repository/tag, covering both the ArangoDB `images:` blocks and upstream image specs.
+// Test_imagesFromValues ensures container images are derived ONLY from the root `images` map,
+// following the ArangoDB chart convention `images.<name>`. Image specs anywhere else in values are
+// inherited upstream defaults rather than images the chart declares, and must stay out of the
+// air-gapped list; the chart's own images.yaml is not scanned.
 func Test_imagesFromValues(t *testing.T) {
-	values := map[string]interface{}{
-		// ArangoDB convention: images.<name>.{image,registry,tag}
-		"images": map[string]interface{}{
-			"application": map[string]interface{}{
-				"image":    "gral/engine",
-				"registry": "registry.license.arango.ai",
-				"tag":      "v1.1.12",
+	t.Run("derives the root images map", func(t *testing.T) {
+		got := imagesFromValues(map[string]interface{}{
+			// ArangoDB convention: images.<name>.{image,registry,tag}
+			"images": map[string]interface{}{
+				"application": map[string]interface{}{
+					"image":    "gral/engine",
+					"registry": "registry.license.arango.ai",
+					"tag":      "v1.1.12",
+				},
+				// "repository" is accepted as an alias for "image".
+				"reloader": map[string]interface{}{
+					"repository": "platform-monitoring/prometheus-config-reloader",
+					"registry":   "registry.license.arango.ai",
+					"tag":        "v0.0.6",
+				},
 			},
-			// Excluded: sits under the "test" key.
-			"test": map[string]interface{}{
-				"image":    "gral/engine-test",
-				"registry": "registry.license.arango.ai",
-				"tag":      "v1.1.12",
+			// Not an image spec - must be ignored.
+			"imagePullPolicy": "IfNotPresent",
+			"replicas":        3,
+		})
+
+		// Ordered by key so the generated list is reproducible.
+		require.Equal(t, []packageChartRenderInputImage{
+			{OverridePath: "images.application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
+			{OverridePath: "images.reloader", Image: "registry.license.arango.ai/platform-monitoring/prometheus-config-reloader:v0.0.6"},
+		}, got)
+	})
+
+	t.Run("ignores image specs outside the root images map", func(t *testing.T) {
+		// The shape of an upstream chart fork: the chart declares one image it owns, and carries
+		// upstream's own specs for optional components it merely inherits.
+		got := imagesFromValues(map[string]interface{}{
+			"images": map[string]interface{}{
+				"grafana": map[string]interface{}{
+					"image":    "platform-monitoring/grafana",
+					"registry": "registry.license.arango.ai",
+					"tag":      "v0.0.6",
+				},
 			},
-		},
-		// Excluded: repository ends with -test even though the key is not "test".
-		"extra": map[string]interface{}{
-			"image":    "foo/bar-test",
-			"registry": "docker.io",
-			"tag":      "1.0",
-		},
-		// Upstream convention: .image.{registry,repository,tag}
-		"imageRenderer": map[string]interface{}{
-			"image": map[string]interface{}{
+			"initChownData": map[string]interface{}{
+				"image": map[string]interface{}{
+					"registry":   "docker.io",
+					"repository": "library/busybox",
+					"tag":        "1.31.1",
+				},
+			},
+			"sidecar": map[string]interface{}{
+				"image": map[string]interface{}{
+					"registry":   "quay.io",
+					"repository": "kiwigrid/k8s-sidecar",
+					"tag":        "1.30.10",
+				},
+			},
+			"imageRenderer": map[string]interface{}{
+				"image": map[string]interface{}{
+					"registry":   "docker.io",
+					"repository": "grafana/grafana-image-renderer",
+					"tag":        "latest",
+				},
+			},
+			"testFramework": map[string]interface{}{
+				"image": map[string]interface{}{
+					"registry":   "docker.io",
+					"repository": "bats/bats",
+					"tag":        "v1.4.1",
+				},
+			},
+			"downloadDashboardsImage": map[string]interface{}{
 				"registry":   "docker.io",
-				"repository": "grafana/grafana-image-renderer",
-				"tag":        "latest",
+				"repository": "curlimages/curl",
+				"tag":        "8.9.1",
 			},
-		},
-		// A repo that already carries its registry must not be double-prefixed, and a numeric tag
-		// still composes.
-		"other": map[string]interface{}{
-			"image":    "docker.io/library/busybox",
-			"registry": "docker.io",
-			"tag":      1.31,
-		},
-		// Not an image spec - must be ignored.
-		"imagePullPolicy": "IfNotPresent",
-		"replicas":        3,
-	}
+		})
 
-	got := imagesFromValues(values)
+		require.Equal(t, []packageChartRenderInputImage{
+			{OverridePath: "images.grafana", Image: "registry.license.arango.ai/platform-monitoring/grafana:v0.0.6"},
+		}, got)
+	})
 
-	// Test images (the "test" key and the -test repository) are excluded.
-	require.ElementsMatch(t, []packageChartRenderInputImage{
-		{OverridePath: "images.application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
-		{OverridePath: "imageRenderer.image", Image: "docker.io/grafana/grafana-image-renderer:latest"},
-		{OverridePath: "other", Image: "docker.io/library/busybox:1.31"},
-	}, got)
+	t.Run("excludes test images", func(t *testing.T) {
+		got := imagesFromValues(map[string]interface{}{
+			"images": map[string]interface{}{
+				"application": map[string]interface{}{
+					"image":    "gral/engine",
+					"registry": "registry.license.arango.ai",
+					"tag":      "v1.1.12",
+				},
+				// Excluded: sits under the "test" key.
+				"test": map[string]interface{}{
+					"image":    "gral/engine-test",
+					"registry": "registry.license.arango.ai",
+					"tag":      "v1.1.12",
+				},
+				// Excluded: repository ends with -test even though the key is not "test".
+				"extra": map[string]interface{}{
+					"image":    "foo/bar-test",
+					"registry": "docker.io",
+					"tag":      "1.0",
+				},
+			},
+		})
+
+		require.Equal(t, []packageChartRenderInputImage{
+			{OverridePath: "images.application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
+		}, got)
+	})
+
+	t.Run("composes a repo that already carries its registry, and a numeric tag", func(t *testing.T) {
+		got := imagesFromValues(map[string]interface{}{
+			"images": map[string]interface{}{
+				"other": map[string]interface{}{
+					"image":    "docker.io/library/busybox",
+					"registry": "docker.io",
+					"tag":      1.31,
+				},
+			},
+		})
+
+		require.Equal(t, []packageChartRenderInputImage{
+			{OverridePath: "images.other", Image: "docker.io/library/busybox:1.31"},
+		}, got)
+	})
+
+	t.Run("deduplicates by image reference", func(t *testing.T) {
+		got := imagesFromValues(map[string]interface{}{
+			"images": map[string]interface{}{
+				"b": map[string]interface{}{"image": "arangodb/enterprise", "tag": "3.12.5"},
+				"a": map[string]interface{}{"image": "arangodb/enterprise", "tag": "3.12.5"},
+			},
+		})
+
+		// The first key in sorted order wins, so the kept entry is deterministic.
+		require.Equal(t, []packageChartRenderInputImage{
+			{OverridePath: "images.a", Image: "arangodb/enterprise:3.12.5"},
+		}, got)
+	})
+
+	t.Run("no usable root images map yields nothing", func(t *testing.T) {
+		require.Nil(t, imagesFromValues(map[string]interface{}{"replicas": 3}))
+		require.Nil(t, imagesFromValues(map[string]interface{}{"images": "not-a-map"}))
+		// A non-map entry under images is skipped rather than failing the packaging.
+		require.Empty(t, imagesFromValues(map[string]interface{}{
+			"images": map[string]interface{}{"application": "not-a-map"},
+		}))
+	})
 }
 
 // Test_aggregateImages ensures images from every chart are merged, de-duplicated by image


### PR DESCRIPTION
## Summary

The platform release chart's aggregated `images.yaml` (the air-gapped mirror list) was picking up **unowned upstream dependency images** — e.g. `busybox`, `curl`, `bats`, `grafana-image-renderer:latest`, and a `k8s-sidecar` — from a forked Grafana subchart. These come from arbitrary values paths (`testFramework.image`, `downloadDashboardsImage`, `initChownData.image`, `sidecar.image`), not images this release owns.

## Root cause

`packageChartChart` read each chart's own `images.yaml` verbatim (`extractChartImages`) and only fell back to the root `images` map in values when that file was absent. A chart shipping an `images.yaml` full of inherited upstream image specs therefore leaked all of them into the published list.

## Fix

Derive the image list **strictly from each chart's root `images` map in `values.yaml`** (`images.<name>`, the ArangoDB ownership convention) and stop scanning the chart's `images.yaml` entirely. The sub-charts already declare their owned images there (`images.application`, `images.prometheus`, `images.grafana`, `images.otelCollector`, …), so nothing owned is lost — only the inherited junk is dropped.

Removed the now-unused `extractChartImages` and its test.

## Result (verified against the 4.1.0 release)

- **37 → 32 images**
- Dropped: `busybox`, `curl`, `bats`, `grafana-image-renderer:latest`, `k8s-sidecar`
- Kept: all 32 owned images, including the real `platform-monitoring/prometheus`, `prometheus-config-reloader`, `grafana`, and the two `opentelemetry-collector`s (declared under `images.otelCollector`)

`pkg/platform` builds and tests pass.