### PR TITLE
Platform chart: emit image overridePaths as a list (keep every path for a shared image)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) (Chart) Emit the platform release image list with `overridePaths` as a list so an image used at several values paths keeps all of them (previously only the first was kept)
 - (Feature) Add the `--sidecar.unix.enabled` flag (default true) to the serving-member sidecar so the internal UNIX socket - and its directory creation - can be disabled
 - (Documentation) Document the RBAC permissions (action/resource) enforced by the Meta V1, Storage V2, Authorization V1 and Authentication V1 integration services
 - (Maintenance) Bump the Go toolchain to go1.25.13, clearing 7 known standard-library vulnerabilities (net/url, html/template, crypto/tls, net/http, encoding/xml, encoding/asn1)

--- a/pkg/platform/package_chart.go
+++ b/pkg/platform/package_chart.go
@@ -101,11 +101,12 @@ type packageChartRenderInputChart struct {
 // with the values path at which it can be overridden (e.g. to repoint it at a private registry).
 // Fields are exported for template rendering; the json tags match the images.yaml document.
 type packageChartRenderInputImage struct {
-	// OverridePath is the dotted values path of the image spec. In the aggregated list it is
-	// chart-prefixed (e.g. "charts.arangodb-gral.images.application"), so it is the exact key to
-	// override in the release values.yaml.
-	OverridePath string `json:"overridePath"`
-	Image        string `json:"image"`
+	// OverridePaths are the dotted values paths of the image spec. In the aggregated list they are
+	// chart-prefixed (e.g. "charts.arangodb-gral.images.application"), so each is an exact key to
+	// override in the release values.yaml. The same image is often referenced from several places, so
+	// every path pointing at it is listed here rather than keeping only the first.
+	OverridePaths []string `json:"overridePaths"`
+	Image         string   `json:"image"`
 }
 
 type packageChartRenderInputService struct {
@@ -429,7 +430,7 @@ func imagesFromValues(values map[string]interface{}) []packageChartRenderInputIm
 	}
 	sort.Strings(names)
 
-	seen := map[string]struct{}{}
+	idx := map[string]int{}
 	var out []packageChartRenderInputImage
 
 	for _, name := range names {
@@ -446,12 +447,13 @@ func imagesFromValues(values map[string]interface{}) []packageChartRenderInputIm
 			continue
 		}
 
-		if _, ok := seen[ref]; ok {
+		// The same image can be declared under several keys; collect every path pointing at it.
+		if i, ok := idx[ref]; ok {
+			out[i].OverridePaths = append(out[i].OverridePaths, path)
 			continue
 		}
-		seen[ref] = struct{}{}
-
-		out = append(out, packageChartRenderInputImage{OverridePath: path, Image: ref})
+		idx[ref] = len(out)
+		out = append(out, packageChartRenderInputImage{OverridePaths: []string{path}, Image: ref})
 	}
 
 	return out
@@ -547,32 +549,38 @@ func aggregateImages(charts map[string]packageChartRenderInputChart) []packageCh
 	}
 	sort.Strings(names)
 
-	seen := map[string]struct{}{}
+	idx := map[string]int{}
 	var out []packageChartRenderInputImage
 
-	// Iterate charts in name order so the entry kept for a duplicated image is deterministic.
+	// Iterate charts in name order for deterministic output. An image used by several charts (or at
+	// several paths within one chart) is emitted once, with every override path collected.
 	for _, name := range names {
 		for _, img := range charts[name].Images {
 			if img.Image == "" {
 				continue
 			}
-			if _, ok := seen[img.Image]; ok {
+
+			// Chart-prefix each path so it is the exact override key in the release values.yaml.
+			prefixed := make([]string, 0, len(img.OverridePaths))
+			for _, p := range img.OverridePaths {
+				prefixed = append(prefixed, joinPath("charts."+name, p))
+			}
+
+			if i, ok := idx[img.Image]; ok {
+				out[i].OverridePaths = append(out[i].OverridePaths, prefixed...)
 				continue
 			}
-			seen[img.Image] = struct{}{}
-			out = append(out, packageChartRenderInputImage{
-				// Chart-prefix the path so it is the exact override key in the release values.yaml.
-				OverridePath: joinPath("charts."+name, img.OverridePath),
-				Image:        img.Image,
-			})
+			idx[img.Image] = len(out)
+			out = append(out, packageChartRenderInputImage{OverridePaths: prefixed, Image: img.Image})
 		}
 	}
 
+	// Sort each image's paths and the list itself so the generated file is reproducible.
+	for i := range out {
+		sort.Strings(out[i].OverridePaths)
+	}
 	sort.Slice(out, func(i, j int) bool {
-		if out[i].Image != out[j].Image {
-			return out[i].Image < out[j].Image
-		}
-		return out[i].OverridePath < out[j].OverridePath
+		return out[i].Image < out[j].Image
 	})
 
 	return out

--- a/pkg/platform/package_chart_test.go
+++ b/pkg/platform/package_chart_test.go
@@ -491,8 +491,8 @@ func Test_imagesFromValues(t *testing.T) {
 
 		// Ordered by key so the generated list is reproducible.
 		require.Equal(t, []packageChartRenderInputImage{
-			{OverridePath: "images.application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
-			{OverridePath: "images.reloader", Image: "registry.license.arango.ai/platform-monitoring/prometheus-config-reloader:v0.0.6"},
+			{OverridePaths: []string{"images.application"}, Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
+			{OverridePaths: []string{"images.reloader"}, Image: "registry.license.arango.ai/platform-monitoring/prometheus-config-reloader:v0.0.6"},
 		}, got)
 	})
 
@@ -543,7 +543,7 @@ func Test_imagesFromValues(t *testing.T) {
 		})
 
 		require.Equal(t, []packageChartRenderInputImage{
-			{OverridePath: "images.grafana", Image: "registry.license.arango.ai/platform-monitoring/grafana:v0.0.6"},
+			{OverridePaths: []string{"images.grafana"}, Image: "registry.license.arango.ai/platform-monitoring/grafana:v0.0.6"},
 		}, got)
 	})
 
@@ -571,7 +571,7 @@ func Test_imagesFromValues(t *testing.T) {
 		})
 
 		require.Equal(t, []packageChartRenderInputImage{
-			{OverridePath: "images.application", Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
+			{OverridePaths: []string{"images.application"}, Image: "registry.license.arango.ai/gral/engine:v1.1.12"},
 		}, got)
 	})
 
@@ -587,11 +587,11 @@ func Test_imagesFromValues(t *testing.T) {
 		})
 
 		require.Equal(t, []packageChartRenderInputImage{
-			{OverridePath: "images.other", Image: "docker.io/library/busybox:1.31"},
+			{OverridePaths: []string{"images.other"}, Image: "docker.io/library/busybox:1.31"},
 		}, got)
 	})
 
-	t.Run("deduplicates by image reference", func(t *testing.T) {
+	t.Run("collects every path pointing at the same image", func(t *testing.T) {
 		got := imagesFromValues(map[string]interface{}{
 			"images": map[string]interface{}{
 				"b": map[string]interface{}{"image": "arangodb/enterprise", "tag": "3.12.5"},
@@ -599,9 +599,9 @@ func Test_imagesFromValues(t *testing.T) {
 			},
 		})
 
-		// The first key in sorted order wins, so the kept entry is deterministic.
+		// One entry per image, carrying every path (in sorted-key order).
 		require.Equal(t, []packageChartRenderInputImage{
-			{OverridePath: "images.a", Image: "arangodb/enterprise:3.12.5"},
+			{OverridePaths: []string{"images.a", "images.b"}, Image: "arangodb/enterprise:3.12.5"},
 		}, got)
 	})
 
@@ -620,21 +620,21 @@ func Test_imagesFromValues(t *testing.T) {
 func Test_aggregateImages(t *testing.T) {
 	charts := map[string]packageChartRenderInputChart{
 		"a": {Name: "a", Images: []packageChartRenderInputImage{
-			{OverridePath: "images.operator", Image: "arangodb/kube-arangodb:1.4.4"},
-			{OverridePath: "images.db", Image: "arangodb/arangodb-enterprise:3.12.5"},
+			{OverridePaths: []string{"images.operator"}, Image: "arangodb/kube-arangodb:1.4.4"},
+			{OverridePaths: []string{"images.db"}, Image: "arangodb/arangodb-enterprise:3.12.5"},
 		}},
 		"b": {Name: "b", Images: []packageChartRenderInputImage{
-			{OverridePath: "images.dup", Image: "arangodb/kube-arangodb:1.4.4"}, // duplicate image, dropped
-			{OverridePath: "images.webui", Image: "arangodb/webui:2.0.0"},
-			{OverridePath: "images.empty", Image: ""}, // empty image, skipped
+			{OverridePaths: []string{"images.dup"}, Image: "arangodb/kube-arangodb:1.4.4"}, // same image, second path
+			{OverridePaths: []string{"images.webui"}, Image: "arangodb/webui:2.0.0"},
+			{OverridePaths: []string{"images.empty"}, Image: ""}, // empty image, skipped
 		}},
 	}
 
-	// Sorted by image; paths chart-prefixed; the duplicate keeps chart "a" (name order).
+	// Sorted by image; paths chart-prefixed; an image used by two charts carries both paths (sorted).
 	require.Equal(t, []packageChartRenderInputImage{
-		{OverridePath: "charts.a.images.db", Image: "arangodb/arangodb-enterprise:3.12.5"},
-		{OverridePath: "charts.a.images.operator", Image: "arangodb/kube-arangodb:1.4.4"},
-		{OverridePath: "charts.b.images.webui", Image: "arangodb/webui:2.0.0"},
+		{OverridePaths: []string{"charts.a.images.db"}, Image: "arangodb/arangodb-enterprise:3.12.5"},
+		{OverridePaths: []string{"charts.a.images.operator", "charts.b.images.dup"}, Image: "arangodb/kube-arangodb:1.4.4"},
+		{OverridePaths: []string{"charts.b.images.webui"}, Image: "arangodb/webui:2.0.0"},
 	}, aggregateImages(charts))
 }
 
@@ -643,12 +643,13 @@ func Test_aggregateImages(t *testing.T) {
 func Test_renderImagesFile(t *testing.T) {
 	out := string(renderImagesFile(packageChartRenderInput{
 		Name: "arango-platform-release", Version: "1.0.0",
-		Images: []packageChartRenderInputImage{{OverridePath: "charts.op.images.application", Image: "arangodb/kube-arangodb:1.4.4"}},
+		Images: []packageChartRenderInputImage{{OverridePaths: []string{"charts.op.images.application"}, Image: "arangodb/kube-arangodb:1.4.4"}},
 	}))
 
 	require.Contains(t, out, "# Container images bundled by arango-platform-release 1.0.0.")
 	require.Contains(t, out, "Helm does not consume this file")
-	require.Contains(t, out, "overridePath: charts.op.images.application")
+	require.Contains(t, out, "overridePaths:")
+	require.Contains(t, out, "- charts.op.images.application")
 	require.Contains(t, out, "image: arangodb/kube-arangodb:1.4.4")
 
 	// It must be a valid images.yaml document.
@@ -656,7 +657,7 @@ func Test_renderImagesFile(t *testing.T) {
 		Images []packageChartRenderInputImage `json:"images"`
 	}
 	require.NoError(t, yaml.Unmarshal([]byte(out), &doc))
-	require.Equal(t, []packageChartRenderInputImage{{OverridePath: "charts.op.images.application", Image: "arangodb/kube-arangodb:1.4.4"}}, doc.Images)
+	require.Equal(t, []packageChartRenderInputImage{{OverridePaths: []string{"charts.op.images.application"}, Image: "arangodb/kube-arangodb:1.4.4"}}, doc.Images)
 
 	// With no images the document renders an empty list, never null.
 	empty := string(renderImagesFile(packageChartRenderInput{Name: "r", Version: "1"}))
@@ -671,8 +672,8 @@ func Test_packageChartTemplateReadme_Images(t *testing.T) {
 		out, err := packageChartTemplateReadme.RenderBytes(packageChartRenderInput{
 			Name: "arango-platform-release", Version: "1.0.0",
 			Images: []packageChartRenderInputImage{
-				{OverridePath: "charts.op.images.application", Image: "arangodb/kube-arangodb:1.4.4"},
-				{OverridePath: "charts.db.images.application", Image: "arangodb/arangodb-enterprise:3.12.5"},
+				{OverridePaths: []string{"charts.op.images.application"}, Image: "arangodb/kube-arangodb:1.4.4"},
+				{OverridePaths: []string{"charts.db.images.application"}, Image: "arangodb/arangodb-enterprise:3.12.5"},
 			},
 		})
 		require.NoError(t, err)

--- a/pkg/platform/templates/readme.md
+++ b/pkg/platform/templates/readme.md
@@ -44,10 +44,10 @@ This release uses the container images below, aggregated from the bundled charts
 installation, pull each image, re-tag it to your private registry, push it, and override it at the
 listed values path.
 
-| Image | Override path |
-|-------|---------------|
+| Image | Override paths |
+|-------|----------------|
 {{- range $i := .Images }}
-| `{{ $i.Image }}` | `{{ $i.OverridePath }}` |
+| `{{ $i.Image }}` | {{ range $j, $p := $i.OverridePaths }}{{ if $j }}, {{ end }}`{{ $p }}`{{ end }} |
 {{- end }}
 
 The same list is available as a machine-readable `images.yaml` at the root of this chart. To mirror


### PR DESCRIPTION
## Summary

The platform release chart's `images.yaml` used a single `overridePath` per image, and the aggregation de-duplicated by image reference — so when the **same image is referenced from several values paths** (across charts, or within one chart), only the first path was kept and the rest were silently dropped. That leaves an air-gapped mirror unable to override every place the image is used.

## Change

`overridePath` (string) → **`overridePaths` (list)**. An image is still emitted once, but now carries **every** path pointing at it:

- `imagesFromValues` collects all paths per image within a chart.
- `aggregateImages` groups by image across charts and chart-prefixes every path; each image's paths and the overall list are sorted for reproducibility.
- `images.yaml` and the README's image table render the list.

## Verified against 4.1.0

`otel/opentelemetry-collector-contrib:0.153.0` is used by three charts:

```yaml
- image: docker.io/otel/opentelemetry-collector-contrib:0.153.0
  overridePaths:
  - charts.arangodb-autograph.images.otelCollector
  - charts.arangodb-graphrag-importer.images.otelCollector
  - charts.file-manager.images.otelCollector
```

Previously only one of those three would have appeared. Image count is unchanged (32); only the paths are now complete. `pkg/platform` builds and tests pass.
