### PR TITLE
arango-deployment chart: expose gateway SSO (OpenID/ALB) via platform.authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Feature) (Chart) Expose gateway SSO in the arango-deployment chart via `deployment.platform.authentication` (type `OpenID`/`ALB` + an existing config `secretName`)
 - (Bugfix) (Chart) Emit the platform release image list with `overridePaths` as a list so an image used at several values paths keeps all of them (previously only the first was kept)
 - (Feature) Add the `--sidecar.unix.enabled` flag (default true) to the serving-member sidecar so the internal UNIX socket - and its directory creation - can be disabled
 - (Documentation) Document the RBAC permissions (action/resource) enforced by the Meta V1, Storage V2, Authorization V1 and Authentication V1 integration services

--- a/chart/arango-deployment/templates/arangodeployment.yaml
+++ b/chart/arango-deployment/templates/arangodeployment.yaml
@@ -342,6 +342,17 @@ spec:
   gateway:
     enabled: true
     dynamic: {{ .Values.deployment.platform.dynamic }}
+    {{- with .Values.deployment.platform.authentication }}
+    {{- if .type }}
+    {{- if not .secretName }}
+    {{- fail "deployment.platform.authentication.secretName is required when authentication.type is set" }}
+    {{- end }}
+    authentication:
+      type: {{ .type }}
+      secret:
+        name: {{ .secretName }}
+    {{- end }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.deployment.mode "Cluster" }}
   agents:

--- a/chart/arango-deployment/values.schema.json
+++ b/chart/arango-deployment/values.schema.json
@@ -568,6 +568,19 @@
             },
             "dynamic": {
               "type": "boolean"
+            },
+            "authentication": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["", "OpenID", "ALB"]
+                },
+                "secretName": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/chart/arango-deployment/values.yaml
+++ b/chart/arango-deployment/values.yaml
@@ -222,6 +222,13 @@ deployment:
   platform:
     enabled: false
     dynamic: true
+    # authentication configures gateway SSO (spec.gateway.authentication).
+    #   type:       "" (off), OpenID or ALB
+    #   secretName: an existing Secret whose `config` key holds the marshalled provider configuration
+    #               (see the OpenID / ALB integration docs). Required when type is set.
+    authentication:
+      type: ""
+      secretName: ""
   # Server groups (ServerGroupSpec). resources requests are rendered equal to limits.
   agents:
     count: 3


### PR DESCRIPTION
## Summary

The `arango-deployment` chart rendered `spec.gateway: { enabled, dynamic }` but had no way to configure gateway SSO. This exposes `spec.gateway.authentication` so a deployment can turn on `OpenID` or `ALB` authentication through the chart.

## Change

New `deployment.platform.authentication` values block:

```yaml
platform:
  enabled: true
  authentication:
    type: ALB            # "" (off) | OpenID | ALB
    secretName: my-alb-config
```

- `type` — the gateway authentication type.
- `secretName` — an **existing** Secret whose `config` key holds the marshalled provider config (region/signer/claims/proxy for ALB; provider/client/… for OpenID). The chart only references it — it never renders provider config or creates the secret.

When `type` is set the template renders:

```yaml
gateway:
  authentication:
    type: ALB
    secret:
      name: my-alb-config
```

and **fails the render** with a clear message if `secretName` is empty. `values.schema.json` gains the block (`type` enum `""`/`OpenID`/`ALB`).

Default behaviour is unchanged — with no `authentication.type`, the gateway is rendered exactly as before.

## Validation

`helm lint` passes; rendered output verified for ALB+secretName (renders the block), ALB without secretName (fails), and the default (no authentication block).
