### PR TITLE
Sidecar: register authentication.v1 / authorization.v1 as default integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [master](https://github.com/arangodb/kube-arangodb/tree/master) (N/A)
 - (Bugfix) Serve the serving-member sidecar management API on a routable external HTTP endpoint (TLS per deployment settings) so the platform gateway can reach `/_management` cross-Pod, keeping the internal HTTP endpoint loopback-only for arangod
 - (Feature) Add gateway `ALB` authentication type that trusts identity from an AWS Application Load Balancer terminating OIDC by verifying the signed `x-amzn-oidc-data` token
+- (Maintenance) Register the sidecar authentication.v1 and authorization.v1 integrations through the default integration registry instead of wiring them by hand (no behaviour change; both self-enable only when authentication is configured)
 - (Feature) (Chart) Expose gateway SSO in the arango-deployment chart via `deployment.platform.authentication` (type `OpenID`/`ALB` + an existing config `secretName`)
 - (Feature) (Chart) Expose `deployment.platform.createUsers` in the arango-deployment chart to render `spec.gateway.createUsers` (create gateway-authenticated users in ArangoDB)
 - (Bugfix) (Chart) Emit the platform release image list with `overridePaths` as a list so an image used at several values paths keeps all of them (previously only the first was kept)

--- a/pkg/sidecar/register.go
+++ b/pkg/sidecar/register.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	pbImplAuthenticationV1 "github.com/arangodb/kube-arangodb/integrations/authentication/v1"
 	pbImplAuthorizationV1 "github.com/arangodb/kube-arangodb/integrations/authorization/v1"
 	integrationsShared "github.com/arangodb/kube-arangodb/pkg/integrations/shared"
 	"github.com/arangodb/kube-arangodb/pkg/logging"
@@ -166,38 +165,6 @@ func runWithContext(ctx context.Context, cmd *cobra.Command) error {
 
 	if enabled {
 		handlers = append(handlers, handler)
-	}
-
-	// Serve the authentication.v1 and authorization.v1 integration services so arangod's external RBAC
-	// (--server.external-rbac-service -> POST /_integration/authorization/v1/evaluate-token-many) is
-	// answered locally: authn.v1 validates the presented token, authz.v1 evaluates it via the pool
-	// plugin (which syncs from the local authorizer's pool). Without these the endpoint is unserved and
-	// arangod fail-closes every check.
-	if authPath, err := flagAuth.Get(cmd); err != nil {
-		return err
-	} else if authPath != "" {
-		authnHandler, err := pbImplAuthenticationV1.New(ctx, pbImplAuthenticationV1.NewConfiguration().With(func(c pbImplAuthenticationV1.Configuration) pbImplAuthenticationV1.Configuration {
-			c.Path = authPath
-			return c
-		}))
-		if err != nil {
-			return err
-		}
-		handlers = append(handlers, authnHandler)
-
-		authMode, err := flagAuthMode.Get(cmd)
-		if err != nil {
-			return err
-		}
-
-		authzHandler, err := pbImplAuthorizationV1.New(ctx, pbImplAuthorizationV1.NewConfiguration().With(func(c pbImplAuthorizationV1.Configuration) pbImplAuthorizationV1.Configuration {
-			c.Type = pbImplAuthorizationV1.ConfigurationType(authMode)
-			return c
-		}))
-		if err != nil {
-			return err
-		}
-		handlers = append(handlers, authzHandler)
 	}
 
 	for _, item := range global.Items() {

--- a/pkg/sidecar/register.service.authenticationv1.go
+++ b/pkg/sidecar/register.service.authenticationv1.go
@@ -1,0 +1,53 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package sidecar
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	pbImplAuthenticationV1 "github.com/arangodb/kube-arangodb/integrations/authentication/v1"
+	"github.com/arangodb/kube-arangodb/pkg/util/svc"
+)
+
+func init() {
+	register("authentication-v1", func(ctx context.Context, cmd *cobra.Command) (svc.Handler, bool, error) {
+		authPath, err := flagAuth.Get(cmd)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if authPath == "" {
+			return nil, false, nil
+		}
+
+		handler, err := pbImplAuthenticationV1.New(ctx, pbImplAuthenticationV1.NewConfiguration().With(func(c pbImplAuthenticationV1.Configuration) pbImplAuthenticationV1.Configuration {
+			c.Path = authPath
+			return c
+		}))
+		if err != nil {
+			return nil, false, err
+		}
+
+		return handler, true, nil
+	})
+}

--- a/pkg/sidecar/register.service.authorizationv1.go
+++ b/pkg/sidecar/register.service.authorizationv1.go
@@ -1,0 +1,58 @@
+//
+// DISCLAIMER
+//
+// Copyright 2026 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package sidecar
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	pbImplAuthorizationV1 "github.com/arangodb/kube-arangodb/integrations/authorization/v1"
+	"github.com/arangodb/kube-arangodb/pkg/util/svc"
+)
+
+func init() {
+	register("authorization-v1", func(ctx context.Context, cmd *cobra.Command) (svc.Handler, bool, error) {
+		authPath, err := flagAuth.Get(cmd)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if authPath == "" {
+			return nil, false, nil
+		}
+
+		authMode, err := flagAuthMode.Get(cmd)
+		if err != nil {
+			return nil, false, err
+		}
+
+		handler, err := pbImplAuthorizationV1.New(ctx, pbImplAuthorizationV1.NewConfiguration().With(func(c pbImplAuthorizationV1.Configuration) pbImplAuthorizationV1.Configuration {
+			c.Type = pbImplAuthorizationV1.ConfigurationType(authMode)
+			return c
+		}))
+		if err != nil {
+			return nil, false, err
+		}
+
+		return handler, true, nil
+	})
+}


### PR DESCRIPTION
The sidecar's `authentication.v1` (`/_integration/authn/v1/*`) and `authorization.v1` (`/_integration/authorization/v1/*`) services were hand-wired in a conditional block inside `runWithContext`, unlike every other sidecar integration (`pong`, `meta-v1`, `storage-v2`, and the authentication-keys service) which self-registers into the default integration registry via `register(...)` in `init()`.

Since authn.v1 is effectively always required (the gateway routes `/_identity`, `/_login`, `/_logout` to it, and authz.v1 validates tokens through it), this moves both into the default registry to match the established pattern:

- `register.service.authenticationv1.go` / `register.service.authorizationv1.go` — each registers in `init()`; its `Build` returns `enabled=false` when no auth path is configured (neither can validate/sign without the JWT secret) and the handler otherwise. authz.v1 reads the authorization pool plugin from the context, which is set before the integrations are built.
- The conditional block is removed from `runWithContext`.

No behaviour change: the same handlers are served under the same conditions (only when authentication is on). No new flags, no API or docs changes. Full `pkg/sidecar` suite passes.