### PR TITLE
Document RBAC permissions for Meta V1, Storage V2 and Authorization V1 services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Documentation) Document the RBAC permissions (action/resource) enforced by the Meta V1, Storage V2 and Authorization V1 integration services
 - (Maintenance) Bump the Go toolchain to go1.25.13, clearing 7 known standard-library vulnerabilities (net/url, html/template, crypto/tls, net/http, encoding/xml, encoding/asn1)
 - (Bugfix) Set the Envoy node identity in the static gateway bootstrap so SDS-served TLS initializes (a static-config gateway otherwise crashed with `TlsCertificateSdsApi: node 'id' and 'cluster' are required`)
 - (Bugfix) Build the platform release chart's aggregated image list only from each chart's root `images` map (not its `images.yaml`), so unowned upstream dependency images (e.g. busybox, curl, grafana-image-renderer) stay out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
-- (Documentation) Document the RBAC permissions (action/resource) enforced by the Meta V1, Storage V2 and Authorization V1 integration services
+- (Documentation) Document the RBAC permissions (action/resource) enforced by the Meta V1, Storage V2, Authorization V1 and Authentication V1 integration services
 - (Maintenance) Bump the Go toolchain to go1.25.13, clearing 7 known standard-library vulnerabilities (net/url, html/template, crypto/tls, net/http, encoding/xml, encoding/asn1)
 - (Bugfix) Set the Envoy node identity in the static gateway bootstrap so SDS-served TLS initializes (a static-config gateway otherwise crashed with `TlsCertificateSdsApi: node 'id' and 'cluster' are required`)
 - (Bugfix) Build the platform release chart's aggregated image list only from each chart's root `images` map (not its `images.yaml`), so unowned upstream dependency images (e.g. busybox, curl, grafana-image-renderer) stay out

--- a/docs/integration/authentication.v1.md
+++ b/docs/integration/authentication.v1.md
@@ -26,6 +26,20 @@ direct access to the deployment JWT secret.
 | `POST` | `/_integration/authn/v1/login` | Exchange credentials for a token |
 | `GET`  | `/_integration/authn/v1/logout` | Invalidate the current session |
 
+## RBAC Permissions
+
+Only `CreateToken` is RBAC-gated, and only when central services are enabled with an asymmetric
+signing key; the caller's token must be granted the matching action via an
+[`ArangoPermissionPolicy`](../platform/rbac/policies.md) bound to their role. `Validate`, `Identity`,
+`Login` and `Logout` are not gated by an RBAC action.
+
+| Action | Resource |
+|---|---|
+| `authentication:CreateToken` | the user the token is minted for (e.g. `root`, or `*` for any user) |
+
+See [Authorization gating](#authorization-gating) below for exactly when this applies and how a mint
+request without an explicit `user` is handled.
+
 ## Token creation
 
 `CreateToken` signs a new token with the deployment JWT secret. The request

--- a/docs/integration/authorization.v1.md
+++ b/docs/integration/authorization.v1.md
@@ -68,6 +68,23 @@ Request:
 Same as Evaluate/EvaluateMany but takes a JWT token instead of explicit
 user and roles. The user and roles are extracted from the token claims.
 
+## RBAC Permissions
+
+Beyond evaluating permissions, the authorization service also exposes the RBAC management API (roles,
+policies and user-role bindings) and the streaming pool endpoints that sidecars use to sync RBAC
+state. Each management call is itself authorized: the caller's token must be granted the matching
+`rbac:*` action, via an [`ArangoPermissionPolicy`](../platform/rbac/policies.md) bound to their role.
+
+| Action | Resource |
+|---|---|
+| `rbac:ListRole`, `rbac:GetRole`, `rbac:CreateRole`, `rbac:UpdateRole`, `rbac:DeleteRole` | the role name (empty for List) |
+| `rbac:ListPolicy`, `rbac:GetPolicy`, `rbac:CreatePolicy`, `rbac:UpdatePolicy`, `rbac:DeletePolicy` | the policy name (empty for List) |
+| `rbac:ListUserRoleBinding`, `rbac:AssignUserRole`, `rbac:RemoveUserRole`, `rbac:ReplaceUserRoleScope` | the target user |
+| `rbac:PoolRole`, `rbac:PoolPolicy`, `rbac:PoolUserRoleBinding` | *(empty)* — the streaming pool sidecars use to sync RBAC state |
+
+The `Evaluate` / `EvaluateToken` endpoints above are **not** gated by an `rbac:*` action — they are the
+enforcement primitive other services call to authorize their own operations.
+
 ## Configuration
 
 The authorization mode is controlled by the `INTEGRATION_AUTHORIZATION_V1_TYPE`

--- a/docs/integration/meta.v1.md
+++ b/docs/integration/meta.v1.md
@@ -10,3 +10,29 @@ parent: Integration Sidecars
 Definitions:
 
 - [Service](https://github.com/arangodb/kube-arangodb/blob/1.4.4/integrations/meta/v1/definition/definition.proto)
+
+## RBAC Permissions
+
+Every Meta V1 operation is authorized against the [Authorization V1](authorization.v1.md) service
+before it runs: the caller's token must be granted the matching action on the key it targets, via an
+[`ArangoPermissionPolicy`](../platform/rbac/policies.md) bound to their role. A denied check fails the
+request.
+
+| Action | Resource |
+|---|---|
+| `meta:GetKey` | the key being read |
+| `meta:UpdateKey` | the key being written |
+| `meta:DeleteKey` | the key being deleted |
+| `meta:ListKey` | the key prefix being listed |
+
+Example policy statement granting read access to keys under `config/`:
+
+```yaml
+statements:
+  - effect: Allow
+    actions:
+      - "meta:GetKey"
+      - "meta:ListKey"
+    resources:
+      - "config/*"
+```

--- a/docs/integration/storage.v2.md
+++ b/docs/integration/storage.v2.md
@@ -14,3 +14,32 @@ Definitions:
 ## Configuration
 
 In order to configure Platform Storage, refer to the [documentation](../platform/storage.md).
+
+## RBAC Permissions
+
+Every Storage V2 object operation is authorized against the [Authorization V1](authorization.v1.md)
+service before it runs: the caller's token must be granted the matching action on the object path, via
+an [`ArangoPermissionPolicy`](../platform/rbac/policies.md) bound to their role. A denied check fails
+the request.
+
+| Action | Resource |
+|---|---|
+| `storage:WriteObject` | the object path being written |
+| `storage:ReadObject` | the object path being read |
+| `storage:HeadObject` | the object path being stat-ed |
+| `storage:DeleteObject` | the object path being deleted |
+| `storage:ListObjects` | the path prefix being listed |
+| `storage:Init` | *(empty)* — bucket-level initialization |
+
+Example policy statement granting read-only access to objects under `reports/`:
+
+```yaml
+statements:
+  - effect: Allow
+    actions:
+      - "storage:ReadObject"
+      - "storage:HeadObject"
+      - "storage:ListObjects"
+    resources:
+      - "reports/*"
+```


### PR DESCRIPTION
## Summary

Documents the RBAC permissions each RBAC-enforcing integration service checks, so users know exactly which `ArangoPermissionPolicy` action/resource to grant. Each section mirrors the format already used in the Authentication V1 doc.

## Services documented

- **Meta V1** (metastore) — `meta:GetKey` / `meta:UpdateKey` / `meta:DeleteKey` on the key, `meta:ListKey` on the prefix.
- **Storage V2** (filestore) — `storage:{Write,Read,Head,Delete}Object` on the object path, `storage:ListObjects` on the prefix, `storage:Init` (bucket-level).
- **Authorization V1** (authz) — the `rbac:*` actions that gate the RBAC management API (roles, policies, user-role bindings) and the streaming pool endpoints; notes that the plain `Evaluate`/`EvaluateToken` endpoints are the enforcement primitive and are not `rbac:*`-gated.

**Authentication V1** (authn) already documents its `authentication:CreateToken` gate (added in #2147), so it is unchanged.

All action/resource pairs are taken directly from the `EvaluatePermission` calls in the service implementations. Each section includes an example policy statement.
