### PR TITLE
Add --sidecar.unix.enabled flag to disable the sidecar internal UNIX socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) Add the `--sidecar.unix.enabled` flag (default true) to the serving-member sidecar so the internal UNIX socket - and its directory creation - can be disabled
 - (Documentation) Document the RBAC permissions (action/resource) enforced by the Meta V1, Storage V2, Authorization V1 and Authentication V1 integration services
 - (Maintenance) Bump the Go toolchain to go1.25.13, clearing 7 known standard-library vulnerabilities (net/url, html/template, crypto/tls, net/http, encoding/xml, encoding/asn1)
 - (Bugfix) Set the Envoy node identity in the static gateway bootstrap so SDS-served TLS initializes (a static-config gateway otherwise crashed with `TlsCertificateSdsApi: node 'id' and 'cluster' are required`)

--- a/pkg/sidecar/flags.go
+++ b/pkg/sidecar/flags.go
@@ -72,6 +72,12 @@ var (
 		Description: "Defines if central services are enabled",
 		Default:     false,
 	}
+	flagUnixEnabled = cli.Flag[bool]{
+		Name: "sidecar.unix.enabled",
+		Description: "Defines if the internal UNIX socket (used for service-to-service calls that bypass " +
+			"the network authenticator) is served. Disabling it stops the sidecar creating the socket directory.",
+		Default: true,
+	}
 	flagAuthDeletedTTL = cli.Flag[time.Duration]{
 		Name:        "sidecar.auth.deleted-ttl",
 		Description: "TTL for soft-deleted RBAC documents before permanent removal from ArangoDB collections",

--- a/pkg/sidecar/register.go
+++ b/pkg/sidecar/register.go
@@ -55,6 +55,7 @@ func Register() (*cobra.Command, error) {
 		flagHealthAddress,
 		flagArangodb,
 		flagCentralServicesEnabled,
+		flagUnixEnabled,
 	}
 	for _, item := range global.Items() {
 		flags = append(flags, item.V.Flags...)
@@ -96,7 +97,12 @@ func configuration(cmd *cobra.Command) (svc.Configuration, error) {
 	// A unix socket for internal service-to-service calls (e.g. authorization.v1 -> authentication.v1
 	// Validate). The svc client dials the socket directly, bypassing the network authenticator - which in
 	// strict (rbac-enforced/central) mode would otherwise reject these in-process calls with Unauthorized.
-	cfg.Unix = fmt.Sprintf("%s/%s", utilConstants.SidecarUnixSocketMountPath, utilConstants.SidecarUnixSocketMountFile)
+	// Enabled by default; when disabled the svc leaves the socket (and its directory) uncreated.
+	if unixEnabled, err := flagUnixEnabled.Get(cmd); err != nil {
+		return svc.Configuration{}, err
+	} else if unixEnabled {
+		cfg.Unix = fmt.Sprintf("%s/%s", utilConstants.SidecarUnixSocketMountPath, utilConstants.SidecarUnixSocketMountFile)
+	}
 
 	if addr, err := flagGatewayAddress.Get(cmd); err != nil {
 		return svc.Configuration{}, err


### PR DESCRIPTION
## Summary

The serving-member sidecar (`pkg/sidecar`) hardcoded its internal UNIX socket path, so the socket — and the `os.MkdirAll` that creates its directory (`pkg/util/svc/starter.go`) — always ran, with no way to turn it off. The `svc` starter already skips the listener and the mkdir when the path is empty; it was just never given an empty path.

## Change

Adds a `--sidecar.unix.enabled` flag (default **true**, so behaviour is unchanged) to the `sidecar` command. When set to `false`, `configuration()` leaves `cfg.Unix` empty, so the sidecar neither serves the UNIX socket nor creates its directory.

- `pkg/sidecar/flags.go`: new `flagUnixEnabled`.
- `pkg/sidecar/register.go`: register it and gate the `cfg.Unix` assignment on it.

## Why the socket exists

The UNIX socket carries internal service-to-service calls (e.g. `authorization.v1 → authentication.v1 Validate`) that dial it directly to bypass the network authenticator — which in strict (`rbac-enforced`/central) mode would otherwise reject in-process calls with `Unauthorized`. So the flag defaults to enabled; disable it only when those internal calls are not needed.

> Note: this exposes the CLI flag. Driving it from an ArangoDeployment (a spec toggle → operator arg) would be a follow-up if a per-deployment switch is wanted.
