### PR TITLE
Sidecar: routable external HTTP endpoint for the management API (gateway reachability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
+- (Bugfix) Serve the serving-member sidecar management API on a routable external HTTP endpoint (TLS per deployment settings) so the platform gateway can reach `/_management` cross-Pod, keeping the internal HTTP endpoint loopback-only for arangod
 - (Feature) (Chart) Expose gateway SSO in the arango-deployment chart via `deployment.platform.authentication` (type `OpenID`/`ALB` + an existing config `secretName`)
 - (Bugfix) (Chart) Emit the platform release image list with `overridePaths` as a list so an image used at several values paths keeps all of them (previously only the first was kept)
 - (Feature) Add the `--sidecar.unix.enabled` flag (default true) to the serving-member sidecar so the internal UNIX socket - and its directory creation - can be disabled

--- a/pkg/apis/shared/constants.go
+++ b/pkg/apis/shared/constants.go
@@ -44,35 +44,41 @@ const (
 	NodeArchAffinityLabelBeta = "beta.kubernetes.io/arch"
 
 	// Pod constants
-	ServerContainerName                    = "server"
-	ExporterContainerName                  = "exporter"
-	IntegrationContainerName               = "integration"
-	InternalSidecarContainerPortGRPCName   = "isidecar-grpc"
-	InternalSidecarContainerPortGRPC       = 8109
-	InternalSidecarContainerPortHTTPName   = "isidecar-http"
-	InternalSidecarContainerPortHTTP       = 8108
-	InternalSidecarContainerPortHealthName = "isidecar-health"
-	InternalSidecarContainerPortHealth     = 8107
-	OperatorContainerName                  = "operator"
-	ArangodVolumeName                      = "arangod-data"
-	TlsKeyfileVolumeName                   = "tls-keyfile"
-	ClientAuthCAVolumeName                 = "client-auth-ca"
-	ClusterJWTSecretVolumeName             = "cluster-jwt"
-	MasterJWTSecretVolumeName              = "master-jwt"
-	LifecycleVolumeName                    = "lifecycle"
-	FoxxAppEphemeralVolumeName             = "ephemeral-apps"
-	TMPEphemeralVolumeName                 = "ephemeral-tmp"
-	ArangoDTimezoneVolumeName              = "arangod-timezone"
-	RocksdbEncryptionVolumeName            = "rocksdb-encryption"
-	ExporterJWTVolumeName                  = "exporter-jwt"
-	ArangodVolumeMountDir                  = "/data"
-	RocksDBEncryptionVolumeMountDir        = "/secrets/rocksdb/encryption"
-	TLSKeyfileVolumeMountDir               = "/secrets/tls"
-	TLSSNIKeyfileVolumeMountDir            = "/secrets/sni"
-	ClientAuthCAVolumeMountDir             = "/secrets/client-auth/ca"
-	ClusterJWTSecretVolumeMountDir         = "/secrets/cluster/jwt"
-	ExporterJWTVolumeMountDir              = "/secrets/exporter/jwt"
-	MasterJWTSecretVolumeMountDir          = "/secrets/master/jwt"
+	ServerContainerName                  = "server"
+	ExporterContainerName                = "exporter"
+	IntegrationContainerName             = "integration"
+	InternalSidecarContainerPortGRPCName = "isidecar-grpc"
+	InternalSidecarContainerPortGRPC     = 8109
+	InternalSidecarContainerPortHTTPName = "isidecar-http"
+	InternalSidecarContainerPortHTTP     = 8108
+	// InternalSidecarContainerPortHTTPExternal is the sidecar's external HTTP endpoint. It carries the
+	// same gateway mux as the internal HTTP port but is bound to a routable address (and served over TLS
+	// on a secure deployment), so the platform gateway can reach the management API cross-Pod. The
+	// internal HTTP port stays loopback-only for in-Pod consumers (e.g. arangod --server.external-rbac-service).
+	InternalSidecarContainerPortHTTPExternalName = "isidecar-httpx"
+	InternalSidecarContainerPortHTTPExternal     = 8106
+	InternalSidecarContainerPortHealthName       = "isidecar-health"
+	InternalSidecarContainerPortHealth           = 8107
+	OperatorContainerName                        = "operator"
+	ArangodVolumeName                            = "arangod-data"
+	TlsKeyfileVolumeName                         = "tls-keyfile"
+	ClientAuthCAVolumeName                       = "client-auth-ca"
+	ClusterJWTSecretVolumeName                   = "cluster-jwt"
+	MasterJWTSecretVolumeName                    = "master-jwt"
+	LifecycleVolumeName                          = "lifecycle"
+	FoxxAppEphemeralVolumeName                   = "ephemeral-apps"
+	TMPEphemeralVolumeName                       = "ephemeral-tmp"
+	ArangoDTimezoneVolumeName                    = "arangod-timezone"
+	RocksdbEncryptionVolumeName                  = "rocksdb-encryption"
+	ExporterJWTVolumeName                        = "exporter-jwt"
+	ArangodVolumeMountDir                        = "/data"
+	RocksDBEncryptionVolumeMountDir              = "/secrets/rocksdb/encryption"
+	TLSKeyfileVolumeMountDir                     = "/secrets/tls"
+	TLSSNIKeyfileVolumeMountDir                  = "/secrets/sni"
+	ClientAuthCAVolumeMountDir                   = "/secrets/client-auth/ca"
+	ClusterJWTSecretVolumeMountDir               = "/secrets/cluster/jwt"
+	ExporterJWTVolumeMountDir                    = "/secrets/exporter/jwt"
+	MasterJWTSecretVolumeMountDir                = "/secrets/master/jwt"
 
 	// Security constants
 	DefaultRunAsUser  = 1000

--- a/pkg/deployment/resources/config_map_gateway.go
+++ b/pkg/deployment/resources/config_map_gateway.go
@@ -75,10 +75,12 @@ func (r *Resources) ensureGatewayConfig(ctx context.Context, cachedStatus inspec
 					pbImplEnvoyAuthV3Shared.AuthConfigAuthPassModeKey: string(networkingApi.ArangoRouteSpecAuthenticationPassModePass),
 				},
 			},
+			// Target the sidecar's external HTTP endpoint (routable, TLS-per-settings), not the internal
+			// loopback one which is reachable only in-Pod.
 			Targets: util.FormatList(services, func(a string) gateway.ConfigDestinationTarget {
 				return gateway.ConfigDestinationTargetEndpoint{
 					Host: a,
-					Port: shared.InternalSidecarContainerPortHTTP,
+					Port: shared.InternalSidecarContainerPortHTTPExternal,
 				}
 			}),
 		}

--- a/pkg/deployment/resources/internal_sidecar.go
+++ b/pkg/deployment/resources/internal_sidecar.go
@@ -69,6 +69,11 @@ func createInternalSidecarArgs(spec api.DeploymentSpec, groupSpec api.ServerGrou
 		options.Add("--sidecar.keyfile", filepath.Join(shared.TLSKeyfileVolumeMountDir, utilConstants.SecretTLSKeyfile))
 	}
 
+	// Expose the management API on a routable external endpoint so the platform gateway can reach it
+	// cross-Pod (the internal endpoint stays loopback-only for in-Pod arangod). It follows the deployment
+	// TLS setting via the keyfile above.
+	options.Addf("--sidecar.gateway.external.address", "0.0.0.0:%d", shared.InternalSidecarContainerPortHTTPExternal)
+
 	if storage != nil {
 		options.Merge(internalSidecarStorageV2Args(storage))
 	}
@@ -94,6 +99,11 @@ func ArangodbInternalSidecarContainer(image string, args []string,
 			{
 				Name:          shared.InternalSidecarContainerPortHTTPName,
 				ContainerPort: int32(shared.InternalSidecarContainerPortHTTP),
+				Protocol:      core.ProtocolTCP,
+			},
+			{
+				Name:          shared.InternalSidecarContainerPortHTTPExternalName,
+				ContainerPort: int32(shared.InternalSidecarContainerPortHTTPExternal),
 				Protocol:      core.ProtocolTCP,
 			},
 			{

--- a/pkg/sidecar/flags.go
+++ b/pkg/sidecar/flags.go
@@ -37,10 +37,18 @@ var (
 	}
 	flagGatewayAddress = cli.Flag[string]{
 		Name: "sidecar.gateway.address",
-		Description: "Address of the http gateway server. Defaults to a loopback address: the endpoint is " +
-			"consumed only in-Pod (e.g. by arangod), so it is served plain HTTP; bind a routable address to " +
-			"have it served over TLS.",
+		Description: "Address of the internal http gateway server. Defaults to a loopback address: the " +
+			"endpoint is consumed only in-Pod (e.g. by arangod), so it is served plain HTTP; bind a routable " +
+			"address to have it served over TLS.",
 		Default: fmt.Sprintf("127.0.0.1:%d", shared.InternalSidecarContainerPortHTTP),
+	}
+	flagGatewayExternalAddress = cli.Flag[string]{
+		Name: "sidecar.gateway.external.address",
+		Description: "Address of the external http gateway server, serving the same routes as the internal " +
+			"one on a routable address so an out-of-Pod client (the platform gateway) can reach the management " +
+			"API. It follows the deployment TLS setting - served over TLS when a keyfile is configured, plain " +
+			"otherwise. Empty disables it.",
+		Default: "",
 	}
 	flagHealthAddress = cli.Flag[string]{
 		Name:        "sidecar.health.address",

--- a/pkg/sidecar/register.go
+++ b/pkg/sidecar/register.go
@@ -48,6 +48,7 @@ func Register() (*cobra.Command, error) {
 	flags := []cli.FlagRegisterer{
 		flagAddress,
 		flagGatewayAddress,
+		flagGatewayExternalAddress,
 		flagKeyfile,
 		flagAuth,
 		flagAuthMode,
@@ -110,6 +111,14 @@ func configuration(cmd *cobra.Command) (svc.Configuration, error) {
 		// The sidecar's HTTP gateway is an in-Pod endpoint (default loopback address), so it opts into
 		// plain HTTP. If it is bound to a routable address instead, the svc still serves it over TLS.
 		cfg.Gateway = &svc.ConfigurationGateway{Address: addr, Insecure: true}
+	}
+
+	// The external gateway address, when set, serves the same routes on a routable listener (the platform
+	// gateway reaches the management API here). It always follows the deployment TLS setting.
+	if addr, err := flagGatewayExternalAddress.Get(cmd); err != nil {
+		return svc.Configuration{}, err
+	} else if addr != "" {
+		cfg.Gateway.ExternalAddress = addr
 	}
 
 	if keyfile, err := flagKeyfile.Get(cmd); err != nil {

--- a/pkg/util/svc/configuration.go
+++ b/pkg/util/svc/configuration.go
@@ -78,9 +78,17 @@ type ConfigurationGateway struct {
 	Address string
 	Unix    string
 
+	// ExternalAddress, when set, serves the same gateway mux on a second, routable listener (e.g.
+	// 0.0.0.0). It is always served with the service TLS options when present (TLS on a secure
+	// deployment, plain otherwise) - matching the ArangoDB server's own TLS mode - so a network-exposed
+	// endpoint is never served plain while the service has TLS. Address stays the in-Pod (loopback)
+	// listener; ExternalAddress is what an out-of-Pod client (the platform gateway) connects to.
+	ExternalAddress string
+
 	// Insecure requests that the HTTP gateway be served without TLS. It is honoured only when Address is a
 	// loopback address (127.0.0.1/localhost/::1); a gateway bound to a routable address (e.g. 0.0.0.0) is
 	// always served with TLS when the service has TLS options. The gRPC endpoint keeps its TLS regardless.
+	// It applies to Address only; ExternalAddress always follows the service TLS options.
 	Insecure bool
 
 	MuxExtensions []runtime.ServeMuxOption

--- a/pkg/util/svc/error.go
+++ b/pkg/util/svc/error.go
@@ -48,6 +48,10 @@ func (p serviceError) HTTPAddress() string {
 	return ""
 }
 
+func (p serviceError) HTTPExternalAddress() string {
+	return ""
+}
+
 func (p serviceError) Wait() error {
 	return p
 }

--- a/pkg/util/svc/service.go
+++ b/pkg/util/svc/service.go
@@ -68,8 +68,9 @@ type serviceGRPC struct {
 }
 
 type serviceHTTP struct {
-	network *goHttp.Server
-	unix    *goHttp.Server
+	network  *goHttp.Server
+	external *goHttp.Server
+	unix     *goHttp.Server
 }
 
 func (p *service) Dial(opts ...grpc.DialOption) (*grpc.ClientConn, error) {
@@ -193,6 +194,15 @@ func newService(cfg Configuration, handlers ...Handler) (*service, error) {
 
 		http.network = &goHttp.Server{
 			TLSConfig: httpTLS,
+		}
+
+		// The external listener is network-exposed, so it always follows the service TLS options (TLS on a
+		// secure deployment, plain otherwise) regardless of gateway.Insecure - it is never served plain
+		// while the service has TLS.
+		if gateway.ExternalAddress != "" {
+			http.external = &goHttp.Server{
+				TLSConfig: tls,
+			}
 		}
 
 		if gateway.Unix != "" {

--- a/pkg/util/svc/service_test.go
+++ b/pkg/util/svc/service_test.go
@@ -159,6 +159,37 @@ func Test_Service_Connections(t *testing.T) {
 		require.NoError(t, st.Wait())
 	})
 
+	t.Run("HTTP External", func(t *testing.T) {
+		// The external listener serves the same routes as the internal one on a second, routable address.
+		// With no TLS options it is served plain, so a direct HTTP GET to HTTPExternalAddress succeeds.
+		h, err := NewService(Configuration{
+			Address: "127.0.0.1:0",
+			Gateway: &ConfigurationGateway{
+				Address:         "127.0.0.1:0",
+				ExternalAddress: "127.0.0.1:0",
+			},
+		}, handler)
+		require.NoError(t, err)
+
+		ctx, c := context.WithCancel(context.Background())
+		defer c()
+
+		st := h.Start(ctx)
+
+		require.NotEmpty(t, st.HTTPExternalAddress())
+
+		// Both the internal and the external listener serve the mux.
+		_, err = ugrpc.Get[*pbPongV1.PongV1PingResponse](context.Background(), operatorHTTP.NewHTTPClient(), fmt.Sprintf("http://%s/_integration/pong/v1/ping", st.HTTPAddress())).WithCode(goHttp.StatusOK).Get()
+		require.NoError(t, err)
+
+		_, err = ugrpc.Get[*pbPongV1.PongV1PingResponse](context.Background(), operatorHTTP.NewHTTPClient(), fmt.Sprintf("http://%s/_integration/pong/v1/ping", st.HTTPExternalAddress())).WithCode(goHttp.StatusOK).Get()
+		require.NoError(t, err)
+
+		c()
+
+		require.NoError(t, st.Wait())
+	})
+
 	t.Run("TCP", func(t *testing.T) {
 		h, err := NewService(Configuration{
 			Address: "127.0.0.1:0",

--- a/pkg/util/svc/starter.go
+++ b/pkg/util/svc/starter.go
@@ -45,13 +45,14 @@ type ServiceStarter interface {
 	Unix() string
 
 	HTTPAddress() string
+	HTTPExternalAddress() string
 	HTTPUnix() string
 }
 
 type serviceStarter struct {
 	service *service
 
-	address, httpAddress, unix, httpUnix string
+	address, httpAddress, httpExternalAddress, unix, httpUnix string
 
 	error error
 	done  chan struct{}
@@ -73,19 +74,23 @@ func (s *serviceStarter) HTTPAddress() string {
 	return s.httpAddress
 }
 
+func (s *serviceStarter) HTTPExternalAddress() string {
+	return s.httpExternalAddress
+}
+
 func (s *serviceStarter) Wait() error {
 	<-s.done
 
 	return s.error
 }
 
-func (s *serviceStarter) run(ctx context.Context, health Health, grpcListener, unixGRPCListener, httpListener, unixHTTPListener net.Listener, conn *grpc.ClientConn) {
+func (s *serviceStarter) run(ctx context.Context, health Health, grpcListener, unixGRPCListener, httpListener, externalHTTPListener, unixHTTPListener net.Listener, conn *grpc.ClientConn) {
 	defer close(s.done)
 
-	s.error = s.runE(ctx, health, grpcListener, unixGRPCListener, httpListener, unixHTTPListener, conn)
+	s.error = s.runE(ctx, health, grpcListener, unixGRPCListener, httpListener, externalHTTPListener, unixHTTPListener, conn)
 }
 
-func (s *serviceStarter) runE(ctx context.Context, health Health, grpcListener, unixGRPCListener, httpListener, unixHTTPListener net.Listener, conn *grpc.ClientConn) error {
+func (s *serviceStarter) runE(ctx context.Context, health Health, grpcListener, unixGRPCListener, httpListener, externalHTTPListener, unixHTTPListener net.Listener, conn *grpc.ClientConn) error {
 	ctx, c := context.WithCancel(ctx)
 	defer c()
 
@@ -150,6 +155,32 @@ func (s *serviceStarter) runE(ctx context.Context, health Health, grpcListener, 
 			}
 		} else {
 			if err := s.service.http.network.Serve(httpListener); !errors.AnyOf(err, goHttp.ErrServerClosed) {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	wg.Go(func() error {
+		if s.service.cfg.Gateway == nil || s.service.cfg.Gateway.ExternalAddress == "" {
+			return nil
+		}
+
+		go func() {
+			<-nctx.Done()
+
+			s.service.http.external.Close()
+		}()
+
+		// The external listener follows the service TLS options: TLS on a secure deployment, plain
+		// otherwise. It is never served plain while the service has TLS.
+		if s.service.http.external.TLSConfig != nil {
+			if err := s.service.http.external.ServeTLS(externalHTTPListener, "", ""); !errors.AnyOf(err, goHttp.ErrServerClosed) {
+				return err
+			}
+		} else {
+			if err := s.service.http.external.Serve(externalHTTPListener); !errors.AnyOf(err, goHttp.ErrServerClosed) {
 				return err
 			}
 		}
@@ -225,7 +256,7 @@ func newServiceStarter(ctx context.Context, service *service, health Health) Ser
 
 	logger.Str("address", st.address).Info("Started GRPC Listener")
 
-	var gsln, hln, hsln net.Listener
+	var gsln, hln, hxln, hsln net.Listener
 
 	if unix := service.cfg.Unix; unix != "" {
 		if err := os.MkdirAll(filepath.Dir(unix), 0755); err != nil {
@@ -293,6 +324,40 @@ func newServiceStarter(ctx context.Context, service *service, health Health) Ser
 		logger.Info("Starting HTTP Listener skipped")
 	}
 
+	if gateway := service.cfg.Gateway; gateway != nil && gateway.ExternalAddress != "" {
+		logger.Str("address", gateway.ExternalAddress).Info("Starting External HTTP Listener")
+
+		mux := runtime.NewServeMux(gateway.MuxExtensions...)
+
+		for _, handler := range service.handlers {
+			if h, ok := handler.(HandlerGateway); ok {
+				if err := h.Gateway(shutdown.Context(), mux, conn); err != nil {
+					return serviceError{err}
+				}
+			}
+		}
+
+		service.http.external.Handler = service.cfg.Wrap.Wrap(mux)
+
+		httpxln, err := net.Listen("tcp", gateway.ExternalAddress)
+		if err != nil {
+			return serviceError{err}
+		}
+
+		hxln = httpxln
+
+		pr := httpxln.Addr().(*net.TCPAddr)
+		if pr.IP.IsUnspecified() {
+			st.httpExternalAddress = fmt.Sprintf("127.0.0.1:%d", pr.Port)
+		} else {
+			st.httpExternalAddress = fmt.Sprintf("%s:%d", pr.IP.String(), pr.Port)
+		}
+
+		logger.Str("address", st.httpExternalAddress).Info("Started External HTTP Listener")
+	} else {
+		logger.Info("Starting External HTTP Listener skipped")
+	}
+
 	if gateway := service.cfg.Gateway; gateway != nil && gateway.Unix != "" {
 		if err := os.MkdirAll(filepath.Dir(gateway.Unix), 0755); err != nil {
 			return serviceError{err}
@@ -332,7 +397,7 @@ func newServiceStarter(ctx context.Context, service *service, health Health) Ser
 		logger.Info("Starting UNIX HTTP Listener skipped")
 	}
 
-	go st.run(ctx, health, ln, gsln, hln, hsln, conn)
+	go st.run(ctx, health, ln, gsln, hln, hxln, hsln, conn)
 
 	return st
 }


### PR DESCRIPTION
The platform gateway's `/_management` route was unreachable (`503`, connection refused): the serving-member sidecar's HTTP endpoint (`8108`) is bound to **loopback**, because it is also arangod's internal permission-check endpoint (`--server.external-rbac-service http://127.0.0.1:8108`). Internal (arangod checks permissions) and external (gateway manages permissions) shared one loopback port, so the gateway could not reach it cross-Pod - and simply binding `8108` to `0.0.0.0` would either break arangod's plain-HTTP loopback (TLS on a secure deployment) or expose it plain on the network.

This adds a dedicated **external** HTTP endpoint, keeping the internal one untouched:

- **svc** (`pkg/util/svc`): `ConfigurationGateway.ExternalAddress` serves the same gateway mux on a second, routable listener, always following the service TLS options (TLS on secure, plain otherwise) - a network-exposed endpoint is never served plain while the service has TLS. Adds `HTTPExternalAddress()`.
- **sidecar**: new `--sidecar.gateway.external.address` flag (opt-in; empty default). The operator sets it to `0.0.0.0:8106` on the serving-member sidecar and exposes the new container port.
- **gateway**: `config_map_gateway` points the `_management` destination at the external port (`8106`), keeping HTTPS-on-secure to the cert-covered member-service host.
- **arangod**: `--server.external-rbac-service` **unchanged** - still the internal `http://127.0.0.1:8108` loopback endpoint. No cert-SAN change.

Ports: internal `8108` (loopback, arangod), external `8106` (`0.0.0.0`, TLS-per-settings, gateway). Adds an svc unit test for the external listener; existing svc/resources/gateway tests pass. This unblocks the platform gateway's `/_management` reachability end-to-end.
