### PR TITLE
RBAC API design doc: DELETE returns HTTP 200 with the resource response body, not 204 No Content

### DIFF
--- a/design/rbac/api.md
+++ b/design/rbac/api.md
@@ -38,7 +38,7 @@ Request body (POST/PUT): `AuthorizationAPIPolicyCreateRequest { rules[] }` where
 Response body (GET single): `AuthorizationAPIPolicyResponse { name, rules[] }`
 Response body (GET list): `AuthorizationAPIPolicyListResponse { policies[] }`
 Response body (POST/PUT): `AuthorizationAPIPolicyResponse { name, rules[] }`
-Response body (DELETE): empty (204 No Content)
+Response body (DELETE): `AuthorizationAPIPolicyResponse { name, index }` (HTTP 200; `item` is not populated on delete)
 
 Implementation: `pkg/sidecar/services/authorization/impl_api_policy.go`
 
@@ -56,7 +56,7 @@ Request body (POST/PUT): `AuthorizationAPIRoleCreateRequest { policies[] }` wher
 Response body (GET single): `AuthorizationAPIRoleResponse { name, policies[] }`
 Response body (GET list): `AuthorizationAPIRoleListResponse { roles[] }`
 Response body (POST/PUT): `AuthorizationAPIRoleResponse { name, policies[] }`
-Response body (DELETE): empty (204 No Content)
+Response body (DELETE): `AuthorizationAPIRoleResponse { name, index }` (HTTP 200; `item` is not populated on delete)
 
 Implementation: `pkg/sidecar/services/authorization/impl_api_roles.go`
 
@@ -73,7 +73,7 @@ Request body (POST): `AuthorizationAPIUserRoleBindingCreateRequest { scope }` (o
 Request body (PUT): `AuthorizationAPIUserRoleBindingUpdateRequest { scope }` (new scope for the binding)
 Response body (GET list): `AuthorizationAPIUserRoleBindingListResponse { bindings[] }` where each binding contains `{ role, scope }`
 Response body (POST/PUT): `AuthorizationAPIUserRoleBindingResponse { user, role, scope }`
-Response body (DELETE): empty (204 No Content)
+Response body (DELETE): `AuthorizationAPIUserRoleBindingResponse { user, role, index }` (HTTP 200; `scope` is not populated on delete)
 
 Implementation: `pkg/sidecar/services/authorization/impl_api_user_role_bindings.go`
 


### PR DESCRIPTION
The RBAC `design/rbac/api.md` documented all three Management-API DELETE endpoints (policy, role, user-role binding) as `Response body (DELETE): empty (204 No Content)`. That is inaccurate — every DELETE handler returns a populated response object, so a successful delete is HTTP 200 with a JSON body:

- `APIDeletePolicy` -> `AuthorizationAPIPolicyResponse { name, index }` (`impl_api_policy.go`)
- `APIDeleteRole` -> `AuthorizationAPIRoleResponse { name, index }` (`impl_api_roles.go`)
- `APIRemoveUserRole` -> `AuthorizationAPIUserRoleBindingResponse { user, role, index }` (`impl_api_user_role_bindings.go`)

The `item`/`scope` spec field is left empty on delete; `index` carries the pool sequence index of the removal. Doc-only change.